### PR TITLE
Add collections + updates

### DIFF
--- a/samples/data/s/sclaudubon/Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001.xml
+++ b/samples/data/s/sclaudubon/Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001.xml
@@ -1,0 +1,2593 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">
+
+  <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>results_nav.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>displayheader_results.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>results.xsl</Filename>
+    <Filename>reslist.xsl</Filename>
+    <Filename>reslist_result.xsl</Filename>
+  </XslFallbackFileList>  
+
+
+  <!-- Custom OPTIONAL XML for top-level file reslist.xml<2> -->
+  <CustomXml/>
+
+  <ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+  
+  <DlxsGlobals><CurrentCgi><Param name="cc">sclaudubon</Param>
+<Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="start">1</Param>
+<Param name="type">boolean</Param>
+<Param name="view">reslist</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="q1">American</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;start=1;type=boolean;view=reslist;rgn1=istruct_caption_image_title;select1=any;q1=American;c=sclaudubon;debug=xml;size=50</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>0ec55ecd1ad773236f870989a514de7c</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/reslist.xml</TemplatePath>
+<TemplateName>reslist</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<GroupName/>
+
+<JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776093</Url><Mode>login</Mode></LoginLink>
+
+<SearchSummary/>
+<TotalResults>18</TotalResults>
+<Next/>
+<Prev/>
+<Fisheye/>
+
+<BbagOptionsMenu><UserIsOwner>false</UserIsOwner><HiddenVars><Variable name="lasttype">boolean</Variable>
+<Variable name="lastview">reslist</Variable>
+</HiddenVars></BbagOptionsMenu>
+<SortOptionsMenu><HiddenVars><Variable name="cc">sclaudubon</Variable>
+<Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="view">reslist</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="type">boolean</Variable>
+<Variable name="q1">American</Variable>
+</HiddenVars><TotalResults>18</TotalResults><SortThresshold>1000</SortThresshold><ThresholdExceeded>false</ThresholdExceeded><Option index="0"><Label>(None)</Label><Value>none</Value></Option><Option index="1"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="2"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="3"><Label>Image Title</Label><Value>istruct_caption_image_title</Value><Focus>true</Focus></Option><Name>sort</Name><Default>istruct_caption_image_title</Default></SortOptionsMenu>
+
+<ViewInstruct>reslist1</ViewInstruct>
+
+<SliceSummary><Start>1</Start><End>18</End><Total>18</Total></SliceSummary>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;page=search;view=reslist</SearchLink>
+<ViewTabs><Form>graphic</Form><Graphic name="reslist"><Url>/i/image/graphics/display-tabs-C.gif</Url><Alt/></Graphic><View name="thumbnail"><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;start=1;type=boolean;view=thumbnail</Url><ImageMapCoords>0,11,130,34</ImageMapCoords></View><View name="reslist"><Current>true</Current><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;start=1;type=boolean;view=reslist</Url><ImageMapCoords>131,11,258,34</ImageMapCoords></View></ViewTabs>
+
+<GuideFrame><!--GUIDEFRAME_XML--></GuideFrame>
+
+<ResultsHeader><Row><Column abbrev="istruct_caption_image_title" section="1" parent="section-1">Image Title</Column><Column abbrev="is_part_of__work_title_" section="1" parent="section-1">Work Title</Column></Row><Index>1</Index><Debug>0.000211954116821289</Debug></ResultsHeader>
+
+<!-- "full" is used to display full record. -->
+<!-- and to differentiate between additional "brief" results -->
+<!-- used in bbcustomorder.xml. -->
+<Results name="full"><BookBagToggle>on</BookBagToggle><Result resultnum="1" sliceresultid="0" marker="111ffbb66842f49d5f2e023e5131778d"><EntryIdSplit><viewid>29376_0009</viewid><m_source>sclib</m_source><path>/s/sclaudubon</path><entryid>x-b6719890</entryid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0009</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0009</EntryWindowName><ResultNumber>1</ResultNumber><SliceResultId>0</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/539,417/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>416</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0009</istruct_isentryid>
+<istruct_m class="fieldsRef">29376_0009</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">9</istruct_x>
+<istruct_caption_plate class="fieldsRef">plate 057</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0009</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29376_0009</istruct_caption_image_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2014-12-11 10:37:15</m_flm>
+<istruct_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</istruct_caption>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-9</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_id class="fieldsRef">B6719890</m_id>
+<m_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</m_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0009</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:37:15</modified>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">28e3bc418abcab245230f28dd8be386e</md5>
+<height class="imgInfHashRef">6664</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29376_0009</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8620</width>
+<size class="imgInfHashRef">7731098</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/7/audubonVQ_v2_12_p57/audubonVQ_v2_12_p57.jp2</filename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+</Captions><ItemDescription>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison (female, and young). (v. 2, no. 12, plate 57)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="2" sliceresultid="1" marker="111ffbb66842f49d5f2e023e5131778d"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><m_source>sclib</m_source><viewid>29376_0008</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0008</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0008</EntryWindowName><ResultNumber>2</ResultNumber><SliceResultId>1</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/539,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_x class="fieldsRef">8</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0008</istruct_isentryid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0008</istruct_m>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 056</istruct_caption_plate>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0008</m_iid>
+<istruct_caption_image_id class="fieldsRef">29376_0008</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:07:44</m_flm>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<m_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</m_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-8</istruct_isentryidv>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29376_0008</m_fn>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</istruct_caption_image_title>
+<md5 class="imgInfHashRef">39c661cab405233d69a0d9b728e918f9</md5>
+<use class="imgInfHashRef">access</use>
+<modified class="imgInfHashRef">2014-12-11 11:07:44</modified>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/6/audubonVQ_v2_12_p56/audubonVQ_v2_12_p56.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<size class="imgInfHashRef">5582522</size>
+<width class="imgInfHashRef">8615</width>
+<master class="imgInfHashRef">0</master>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29376_0008</basename>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6644</height>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+</Captions><ItemDescription>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="3" sliceresultid="2" marker="111ffbb66842f49d5f2e023e5131778d"><EntryIdSplit><viewid>29377_0002</viewid><m_source>sclib</m_source><path>/s/sclaudubon</path><entryid>x-b6719889</entryid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0002</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0002</EntryWindowName><ResultNumber>3</ResultNumber><SliceResultId>2</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/543,419/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>542</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0002</m_iid>
+<istruct_caption_image_id class="fieldsRef">29377_0002</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_x class="fieldsRef">8</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29377_0002</istruct_m>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0002</istruct_isentryid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 006</istruct_caption_plate>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29377_0002</m_fn>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</istruct_caption_image_title>
+<istruct_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:08:59</m_flm>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</m_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-8</istruct_isentryidv>
+<u class="imgInfHashRef">1</u>
+<height class="imgInfHashRef">6704</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<basename class="imgInfHashRef">29377_0002</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<width class="imgInfHashRef">8686</width>
+<master class="imgInfHashRef">0</master>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/6/audubonVQ_v1_2_p6/audubonVQ_v1_2_p6.jp2</filename>
+<size class="imgInfHashRef">4388975</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:37</loaded>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 11:08:59</modified>
+<levels class="imgInfHashRef">6</levels>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">19e1a423cc71ca925526f7d7fda88428</md5>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+</Captions><ItemDescription>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Cross-Fox. (v. 1, no. 2, plate 6)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="4" sliceresultid="3" marker="111ffbb66842f49d5f2e023e5131778d"><EntryIdSplit><cc>sclaudubon</cc><entryid>x-b6719890</entryid><path>/s/sclaudubon</path><m_source>sclib</m_source><viewid>29376_0038</viewid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0038</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0038</EntryWindowName><ResultNumber>4</ResultNumber><SliceResultId>3</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/537,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>536</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_source class="fieldsRef">sclib</m_source>
+<m_iid class="fieldsRef">29376_0038</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29376_0038</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_m class="fieldsRef">29376_0038</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0038</istruct_isentryid>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">24</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 072</istruct_caption_plate>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29376_0038</m_fn>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:23:16</m_flm>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-24</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<md5 class="imgInfHashRef">80667950baa159b01c3906d16885b082</md5>
+<use class="imgInfHashRef">access</use>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 11:23:16</modified>
+<type class="imgInfHashRef">image</type>
+<size class="imgInfHashRef">7410676</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/5_/p7/2/audubonVQ_v2_15_p72/audubonVQ_v2_15_p72.jp2</filename>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8577</width>
+<basename class="imgInfHashRef">29376_0038</basename>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<height class="imgInfHashRef">6642</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+</Captions><ItemDescription>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis lupus (Var. Albus), Linn. White <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 15, plate 72)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="5" sliceresultid="4" marker="111ffbb66842f49d5f2e023e5131778d"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><viewid>29376_0012</viewid><m_source>sclib</m_source><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0012</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0012</EntryWindowName><ResultNumber>5</ResultNumber><SliceResultId>4</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/538,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_title class="fieldsRef">Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0012</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-19</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2014-12-11 11:09:51</m_flm>
+<istruct_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</istruct_caption>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29376_0012</istruct_caption_image_id>
+<m_iid class="fieldsRef">29376_0012</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_plate class="fieldsRef">plate 067</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0012</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0012</istruct_isentryid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">19</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 11:09:51</modified>
+<levels class="imgInfHashRef">6</levels>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">839172d2f92639a1b9fffe33e2d0f53d</md5>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6708</height>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29376_0012</basename>
+<width class="imgInfHashRef">8602</width>
+<master class="imgInfHashRef">0</master>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/4_/p6/7/audubonVQ_v2_14_p67/audubonVQ_v2_14_p67.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<size class="imgInfHashRef">5467100</size>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+</Captions><ItemDescription>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis Lupus (Var. Ater), Linn. Black <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 14, plate 67)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="6" sliceresultid="5"><EntryIdSplit><entryid>x-b6719889</entryid><cc>sclaudubon</cc><m_source>sclib</m_source><viewid>29377_0049</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0049</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0049</EntryWindowName><ResultNumber>6</ResultNumber><SliceResultId>5</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/534,414/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>533</w>
+    <h>413</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:14:32</m_flm>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-48</istruct_isentryidv>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</m_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29377_0049</m_fn>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29377_0049</istruct_m>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0049</istruct_isentryid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_x class="fieldsRef">48</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 046</istruct_caption_plate>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0049</m_iid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29377_0049</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<basename class="imgInfHashRef">29377_0049</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<height class="imgInfHashRef">6619</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/0_/p4/6/audubonVQ_v1_10_p46/audubonVQ_v1_10_p46.jp2</filename>
+<size class="imgInfHashRef">5020737</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<width class="imgInfHashRef">8535</width>
+<master class="imgInfHashRef">0</master>
+<modified class="imgInfHashRef">2014-12-11 11:14:32</modified>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<md5 class="imgInfHashRef">bf6d9153b928aec507046ef26268127c</md5>
+<use class="imgInfHashRef">access</use>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+</Captions><ItemDescription>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=6;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Castor Fiber Americanus, Linn. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Beaver. (v. 1, no. 10, plate 46)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="7" sliceresultid="6"><EntryIdSplit><viewid>29376_0014</viewid><m_source>sclib</m_source><path>/s/sclaudubon</path><entryid>x-b6719890</entryid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0014</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0014</EntryWindowName><ResultNumber>7</ResultNumber><SliceResultId>6</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0014/full/535,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_iid class="fieldsRef">29376_0014</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29376_0014</istruct_caption_image_id>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">14</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0014</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0014</istruct_isentryid>
+<istruct_caption_plate class="fieldsRef">plate 062</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_fn class="fieldsRef">29376_0014</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_title class="fieldsRef">Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_flm class="fieldsRef">2014-12-11 10:34:45</m_flm>
+<istruct_caption class="fieldsRef">29376_0014||||||||||||||||||Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||Exhibit||||||||||||plate 062</istruct_caption>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29376_0014||||||||||||||||||Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||Exhibit||||||||||||plate 062</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-14</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">04cf9f4905dd8b4cf400450e3918f6fd</md5>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:34:45</modified>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8554</width>
+<loaded class="imgInfHashRef">2014-12-12 17:07:39</loaded>
+<size class="imgInfHashRef">4939458</size>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/3_/p6/2/audubonVQ_v2_13_p62/audubonVQ_v2_13_p62.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6645</height>
+<u class="imgInfHashRef">1</u>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<basename class="imgInfHashRef">29376_0014</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+</Captions><ItemDescription>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=7;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Cervus Canadensis, Ray. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="8" sliceresultid="7"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><m_source>sclib</m_source><viewid>29376_0036</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0036</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0036</EntryWindowName><ResultNumber>8</ResultNumber><SliceResultId>7</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0036/full/534,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>411</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 081</istruct_caption_plate>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0036</istruct_m>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0036</istruct_isentryid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_x class="fieldsRef">33</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29376_0036</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0036</m_iid>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-33</istruct_isentryidv>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29376_0036||||||||||||||||||Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||Exhibit||||||||||||plate 081</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0036||||||||||||||||||Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||Exhibit||||||||||||plate 081</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:05:27</m_flm>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29376_0036</m_fn>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/7_/p8/1/audubonVQ_v2_17_p81/audubonVQ_v2_17_p81.jp2</filename>
+<size class="imgInfHashRef">5303579</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<width class="imgInfHashRef">8544</width>
+<master class="imgInfHashRef">0</master>
+<basename class="imgInfHashRef">29376_0036</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<height class="imgInfHashRef">6577</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">955cc287b6453a6cefa8ad388dcf33c3</md5>
+<use class="imgInfHashRef">access</use>
+<modified class="imgInfHashRef">2014-12-11 11:05:27</modified>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+</Captions><ItemDescription>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=8;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Cervus Virginianus, Pennant. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Deer (fawn). (v. 2, no. 18, plate 81)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="9" sliceresultid="8"><EntryIdSplit><path>/s/sclaudubon</path><viewid>29375_0044</viewid><m_source>sclib</m_source><cc>sclaudubon</cc><entryid>x-b6719891</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0044</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0044</EntryWindowName><ResultNumber>9</ResultNumber><SliceResultId>8</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0044/full/519,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>518</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_plate class="fieldsRef">plate 147</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">49</istruct_x>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0044</istruct_isentryid>
+<istruct_m class="fieldsRef">29375_0044</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29375_0044</istruct_caption_image_id>
+<istruct_caption_software class="fieldsRef"/>
+<m_iid class="fieldsRef">29375_0044</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<m_id class="fieldsRef">B6719891</m_id>
+<m_caption class="fieldsRef">29375_0044||||||||||||||||||Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||Exhibit||||||||||||plate 147</m_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-49</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_flm class="fieldsRef">2014-12-11 10:38:56</m_flm>
+<istruct_caption class="fieldsRef">29375_0044||||||||||||||||||Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||Exhibit||||||||||||plate 147</istruct_caption>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">29375_0044</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_title class="fieldsRef">Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<height class="imgInfHashRef">6404</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29375_0044</basename>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8296</width>
+<size class="imgInfHashRef">4346330</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:34</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_3/0_/p1/47/audubonVQ_v3_30_p147/audubonVQ_v3_30_p147.jp2</filename>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:38:56</modified>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">47e86a07d6d41bbec822254da4927ae6</md5>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0044</Caption><Caption>Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</Caption><Caption>Exhibit</Caption><Caption>plate 147</Caption>
+</Captions><ItemDescription>Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD20RjF
+O8selP25GMkfSnBcADJP1rOxZH5YpPL9qnxRipsK5B5dHl1NikpWC5F5dJ5Q9KnxRimkFyv5Q9KQ
+wj0qzim4p2HcrmAelMaAY6VaZcgjJHuKj8ogj94xx645/Sk0Fyr5A9KKtbaKmwycU7FNyFUseAOt
+VDqtmH2GbDe4Na2JZdoxVc6haKQGuIwT0y1JJqNnEheS5iVQMklxSaEWMUYrFHi/w9lx/bFnlOo8
+0Vi2fjK/1TWFjsbGI2BbCvKSGYevXj6YqHJLcai2dpRSB1xncPzpdwz1GPrVoQUU1ydpKYLdhnrT
+IplmTevA9DTAkIpCKQsGwAcZGVPrQjb0z0PQj0NJlDSKKU0VIFbVb2Kw0ya4mYKir3ry6TxPFLOx
+WQHnPWu78cQyz+Er0RH5gA34A818/T3UtuW2LnB61Tb6CaueiyeJrcqQ5QP2/eZIP0rKv76a9aQk
+EWkA+YM3LH6Z5rHtIpYLFbq42YK5wx6VSudXsdrozvI3baelc0pzk7LU1jTUdWWJpLCa/jktFkdQ
+BkKuTn+Vak2u3NnCpWT7Cc4GCCzD3Hb8K5UeIJ3Ux2qpAByMLkt9aiENxdOd2X4zkdjU8rvd6D02
+OmsfH+qQXAS5uGkt3barMBuB9fpXUx+KdQE3lmXcwGeWXGPyryy4hchFCF2DZNdfp+j26Wkc+qPF
+DIw+VWk2j9TVyqcsU7mTp3eh07eLNTikMjvHGijOSapx+N9TV5Ht2nMRJLMAME+vJrOudD83yngi
+iEasH4YnzAO1SXD3LF4ItNbyX53mQDH4YqY1W+pao23NS18a6tOxjSchUOA2B/nvXWeF9bvr68Md
+1LvDewGTj/61eWXLPbytHdyW8KHnZGeWPv8A/XroPh5qstxr0UZkYoCyhfQdqvnk3oKUEj2M0UtF
+bEmZ4gjeXQLxI1DExnIPp3rwLUJooJmit4d8wPOVwB+NfR+AykEZB6iuV1bwLpt9K08MKI5OSBxk
+0pq+pcJW0PCLpNQuowJZWMY6DoKqW+nDfjBYivbh4BCggRrjOeTmof8AhBJ7bLxQh3PTkcCueU5p
+aRL919TyeDSxE3m7SB+X860lt2kTYm1I+hC9TXcXnhPWWJAttw7KuMCktPAmpuxM8Pkxj+6w3Gud
+zqy6Md49DjfsMUKA7cHs+M4q1ZRwGXfOIZtwx++yfy5GK6W78A3sybYIGVv7zsT+NaNl4FmggVHs
+4pHAwXbrUr2vYd49zkks4bZmnhuTEOo8s46/iRSXuvrFHsZgxA4ORXT3Pw+v3csoTBOdoNSQfDg4
+RpbeFmzzk4x+lWqc2/eRXNFbM8jaWa/vZZXQsScYQEg/TPSu6+F9jJHrgeRHQBicMPau+tvA1rDg
+bIwB6VvWGkWunAmJBuPU11xUu1kZTlFovGikJorUyGK1PDH2qur08PzTuFiYOfT9acGOeQPzqDfz
+inB6VwsTZpCT6UzfRupXEPDHsP1p4PHNRBqXdQmA8t6UxnYfw/rRupC1UMQu+OEH4mjJ74pC1NJo
+uApNFQl+aKm4z//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0044/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=9;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0044</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Fig. 1. Spermophilus Townsendii, Bach. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="10" sliceresultid="9"><EntryIdSplit><entryid>x-b6719889</entryid><cc>sclaudubon</cc><path>/s/sclaudubon</path><m_source>sclib</m_source><viewid>29377_0048</viewid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0048</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0048</EntryWindowName><ResultNumber>10</ResultNumber><SliceResultId>9</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/544,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>543</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0048</m_iid>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29377_0048</istruct_caption_image_id>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0048</istruct_isentryid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_m class="fieldsRef">29377_0048</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_x class="fieldsRef">3</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_plate class="fieldsRef">plate 001c</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0048</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_flm class="fieldsRef">2014-12-11 10:41:06</m_flm>
+<istruct_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</istruct_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-3</istruct_isentryidv>
+<m_id class="fieldsRef">B6719889</m_id>
+<m_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</m_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">e96ecf681e7e8d8efb9b562c26fcfa97</md5>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 10:41:06</modified>
+<levels class="imgInfHashRef">6</levels>
+<width class="imgInfHashRef">8698</width>
+<master class="imgInfHashRef">0</master>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/_p/1/audubonVQ_v1_1_p1/audubonVQ_v1_1_p1.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<size class="imgInfHashRef">7880555</size>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6718</height>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<basename class="imgInfHashRef">29377_0048</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+</Captions><ItemDescription>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=10;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Lynx Rufus, Guldenstaed. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wild Cat. (v. 1, no. 1, plate 1)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="11" sliceresultid="10"><EntryIdSplit><cc>sclaudubon</cc><entryid>x-b6719889</entryid><m_source>sclib</m_source><viewid>29377_0001</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0001</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0001</EntryWindowName><ResultNumber>11</ResultNumber><SliceResultId>10</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0001/full/533,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>532</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0001</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2014-12-11 10:27:48</m_flm>
+<istruct_caption class="fieldsRef">29377_0001||||||||||||||||||Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||Exhibit||||||||||||plate 047</istruct_caption>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-49</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_caption class="fieldsRef">29377_0001||||||||||||||||||Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||Exhibit||||||||||||plate 047</m_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0001</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29377_0001</istruct_caption_image_id>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29377_0001</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0001</istruct_isentryid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">49</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_plate class="fieldsRef">plate 047</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<modified class="imgInfHashRef">2014-12-11 10:27:48</modified>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<md5 class="imgInfHashRef">27a09a39f7ddb17be66bb8461e9ea85c</md5>
+<use class="imgInfHashRef">access</use>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<basename class="imgInfHashRef">29377_0001</basename>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6592</height>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/0_/p4/7/audubonVQ_v1_10_p47/audubonVQ_v1_10_p47.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<size class="imgInfHashRef">5464024</size>
+<width class="imgInfHashRef">8521</width>
+<master class="imgInfHashRef">0</master>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+</Captions><ItemDescription>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=11;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Meles Labradoria, Sabine. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Badger. (v. 1, no. 10, plate 47)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="12" sliceresultid="11"><EntryIdSplit><cc>sclaudubon</cc><entryid>x-b6719889</entryid><m_source>sclib</m_source><viewid>29377_0025</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0025</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0025</EntryWindowName><ResultNumber>12</ResultNumber><SliceResultId>11</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/412,533/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>411</w>
+    <h>532</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29377_0025</m_fn>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 11:07:17</m_flm>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-44</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</m_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<m_source class="fieldsRef">sclib</m_source>
+<m_iid class="fieldsRef">29377_0025</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29377_0025</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29377_0025</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0025</istruct_isentryid>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">44</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 042</istruct_caption_plate>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">6579</width>
+<size class="imgInfHashRef">4987180</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_9/_p/42/audubonVQ_v1_9_p42/audubonVQ_v1_9_p42.jp2</filename>
+<height class="imgInfHashRef">8523</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29377_0025</basename>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">eeb56fd0572b0d85f37e6cbf5250cee1</md5>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 11:07:17</modified>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+</Captions><ItemDescription>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="77" height="100">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar" width="77" height="100">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=12;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Mephitis Americana, Desm. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Skunk. (v. 1, no. 9, plate 42)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="13" sliceresultid="12"><EntryIdSplit><viewid>29377_0010</viewid><m_source>sclib</m_source><path>/s/sclaudubon</path><cc>sclaudubon</cc><entryid>x-b6719889</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0010</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0010</EntryWindowName><ResultNumber>13</ResultNumber><SliceResultId>12</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/538,413/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0010</m_iid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29377_0010</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0010</istruct_isentryid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_m class="fieldsRef">29377_0010</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_x class="fieldsRef">12</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 010</istruct_caption_plate>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29377_0010</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 10:50:51</m_flm>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-12</istruct_isentryidv>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<m_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</m_caption>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:50:51</modified>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">4726b7070d4ee3d4410f18174a814436</md5>
+<height class="imgInfHashRef">6606</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29377_0010</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8602</width>
+<size class="imgInfHashRef">3053212</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/10/audubonVQ_v1_2_p10/audubonVQ_v1_2_p10.jp2</filename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+</Captions><ItemDescription>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=13;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Scallops Aqualicus, Linn. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Shrew Mole. (v. 1, no. 2, plate 10)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="14" sliceresultid="13"><EntryIdSplit><cc>sclaudubon</cc><entryid>x-b6719891</entryid><m_source>sclib</m_source><viewid>29375_0005</viewid><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0005</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0005</EntryWindowName><ResultNumber>14</ResultNumber><SliceResultId>13</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0005/full/525,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>524</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29375_0005</istruct_caption_image_id>
+<m_iid class="fieldsRef">29375_0005</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_plate class="fieldsRef">plate 125</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0005</istruct_isentryid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29375_0005</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">27</istruct_x>
+<istruct_caption_image_title class="fieldsRef">Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29375_0005</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-27</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_id class="fieldsRef">B6719891</m_id>
+<m_caption class="fieldsRef">29375_0005||||||||||||||||||Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||Exhibit||||||||||||plate 125</m_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2014-12-11 10:59:01</m_flm>
+<istruct_caption class="fieldsRef">29375_0005||||||||||||||||||Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||Exhibit||||||||||||plate 125</istruct_caption>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">93b448b65d49c6db00c80d9ade3736e9</md5>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:59:01</modified>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8387</width>
+<size class="imgInfHashRef">3655576</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:34</loaded>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/5_/p1/25/audubonVQ_v3_25_p125/audubonVQ_v3_25_p125.jp2</filename>
+<height class="imgInfHashRef">6409</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29375_0005</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0005</Caption><Caption>Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)</Caption><Caption>Exhibit</Caption><Caption>plate 125</Caption>
+</Captions><ItemDescription>Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hF4p
++ynqKcYw2M549DistCiLy/akMfsKsbaQ7QQCQCeg9aNAK/l+w/Kl8seg/Kp9tG2nZCIfKHoPypph
+X+6PyqyBRgZx3pWQ9Sr5CH+AflSfZ0/uL+VW8U0inZAVTbp/cH5U0wJj7oqfyo2ZuWz3Ac08rxUu
+wygYVz90UVaK80VnYZYXoKivbj7LbM+CWwdoHduw/Gn2zb7aJ/7yA/pVDX5pbaxSaKPzHVwAue5B
+A/UitHog6li2vxc26vGmXYZIB4H41ZVOQzYZ/X0+lZ1vcW9qUsVeLdDGoYkjOee34Z/GryyAcZye
+9SFiWikzmoLi7itreSaRtqp1JFPmQuW5ZqneWf2qWGQTPGY2z8n8Q9D7Vn6Vqt9qSM5s1iQMBl2w
+SMZyBVRb6+TXJ5Z5VS1EBMaOCBw3J/IfrWcqq6l8rg7GnFqip5ouWVdjHBAP3R3NTx3Ud0FMbjaR
+uPPPsK5uXVYdXElu00RZto+RSDtJB5J+mMVMPssN6j/ZJV+X/Wk4UnntnntWcak29LNAo3OkVoxl
+VI+XsKkIyKwtM1BTZtcM3zSOWwewJwB+WPyrfPK10Jp7EsgI5opxHNFIBLIYs4B6Rr/IVW1kqLeD
+d937RHn/AL6FWrP/AI84P+ua/wAqzfFJQaDdEuqui+YmT/EvI/lVS2BbkGklbkXKmNdn2h2f0LZx
+j9M/lWtDGIk2KoUDoAOKw9B1KF7e5LTxbmuC2AQPvBW/9mrYiu4nX/Wx7iMgbh07VBTH27M6u7EH
+LHGPQVKQGUqwBBGCD3rKgvbaxs7q4u7iKKKORyWZgAFz/wDrqlp/inS/EUr29jcSeXGf3jspjDD0
+UnGe3SpEb0rmKM7UJAHbjFed+JPEaXSSwtHKka5Ri0bLntkcZ9a2de8RnQreRbPSbuUswCncnlH3
++8SB+FcRe+IL+a6SDUbSOCaQ5jkjk3Rk9wT64NYYhycbRBIr297c2bxRWatLheJSOGx3qxb+IL6Y
+SC6lCvtI2saooqwGXzHD+ah3LEc4P0BrP1XUIHIUMM5wAD09jzXNDnk+W3zKtZXZ1elayXuIrctg
+kjH9K9dQ5iU+oFfPulz+Vfwgja4YDI789q9+tXElnC69Cg/lXdQVk0Q3cUjmig9aK2AS3GyCNe4U
+D9K81+KGpvb3cNuJlRWiII7nNelqeBXNeL9Ct9UtvNeEPKq4B9Kb1QjxFNZlN0zeac4HIPBrp9Ht
+NQnkEk1yIkPIHBP5VpnwPCs8hWLABGCfpTJ/Dd7ArfZ57hR6KxxXNVWnulRa6kmr6MNSihtWlZYQ
++5zkZfA4ye3PpTtSuNKs7BbeWZJZY0wqpyAcdPaubvtI1mQbXmmIz71mz+HdREPzq7D/AHTWPI2k
+my+ZdCK21iOy1cKcSQSN+8j6gV1p8T6Mif6qMkfdXaMCuOg8KXksuRAcDnO000+FroSENC4yfQ1o
+4Rb3FznTzeMrO42b4wGRgUIPpWBqmpWl4zOURj1yBg1Evg6/ddywvj60DwVqbHBjfHsc1cYRT3Hz
+aGfZ37C7iUFiFwFA5r6e0zjSbTjB8pePwrwvQfAF6+pwyPC20MCd1e9ouyFE4GABxW6t0M2IetFN
+PWikAitUmeOmarKTinhjVAShVPVBS+VF/cX8qjDGl3GlcVhTBAesSH8KY8EAx/o6sPZadk0bjS0E
+RrHBzstV/AYqQWtsRk28efpQGpdxpqwB9ltv+eKD8KPs0A6RJ+VLk0ZNVoMUKq/dRR9KRmpCaYxo
+ugsIW5oqFic0VN0M/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0005/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=14;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0005</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Sorex Palustris, Rich. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Marsh-Shrew. (v. 3, no. 25, plate 125)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="15" sliceresultid="14"><EntryIdSplit><path>/s/sclaudubon</path><viewid>29375_0015</viewid><m_source>sclib</m_source><entryid>x-b6719891</entryid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0015</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0015</EntryWindowName><ResultNumber>15</ResultNumber><SliceResultId>14</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0015/full/525,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>524</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_flm class="fieldsRef">2014-12-11 10:29:55</m_flm>
+<istruct_caption class="fieldsRef">29375_0015||||||||||||||||||Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||Exhibit||||||||||||plate 126</istruct_caption>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29375_0015||||||||||||||||||Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||Exhibit||||||||||||plate 126</m_caption>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-28</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_fn class="fieldsRef">29375_0015</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_title class="fieldsRef">Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">28</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29375_0015</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0015</istruct_isentryid>
+<istruct_caption_plate class="fieldsRef">plate 126</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<m_iid class="fieldsRef">29375_0015</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29375_0015</istruct_caption_image_id>
+<istruct_caption_software class="fieldsRef"/>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:29:55</modified>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">a222f317b48803c17b308a9c55727739</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6407</height>
+<u class="imgInfHashRef">1</u>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<basename class="imgInfHashRef">29375_0015</basename>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8395</width>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<size class="imgInfHashRef">5271352</size>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/6_/p1/26/audubonVQ_v3_26_p126/audubonVQ_v3_26_p126.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0015</Caption><Caption>Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)</Caption><Caption>Exhibit</Caption><Caption>plate 126</Caption>
+</Captions><ItemDescription>Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Dtx
+S7ad5a7t20bvXFOxUWGR4pKl20m2lYVxlLQ5VFLMQFAySe1ZEmuQRan5PmDbnymDHBD5GOPfd+lD
+sgNNbiJ5HjWRS6HDLnkfWpK5XWGRtW0zVNNcSSNc/ZriJZMBxhiN3uCtdYoO0BsZxzimhiUmKfij
+FVYLjCvFMO31FTYGKZ5Mf9xfypAQleaKn20UhkmKKKx9W8R2ek3cNnJk3Mwyg6KOcZY9hQ2krsW5
+sHAHPFJiuYsNcj1G11K11pRZyId4SRgB5TAbWDdDznkVr6FLLPoNjJMSZWgQsT1Jx396Sd2DViLx
+G6J4fvWkk8seXw2Ceew49TxXnmu2lrqOlL4ittTVrqK2EdxaTuPmXHIXuGzyOvNd54t1GDSvDtxc
+zrMwGAqxD5i3UDkHHTrXkGlagNSkN1qAVZPMbyQUAG4njkc8etRPRjieoafcJrCaSlhZTw2Nu4la
+R49qkhSMD15J5rq8V5vpfj9tEt/sOsWM8giGIZ7ZQd69sgkYPvWRd/F/U4tUMaaRAsHZJJDvx7kc
+Zq4yVg5Wev0uK8sX4yxqP3ugz57+XOD/ADFWofjPo5A8/S9Ri55wEYD/AMeFXdBys9JxSVm6H4h0
+zxFZ/adNuVlUffQ8Mh9CO1adMQlFOxRUjCuL8c6YWa11RCT5J8t05OQemB654/Gl8ceLJPD81nFF
+HMS53OUXIZeRge/Q1zh+JV4tk9w9gViV8Bp5FAI7cYJzWc+WUeWQ43TujoNB0GKG4hvtQjDuq4ij
+kO7yFHQD9e1bV/4s0bSwDeXLRA9CYmOfyFYsPiCPWvD0GpWs8apLw5x0PQj865rUPE8Bu3a7sRLa
+AmOAumNxA9/esZVHDRFKPM7s9Gsdc0jWYQbS7hnVv4TwfyPNN1qxsdZ0ubT7l1CuPlIIyjdiPcV5
+a0txqFgwjj8lhKSAjbdncEfh/KrF94n1HTLWKI+TPcKg3OOQT74PX8KdOupXUhTpuOqKs8Os6O7W
+V/ZG4hXiO5H3WH17VwviC6in1SWSL+FQCffJ/oa7U+O7u8tzBLNaLkbWR0OD/wB9Vj22j2LTK09s
+sgmRn3FiMEHIxz0xVc0UwjdnJ2t5dyyrCuxieASat3aPbagqzK4QoASykAnHbNbdnPHo8jSWs9qr
+dA0g3Y+lF5qU2oH/AImU0N5Af4RhSPdSOhq76lKR1fwvlj06C+umiy7sqxt2GAc/zr03TtRa4wHk
+Vm/KvDUV9LlFol2ZLRmVlAbbJGTj069asaVPqUGpIya6yOWwwebOaqM1bUU1rc+gKKjtmLWsTFg5
+KAlh3460VRBzni3UbKxiT7VJbLxnEvJx7Ac15pc+J9HnlZBcRjB7QNivRPGs1vFbp5sG4kZ8woCA
+Pc15xDPBezlY1iCjoFAz+WK5K1r6lxRat9Q0SRCI5o2frs20tlqlg/m+RH8xOHBUrzz/AImsjV5r
+CIFVso7mbHAbg/yP9Ko6frMkEw3+H3jVuSyKzE+5rla0NDqJ5LZwP3LEjoOtUrudFt2DwFEI+/s3
+Af1rSi1ixnMYdBAxHCzR7R+ZFakUUExBWGFs91FZrcLHlr2Qv3lRGVAMkSFvl4H0/Sujs9D1S0lh
+mWfELKIkDc4yu0cfjXZ3WkWUqKWtUL99qgbh6H1FKulQ+YsjGRIwwfygxK7gcg+1dKqXVhKJw0+i
+6zEjRmCCdT1K/Kf8Kjj06YsjNZltpy8afeGBnkEd/X3r0jag+ZEX86YkMk8rBkKg8AqapVWtx8iP
+M5oRcSy3n2dxKDuYEAFee4rYtNJNxqij7HLCd+QxTjr+NdvJptoQrzQZdDwWpiXSQ3arEJHO4cBM
+1XtXpYTgjvrdPLtok4+VAOPpRRESYUyMHaMiiusxIJoLe6j2TxLIvoy5qnL4e0q4TY1qoXphcrVx
+GOKlDGpaT3A5gfDfw2JTJ9lk3H/poalfwBoTqF8uZVHZZSK6UGlzUOEHuh3Zz0fgbQok2C2dgeu6
+QnNQHwNoMMpZEniJ7RuQP0rqM0hPtS9lDsK7Mi20SwtY1jSW4ZFGAGYn+lXBpdpIoIRgPcY/nVwK
+o6AClzVqEV0C7KR0ezJzsI+hqVNOto+kY/GrINITVKMew7sp3Ok2F1HsmtY2XOelMttK0+zx5Foi
+kdDtzj86uk00tTsuwC7qKi3Gii4WP//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0015/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=15;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0015</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Tarandus Furcifer, Agassiz. Caribou, or <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Reindeer. (v. 3, no. 26, plate 126)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="16" sliceresultid="15"><EntryIdSplit><entryid>x-b6719891</entryid><cc>sclaudubon</cc><path>/s/sclaudubon</path><viewid>29375_0050</viewid><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0050</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0050</EntryWindowName><ResultNumber>16</ResultNumber><SliceResultId>15</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0050/full/524,403/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>523</w>
+    <h>402</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_fn class="fieldsRef">29375_0050</m_fn>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption class="fieldsRef">29375_0050||||||||||||||||||Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||Exhibit||||||||||||plate 141</istruct_caption>
+<m_flm class="fieldsRef">2014-12-11 10:17:21</m_flm>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-43</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29375_0050||||||||||||||||||Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||Exhibit||||||||||||plate 141</m_caption>
+<m_id class="fieldsRef">B6719891</m_id>
+<m_source class="fieldsRef">sclib</m_source>
+<m_iid class="fieldsRef">29375_0050</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29375_0050</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_m class="fieldsRef">29375_0050</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0050</istruct_isentryid>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">43</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 141</istruct_caption_plate>
+<width class="imgInfHashRef">8377</width>
+<master class="imgInfHashRef">0</master>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/9_/p1/41/audubonVQ_v3_29_p141/audubonVQ_v3_29_p141.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<size class="imgInfHashRef">8204582</size>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6444</height>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29375_0050</basename>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">89a3165b04f8f075d6534e1f6c472eb3</md5>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 10:17:21</modified>
+<levels class="imgInfHashRef">6</levels>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0050</Caption><Caption>Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)</Caption><Caption>Exhibit</Caption><Caption>plate 141</Caption>
+</Captions><ItemDescription>Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2YAAg
+EHn2p5UCoby9hsYt0jgMQdoJ64Ga8+8R+N7q1mj8tFSBwSrh+ucYrllJI01PQpZUiXc3AqpJqlpG
+jOZB8oyQK5vXNdLWVlHEp3TKjkg9iOa5TWb/AMqymZGxt759s/yrGpUtK0QSutTt7vx1odlM8ct2
+AVXJI+pGP0rRTXbd7T7RCpkGBgcDORxXzbqcjyXMchJO8AsSe5r16yupotGMjzKqCzjlKep2Agj0
+6c1V9mS9DttM8RWmpR5CvC+A22QYOCMgj1FT3mt6fYJvubhY1HUmuIu9Xtzp6Kvy3NgiBSg5K42k
+H+dc54nv2u9PiYttjdR5mOKh1mnZIaV0et2etabfrIba7jk8v7+D92ppr61t4fNllVE2lsnjj1r5
+78Oao+m3NwY3k8y6jeEJ2Oeh/OvSjqc+raM9teQAXMWVQ7eMY6Zrb2isDTTO+hliuYEmiYPHIoZW
+HQg0rBQcZGfrXD+CtUa50EWs8rLJZyvBlT2HI/nXbQlJEXgE46kVaswvYYYwTkYoqxsA4AwPaips
+M5zxjFvXT3y3yzcbSBjIxzXlXjOCK2sRGZ3d0UYRjwvHbj2rv/ilfS2elWQiYqzTZzxxivIfFXiT
+7dbQQlB5oUZOc/pQ4tzVgvoauj6qZ9OtzPzsBjbJzx/n+VHia/DQyLCcrtG4E8fdrz5jPsGJnGew
+OBSia8iwTKzJ6McjFJ4f3r3FzaF69dhNtOCEAHFelWUnm6FaIkpbdFDATjIBZuR+Wa8oW6SeTBYh
+ie/TNdjZaqlrp8SXMj4VldFTjkDA5/GoqpwS0JepqagzRai7POGnaTaqKeCMgZNWfFAP9mCDDKq4
+GR9K53ULa1d4rqGSVJOGwWzjmpfEPiItbIg5lI4z296xiueSsOGiZk2bvDcQ3LHLRuGGenBzXW3P
+ii8jkWYXCyMCcIenNedL9unYGGdy393NSx3k4i8q4AXP8fSuz2N3cJO+x6BofiZLBrvf80sz7wo7
+HHPNdP4X8W6rqnia1gDRJbNkOmOox/OvHXc/LHHjJPX1ruPAV4ttr9sJot7Z2rk4wfWn7JR1RHMz
+3+ikYkY+lFI1POfi6iNptluJDBmxj8K8E1NCt4/O7G0fpXvHxdwtpZyGTGwMSM9a8ElbzTIx5JYk
+1rAlltLdbmJDG5BAG5R1I9RUMisYJVJwqrhT69KfpwafbGmQxYLke9NuxJEHtmOSh6/hRfWwijbw
+7nzg8GrUcNyzrGjMq5ySTwP8802C5CAeaMY6HHFaCzF7YeWOpzls89RSk7bgXLoSJGkSOSMgA56m
+s2/JOpRxhTJ8u0BRk1rWFxa2ejXNtJatLeTMrrMW4TB4xx6E/nVCHVZNC1C0vkhSSeMH5JBwRmso
+PV2QWSKywT2zMk7NHIMbkbgj04qtcoqDlmY8jntWtqOrzarf3GqSRAPIQxRhkDAwMVjq0t47AIWy
+S1bxd1dhp0J9MdY1VpASglAHPbvXoXh547jxHpvlrsUTD5Qo6+przPE3nJEy7AGxt967zw5eLbat
+ZOEUMrr1PvUVejA+jmHT6UU4cqp9RRUFnm/xX0aXUtMWSHO9E4wOuDnFeORafbw2arcWt2JiMOTE
+ePpX0J4xtZbjTVeJnGzrt9K81e5WGTy5GJfoA5xXPVrSpuyGkmeb6fKum6jukVygORlcZ9KZ+6ud
+QlkuC6puLEY5bJr1B7GwliaSdIVGcZOSf5VRudE0m4kAjSKQjrtfkfgDWf12L3iw9mzjp4dMu7U+
+VvVgODsJo0O7WxBiuLVpIyfkPHB/wrsG0izgLJHbxEgfd3kYPbgfyp0Vpbxr581r5QHZ8D8snpXM
+8VFwcbNr1K9m7mH9ujDNsssKzZO6sfV0+136yiEokahdvUt34rs2/syQEHeSf4gpA/D1q5DZwb1H
+k4XtvQ7j+FKnio03fl1JcLnBvPcXSeWNM8qPu5OT6VU0pI7eKTznlU5IKoAM/jXrlzoNrJZlJQU8
+1ColVeE4746fjXPad4HsYLU3E0zjDsAbhAinngg5x05rvo1uek3YlxaZxNxbwHUIHUMPlDndzkDP
+U13ngyM6jrNqtvaxrCHBLsnPHpQmi6WtyTaXME8knDbz0+nbFdn4U037JqkQaMJgZAxiidW7UbDs
+ehHjAoprnmitwIvldNrqGU9QRmsi78JaHfOXlslDHklCV/lWkrnFSBzQ7PcZzMnw60OT7v2hPpJU
+R+GehshV2ncnoXYHH6V1u80u81k4Q7BdnIRfDTSIBlJZi/dnwaa3w707ztzXUwA/hCnB/Gux3nNG
+/PaodKm+gXZxs3w60+Q5jvp4umdigE/U4qF/htOxLxa3IpPILIT/ADNd2rcDinbzSWGo9hczOGg+
+H+pwTbx4icqeo8nqPzrRv/A8GoPHJcXReVF2hjGOB7DtXUbzSFz6VsqVNKyQXZySeA4Vj2SXpKk8
+hYwAa1NN8M6dpUiPDvZk+6GbIU+w7VsFzUZf2pxpwjsguwkb5qKryOd1FO4WP//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0050/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=16;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0050</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Ursus Americanus, Pallas. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Black Bear. (v. 3, no. 29, plate 141)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="17" sliceresultid="16"><EntryIdSplit><path>/s/sclaudubon</path><m_source>sclib</m_source><viewid>29375_0010</viewid><entryid>x-b6719891</entryid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0010</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0010</EntryWindowName><ResultNumber>17</ResultNumber><SliceResultId>16</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0010/full/527,406/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>526</w>
+    <h>405</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0010</istruct_isentryid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29375_0010</istruct_m>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_x class="fieldsRef">18</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_plate class="fieldsRef">plate 116</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_iid class="fieldsRef">29375_0010</m_iid>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29375_0010</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_flm class="fieldsRef">2014-12-11 11:08:37</m_flm>
+<istruct_caption class="fieldsRef">29375_0010||||||||||||||||||Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||Exhibit||||||||||||plate 116</istruct_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-18</istruct_isentryidv>
+<m_id class="fieldsRef">B6719891</m_id>
+<m_caption class="fieldsRef">29375_0010||||||||||||||||||Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||Exhibit||||||||||||plate 116</m_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_title class="fieldsRef">Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29375_0010</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">20b51a16b26e02bb37d90e42c6019afd</md5>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 11:08:37</modified>
+<levels class="imgInfHashRef">6</levels>
+<width class="imgInfHashRef">8426</width>
+<master class="imgInfHashRef">0</master>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/4_/p1/16/audubonVQ_v3_24_p116/audubonVQ_v3_24_p116.jp2</filename>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<size class="imgInfHashRef">7535391</size>
+<u class="imgInfHashRef">1</u>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6491</height>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29375_0010</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0010</Caption><Caption>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)</Caption><Caption>Exhibit</Caption><Caption>plate 116</Caption>
+</Captions><ItemDescription>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tY0A
++6vHtTwqMMgKfpUirWXrmprptoWEgR+xxmsWlYsvlR6D8qoXGsaba3KW811EkrtsVT3b0/UfnXH2
+PjjUTdzRTW8c8eflYHaV/DvXCRTSXvxAnurhzKlswkZN2AT1xn69azlJdBqL6nvCkMARgg0blAJy
+MDqfSsWw8U6Zdoi+cEmOB5Z459BXDal4imu9SbS7aZhBPdbp3RudnGVUDk5x+tDaRNmz1TcpQMCC
+p6GgAHpisKKLUL6O2jaBoLRedrvtdsdN2BwPatqGJ41w2OvbpWi1ETbR6Ck2j0FOAoxVco7kbhFG
+WwB70g2NnaVP0qbtRtpNDuVmTntRUxHNFTYZMo4rzzxdqU0s7Q4TCkivQkcNbCToCgb9K8r8Qzod
+QYEqxLH5e5pz2HHcwopJYmbIQADOVrLsrxTeXU/l8FwpYD68/wAq1NS8y3017nHBXaAO3+c1zFlq
+tpbaZ9nI865kdnZc4C88ZNYcrb0LdkjqQ4ltjLHIu1CWbPBGKxfCepCx8bHUJITN5Y29e7cZ/LNY
+d/r08VuYYrtAvdIlAH+NZVh4iFrcZ3kZbJO0HmtIUpLUyclsfTK+J4Wxi3bJ/wBoVKviS3OQYJcj
+6V4/aeNpjaLItvb3CKMFxJsI+oOahk+K8cStH/ZiSMOhSU4/lWyUuxB7ZHr1q5wUmX3K8fzqT+2r
+HdtMjZ/3DXlOi/EvTtQKwXVo9pno+7cv/wBauyjnjcB48PnkEHg09VuUkdZFfW04/dzIcdRnBqeO
+WOUHY4bHXBrjJo/MAdMBx3FdFoJY2rB/vA0mOxpEc0U4jmipAjhA/s2MdvJH8q8e8RPHBfOARuyc
+E/yr1eScw+GvOyQVtgcgZP3RXzp4i1C5/fTyyuPm+VSOppS1aSKj3I/EviMrapYRNlyDlv7oJz+d
+cuo+Uqp7c1R3vJOZJDlieSatRTxqSH44rWMFFaGbld6laddgyeTVIqBIpH3T29KvXEiFCBzVeOMy
+NGuPvvgVaIL8t2YtNW3jON/Le9QQCOPBYZPUilurWUSnCYUdM1Pp0LvJNuj5KYUkZA/yM1S2KNCP
+WFtEMSW6PgZBI/h7VvaX45vINLFnbjy5C3yseQi4rnBZzLZAxwqzsPndmGQfTFRWXmhXQlEz1J4O
+DSsmho9T0TVr+bTIJp7t3lK7mYNz1zXpvg67lurJzJJvx0z1rwawYeWkccpAAxgGvY/hoQLS5Tfu
+YY/CsG9bGjWh3R60Up60UiTG1BGbwgyK20/Zl5/AV85+MAVthjJAmGeO1fSZjafw+sY+89uo/wDH
+RXiGvWO6eaGaEMjEhlIqW7STLirpo8pJ+UMvbIal35AwQcf3hWzeeFrmCQtavvjPQMcGs2TRtSDf
+6g1v7SL6mLhJdCFlJXOFrV0GFL+/hs0ty88jYUjt/hWW2m38YJaFgK6z4ZXVtpnioXF+hCrG2Djv
+0qZNNOzFqmbTeDzbErNJcwk/w7+D+fWlh8MwwRubWeWNyOehz9RXo2o+JNGnhwpV89iK5OG/sbnU
+GhtN2ANzDqF9s1yydSOqZvHlfQ5iPw7NDPuEYcZyG6Y+tVW0S+ubsqbUL24PBGeDXpGxGxhPpVhN
+ML4Krj3I6UKtIvkicFbaBqVoVaWMSRJkqFGce1ev+ALZ4LWdmjZA2OCKx4LCQuoIz9a7nR4fJtAN
+uD3rSMnJ3ZEtEaBPNFNJ5oqyCvZ4FnAvpGo/QVm6h4V03UWZ3TY7ckrV6E4iRewAFTK3tS0e49Uc
+PdfDVZH3w3ox2UpgVVb4ZXGMC6hP4GvRA5p281DjEfMzzY/DGbvPEfwqEfCyXJLNbH0+XmvTic8E
+ZphjRuoqOSIOTPNf+FXsTgqh+shxWha+Ap7VNkUcEa/7Peu7CKD0zinDCnIAGarkQrs5i28JyIuJ
+WQ1qx6DEqKC3StTcaN9UoRQ+ZlSLS44zknNXQAq4XgUwvntTC/tV6IWo4tzRUDOc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0010/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=17;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0010</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Black or Silver Fox. (v. 3, no. 24, plate 116)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result><Result resultnum="18" sliceresultid="17"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><path>/s/sclaudubon</path><viewid>29376_0028</viewid><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0028</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0028</EntryWindowName><ResultNumber>18</ResultNumber><SliceResultId>17</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0028/full/535,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0028</istruct_m>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0028</istruct_isentryid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">39</istruct_x>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_plate class="fieldsRef">plate 087</istruct_caption_plate>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0028</m_iid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29376_0028</istruct_caption_image_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2014-12-11 10:38:33</m_flm>
+<istruct_caption class="fieldsRef">29376_0028||||||||||||||||||Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||Exhibit||||||||||||plate 087</istruct_caption>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-39</istruct_isentryidv>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_caption class="fieldsRef">29376_0028||||||||||||||||||Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||Exhibit||||||||||||plate 087</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</istruct_caption_image_title>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0028</m_fn>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<access class="imgInfHashRef">1</access>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/8_/p8/7/audubonVQ_v2_18_p87/audubonVQ_v2_18_p87.jp2</filename>
+<size class="imgInfHashRef">6741884</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:31</loaded>
+<width class="imgInfHashRef">8550</width>
+<master class="imgInfHashRef">0</master>
+<basename class="imgInfHashRef">29376_0028</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<height class="imgInfHashRef">6592</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">ebc859cb3d397ad5106433de96949c31</md5>
+<use class="imgInfHashRef">access</use>
+<modified class="imgInfHashRef">2014-12-11 10:38:33</modified>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+</Captions><ItemDescription>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;subview=detail;resnum=18;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Vulpes Fulvus, Desm. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Red Fox. (v. 2, no. 18, plate 87)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field></Section></Record></Result></Results>
+
+
+
+  <Assets>
+    <script type="text/javascript" src="js/_reslist.js">
+        <script type="text/javascript" src="vendor/sly.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.selection.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.stickytableheaders.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/sly.pagination.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/reslist.js" timestamp="1469476504"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_reslist.css">
+        <link rel="stylesheet" type="text/css" href="css/reslist.css" timestamp="1469476504"/>
+        <link rel="stylesheet" type="text/css" href="css/sly.pagination.css" timestamp="1469476504"/>
+    </link>
+</Assets>
+
+  <SearchForm><NumQs>2</NumQs><Q name="q1"><Value>American</Value><Rgn name="rgn1"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value><Focus>true</Focus></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn1</Name><Default>istruct_caption_image_title</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel></Q><Q name="q2"><Value/><Rgn name="rgn2"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn2</Name><Default>all</Default></Rgn><Sel name="select2" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sclaudubon</Variable>
+</HiddenVars><MediaOnly><Visible>true</Visible></MediaOnly><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+  <!-- WUT -->
+<Facets><Delta label="SQL">0</Delta>
+<Delta label="facets">0</Delta>
+<Query>SELECT SQL_CALC_FOUND_ROWS * FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `istruct_caption_image_title` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'medium' AND f1.value = 'Lithograph' ) x1 </Query>
+<Query>SELECT* FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `istruct_caption_image_title` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'medium' AND f1.value = 'Lithograph' ) x1 </Query>
+<Query>SELECT b.field, b.value, COUNT(b.value) AS total FROM ItemBrowse b, ( SELECT* FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `istruct_caption_image_title` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'medium' AND f1.value = 'Lithograph' ) x1  ) a WHERE b.collid = ? AND a.istruct_isentryid = b.idno  GROUP BY b.field, b.value ORDER BY b.field, total DESC, b.value </Query>
+<Debug>{
+  'medium' => 'Lithograph'
+}
+</Debug>
+<Field abbrev="is_part_of__work_title_">
+    <Label>Work Title</Label>
+    <Values>
+        <Value count="18">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value>
+    </Values>
+</Field>
+<Field abbrev="medium">
+    <Label>Medium</Label>
+    <Values>
+        <Value selected="true" count="18">Lithograph</Value>
+    </Values>
+</Field>
+<Field abbrev="subject">
+    <Label>Subject</Label>
+    <Values>
+        <Value count="18">Mammals</Value>
+    </Values>
+</Field>
+<Delta label="xml">0</Delta>
+</Facets>
+<SearchForm><NumQs>2</NumQs><Q name="q1"><Value>American</Value><Rgn name="rgn1"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value><Focus>true</Focus></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn1</Name><Default>istruct_caption_image_title</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel><Sel name="select1" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>any</Default></Sel></Q><Q name="q2"><Value/><Rgn name="rgn2"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn2</Name><Default>all</Default></Rgn><Sel name="select2" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sclaudubon</Variable>
+</HiddenVars><MediaOnly><Visible>true</Visible></MediaOnly><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+
+
+</Top>

--- a/samples/data/s/sclaudubon/Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001.xml
+++ b/samples/data/s/sclaudubon/Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001.xml
@@ -1,0 +1,2595 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">
+
+  <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>results_nav.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>displayheader_results.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>results.xsl</Filename>
+    <Filename>reslist.xsl</Filename>
+    <Filename>reslist_result.xsl</Filename>
+  </XslFallbackFileList>  
+
+
+  <!-- Custom OPTIONAL XML for top-level file reslist.xml<2> -->
+  <CustomXml/>
+
+  <ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+  
+  <DlxsGlobals><CurrentCgi><Param name="cc">sclaudubon</Param>
+<Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="q1">lithograph</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="q2">American</Param>
+<Param name="view">reslist</Param>
+<Param name="type">boolean</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="start">1</Param>
+<Param name="debug">xml</Param>
+<Param name="sort">medium</Param>
+<Param name="size">50</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;rgn1=medium;select1=all;q1=lithograph;op2=And;rgn2=istruct_caption_image_title;select2=any;q2=American;view=reslist;type=boolean;c=sclaudubon;start=1;debug=xml;sort=medium;size=50</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>666bcdea4b8e42e397a495634ce0bd8e</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/reslist.xml</TemplatePath>
+<TemplateName>reslist</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<GroupName/>
+
+<JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775482</Url><Mode>login</Mode></LoginLink>
+
+<SearchSummary/>
+<TotalResults>18</TotalResults>
+<Next/>
+<Prev/>
+<Fisheye/>
+
+<BbagOptionsMenu><UserIsOwner>false</UserIsOwner><HiddenVars><Variable name="lasttype">boolean</Variable>
+<Variable name="lastview">reslist</Variable>
+</HiddenVars></BbagOptionsMenu>
+<SortOptionsMenu><HiddenVars><Variable name="cc">sclaudubon</Variable>
+<Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="view">reslist</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="type">boolean</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+</HiddenVars><TotalResults>18</TotalResults><SortThresshold>1000</SortThresshold><ThresholdExceeded>false</ThresholdExceeded><Option index="0"><Label>(None)</Label><Value>none</Value></Option><Option index="1"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="2"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="3"><Label>Image Title</Label><Value>istruct_caption_image_title</Value></Option><Name>sort</Name><Default>medium</Default></SortOptionsMenu>
+
+<ViewInstruct>reslist1</ViewInstruct>
+
+<SliceSummary><Start>1</Start><End>18</End><Total>18</Total></SliceSummary>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<ViewTabs><Form>graphic</Form><Graphic name="reslist"><Url>/i/image/graphics/display-tabs-C.gif</Url><Alt/></Graphic><View name="thumbnail"><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;start=1;type=boolean;view=thumbnail</Url><ImageMapCoords>0,11,130,34</ImageMapCoords></View><View name="reslist"><Current>true</Current><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;start=1;type=boolean;view=reslist</Url><ImageMapCoords>131,11,258,34</ImageMapCoords></View></ViewTabs>
+
+<GuideFrame><!--GUIDEFRAME_XML--></GuideFrame>
+
+<ResultsHeader><Row><Column abbrev="istruct_caption_image_title" section="1" parent="section-1">Image Title</Column><Column abbrev="is_part_of__work_title_" section="1" parent="section-1">Work Title</Column><Column abbrev="medium" section="1" parent="section-1">Medium</Column></Row><Index>1</Index><Debug>0.000277042388916016</Debug></ResultsHeader>
+
+<!-- "full" is used to display full record. -->
+<!-- and to differentiate between additional "brief" results -->
+<!-- used in bbcustomorder.xml. -->
+<Results name="full"><BookBagToggle>on</BookBagToggle><Result resultnum="1" sliceresultid="0" marker="c425f4d9542a7a3a827c3ff1ea499b6c"><EntryIdSplit><cc>sclaudubon</cc><viewid>29377_0048</viewid><entryid>x-b6719889</entryid><m_source>sclib</m_source><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0048</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0048</EntryWindowName><ResultNumber>1</ResultNumber><SliceResultId>0</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/544,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>543</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0048</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0048</m_fn>
+<istruct_x class="fieldsRef">3</istruct_x>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-3</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0048</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0048</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 001c</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</istruct_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_id class="fieldsRef">29377_0048</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</m_caption>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:41:06</m_flm>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29377_0048</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 10:41:06</modified>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6718</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">e96ecf681e7e8d8efb9b562c26fcfa97</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/_p/1/audubonVQ_v1_1_p1/audubonVQ_v1_1_p1.jp2</filename>
+<width class="imgInfHashRef">8698</width>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">7880555</size>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+</Captions><ItemDescription>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Lynx Rufus, Guldenstaed. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wild Cat. (v. 1, no. 1, plate 1)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="2" sliceresultid="1" marker="c425f4d9542a7a3a827c3ff1ea499b6c"><EntryIdSplit><entryid>x-b6719889</entryid><cc>sclaudubon</cc><viewid>29377_0002</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0002</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0002</EntryWindowName><ResultNumber>2</ResultNumber><SliceResultId>1</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/543,419/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>542</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0002</m_fn>
+<istruct_x class="fieldsRef">8</istruct_x>
+<m_iid class="fieldsRef">29377_0002</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-8</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0002</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</m_caption>
+<m_flm class="fieldsRef">2014-12-11 11:08:59</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_id class="fieldsRef">29377_0002</istruct_caption_image_id>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_plate class="fieldsRef">plate 006</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0002</istruct_m>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29377_0002</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 11:08:59</modified>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6704</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:37</loaded>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">19e1a423cc71ca925526f7d7fda88428</md5>
+<u class="imgInfHashRef">1</u>
+<width class="imgInfHashRef">8686</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/6/audubonVQ_v1_2_p6/audubonVQ_v1_2_p6.jp2</filename>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">4388975</size>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+</Captions><ItemDescription>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Cross-Fox. (v. 1, no. 2, plate 6)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="3" sliceresultid="2" marker="c425f4d9542a7a3a827c3ff1ea499b6c"><EntryIdSplit><entryid>x-b6719889</entryid><viewid>29377_0010</viewid><cc>sclaudubon</cc><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0010</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0010</EntryWindowName><ResultNumber>3</ResultNumber><SliceResultId>2</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/538,413/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29377_0010</m_iid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-12</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0010</m_fn>
+<istruct_x class="fieldsRef">12</istruct_x>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0010</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:50:51</m_flm>
+<m_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</m_caption>
+<istruct_caption_image_id class="fieldsRef">29377_0010</istruct_caption_image_id>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 010</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0010</istruct_m>
+<modified class="imgInfHashRef">2014-12-11 10:50:51</modified>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6606</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<access class="imgInfHashRef">1</access>
+<ext class="imgInfHashRef">jp2</ext>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29377_0010</basename>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">3053212</size>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/10/audubonVQ_v1_2_p10/audubonVQ_v1_2_p10.jp2</filename>
+<width class="imgInfHashRef">8602</width>
+<u class="imgInfHashRef">1</u>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">4726b7070d4ee3d4410f18174a814436</md5>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+</Captions><ItemDescription>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Scallops Aqualicus, Linn. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Shrew Mole. (v. 1, no. 2, plate 10)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="4" sliceresultid="3" marker="c425f4d9542a7a3a827c3ff1ea499b6c"><EntryIdSplit><entryid>x-b6719889</entryid><cc>sclaudubon</cc><viewid>29377_0025</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0025</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0025</EntryWindowName><ResultNumber>4</ResultNumber><SliceResultId>3</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/412,533/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>411</w>
+    <h>532</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0025</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0025</m_fn>
+<istruct_x class="fieldsRef">44</istruct_x>
+<m_iid class="fieldsRef">29377_0025</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-44</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 042</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0025</istruct_m>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</m_caption>
+<m_flm class="fieldsRef">2014-12-11 11:07:17</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_id class="fieldsRef">29377_0025</istruct_caption_image_id>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29377_0025</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 11:07:17</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">8523</height>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">eeb56fd0572b0d85f37e6cbf5250cee1</md5>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<width class="imgInfHashRef">6579</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_9/_p/42/audubonVQ_v1_9_p42/audubonVQ_v1_9_p42.jp2</filename>
+<size class="imgInfHashRef">4987180</size>
+<use class="imgInfHashRef">access</use>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+</Captions><ItemDescription>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="77" height="100">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar" width="77" height="100">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Mephitis Americana, Desm. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Skunk. (v. 1, no. 9, plate 42)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="5" sliceresultid="4" marker="c425f4d9542a7a3a827c3ff1ea499b6c"><EntryIdSplit><path>/s/sclaudubon</path><m_source>sclib</m_source><entryid>x-b6719889</entryid><viewid>29377_0049</viewid><cc>sclaudubon</cc></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0049</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0049</EntryWindowName><ResultNumber>5</ResultNumber><SliceResultId>4</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/534,414/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>533</w>
+    <h>413</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</m_caption>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 11:14:32</m_flm>
+<istruct_caption_image_id class="fieldsRef">29377_0049</istruct_caption_image_id>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_plate class="fieldsRef">plate 046</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0049</istruct_m>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0049</m_fn>
+<istruct_x class="fieldsRef">48</istruct_x>
+<m_iid class="fieldsRef">29377_0049</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-48</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0049</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<basename class="imgInfHashRef">29377_0049</basename>
+<levels class="imgInfHashRef">6</levels>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6619</height>
+<modified class="imgInfHashRef">2014-12-11 11:14:32</modified>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">bf6d9153b928aec507046ef26268127c</md5>
+<master class="imgInfHashRef">0</master>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<width class="imgInfHashRef">8535</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/0_/p4/6/audubonVQ_v1_10_p46/audubonVQ_v1_10_p46.jp2</filename>
+<size class="imgInfHashRef">5020737</size>
+<use class="imgInfHashRef">access</use>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+</Captions><ItemDescription>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Castor Fiber Americanus, Linn. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Beaver. (v. 1, no. 10, plate 46)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="6" sliceresultid="5"><EntryIdSplit><viewid>29377_0001</viewid><cc>sclaudubon</cc><entryid>x-b6719889</entryid><m_source>sclib</m_source><path>/s/sclaudubon</path></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719889]29377_0001</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0001</EntryWindowName><ResultNumber>6</ResultNumber><SliceResultId>5</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0001/full/533,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>532</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29377_0001||||||||||||||||||Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||Exhibit||||||||||||plate 047</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29377_0001</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 047</istruct_caption_plate>
+<istruct_caption_image_title class="fieldsRef">Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_id class="fieldsRef">29377_0001</istruct_caption_image_id>
+<m_caption class="fieldsRef">29377_0001||||||||||||||||||Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||Exhibit||||||||||||plate 047</m_caption>
+<m_flm class="fieldsRef">2014-12-11 10:27:48</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0001</istruct_isentryid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-49</istruct_isentryidv>
+<m_iid class="fieldsRef">29377_0001</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_x class="fieldsRef">49</istruct_x>
+<m_fn class="fieldsRef">29377_0001</m_fn>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<width class="imgInfHashRef">8521</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/0_/p4/7/audubonVQ_v1_10_p47/audubonVQ_v1_10_p47.jp2</filename>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">5464024</size>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">27a09a39f7ddb17be66bb8461e9ea85c</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 10:27:48</modified>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6592</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29377_0001</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+</Captions><ItemDescription>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=6;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Meles Labradoria, Sabine. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Badger. (v. 1, no. 10, plate 47)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="7" sliceresultid="6"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><viewid>29376_0008</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0008</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0008</EntryWindowName><ResultNumber>7</ResultNumber><SliceResultId>6</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/539,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</m_caption>
+<m_flm class="fieldsRef">2014-12-11 11:07:44</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_id class="fieldsRef">29376_0008</istruct_caption_image_id>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 056</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0008</istruct_m>
+<m_iid class="fieldsRef">29376_0008</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-8</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0008</m_fn>
+<istruct_x class="fieldsRef">8</istruct_x>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0008</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 11:07:44</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6644</height>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29376_0008</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/6/audubonVQ_v2_12_p56/audubonVQ_v2_12_p56.jp2</filename>
+<width class="imgInfHashRef">8615</width>
+<size class="imgInfHashRef">5582522</size>
+<use class="imgInfHashRef">access</use>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">39c661cab405233d69a0d9b728e918f9</md5>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+</Captions><ItemDescription>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=7;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="8" sliceresultid="7"><EntryIdSplit><m_source>sclib</m_source><path>/s/sclaudubon</path><viewid>29376_0009</viewid><cc>sclaudubon</cc><entryid>x-b6719890</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0009</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0009</EntryWindowName><ResultNumber>8</ResultNumber><SliceResultId>7</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/539,417/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>416</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:37:15</m_flm>
+<m_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</m_caption>
+<istruct_caption_image_id class="fieldsRef">29376_0009</istruct_caption_image_id>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</istruct_caption_image_title>
+<istruct_caption_plate class="fieldsRef">plate 057</istruct_caption_plate>
+<istruct_m class="fieldsRef">29376_0009</istruct_m>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</istruct_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0009</m_fn>
+<istruct_x class="fieldsRef">9</istruct_x>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29376_0009</m_iid>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-9</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0009</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">28e3bc418abcab245230f28dd8be386e</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/7/audubonVQ_v2_12_p57/audubonVQ_v2_12_p57.jp2</filename>
+<width class="imgInfHashRef">8620</width>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">7731098</size>
+<basename class="imgInfHashRef">29376_0009</basename>
+<levels class="imgInfHashRef">6</levels>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6664</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<modified class="imgInfHashRef">2014-12-11 10:37:15</modified>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+</Captions><ItemDescription>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=8;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison (female, and young). (v. 2, no. 12, plate 57)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="9" sliceresultid="8"><EntryIdSplit><entryid>x-b6719890</entryid><viewid>29376_0014</viewid><cc>sclaudubon</cc><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0014</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0014</EntryWindowName><ResultNumber>9</ResultNumber><SliceResultId>8</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0014/full/535,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:34:45</m_flm>
+<m_caption class="fieldsRef">29376_0014||||||||||||||||||Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||Exhibit||||||||||||plate 062</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_id class="fieldsRef">29376_0014</istruct_caption_image_id>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_title class="fieldsRef">Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_plate class="fieldsRef">plate 062</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0014</istruct_m>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0014||||||||||||||||||Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||Exhibit||||||||||||plate 062</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_x class="fieldsRef">14</istruct_x>
+<m_fn class="fieldsRef">29376_0014</m_fn>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29376_0014</m_iid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-14</istruct_isentryidv>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0014</istruct_isentryid>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/3_/p6/2/audubonVQ_v2_13_p62/audubonVQ_v2_13_p62.jp2</filename>
+<width class="imgInfHashRef">8554</width>
+<size class="imgInfHashRef">4939458</size>
+<use class="imgInfHashRef">access</use>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">04cf9f4905dd8b4cf400450e3918f6fd</md5>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 10:34:45</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:39</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6645</height>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29376_0014</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+</Captions><ItemDescription>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=9;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Cervus Canadensis, Ray. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="10" sliceresultid="9"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><viewid>29376_0012</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0012</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0012</EntryWindowName><ResultNumber>10</ResultNumber><SliceResultId>9</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/538,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 067</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0012</istruct_m>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_title class="fieldsRef">Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 11:09:51</m_flm>
+<m_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_id class="fieldsRef">29376_0012</istruct_caption_image_id>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0012</istruct_isentryid>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29376_0012</m_iid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-19</istruct_isentryidv>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_x class="fieldsRef">19</istruct_x>
+<m_fn class="fieldsRef">29376_0012</m_fn>
+<modified class="imgInfHashRef">2014-12-11 11:09:51</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6708</height>
+<access class="imgInfHashRef">1</access>
+<ext class="imgInfHashRef">jp2</ext>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29376_0012</basename>
+<size class="imgInfHashRef">5467100</size>
+<use class="imgInfHashRef">access</use>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/4_/p6/7/audubonVQ_v2_14_p67/audubonVQ_v2_14_p67.jp2</filename>
+<width class="imgInfHashRef">8602</width>
+<u class="imgInfHashRef">1</u>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">839172d2f92639a1b9fffe33e2d0f53d</md5>
+<master class="imgInfHashRef">0</master>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+</Captions><ItemDescription>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=10;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Canis Lupus (Var. Ater), Linn. Black <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 14, plate 67)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="11" sliceresultid="10"><EntryIdSplit><m_source>sclib</m_source><path>/s/sclaudubon</path><viewid>29376_0038</viewid><cc>sclaudubon</cc><entryid>x-b6719890</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0038</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0038</EntryWindowName><ResultNumber>11</ResultNumber><SliceResultId>10</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/537,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>536</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0038</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0038</m_fn>
+<istruct_x class="fieldsRef">24</istruct_x>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-24</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0038</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0038</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 072</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29376_0038</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</m_caption>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 11:23:16</m_flm>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</istruct_caption_image_title>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<modified class="imgInfHashRef">2014-12-11 11:23:16</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<height class="imgInfHashRef">6642</height>
+<type class="imgInfHashRef">image</type>
+<access class="imgInfHashRef">1</access>
+<ext class="imgInfHashRef">jp2</ext>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29376_0038</basename>
+<size class="imgInfHashRef">7410676</size>
+<use class="imgInfHashRef">access</use>
+<width class="imgInfHashRef">8577</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/5_/p7/2/audubonVQ_v2_15_p72/audubonVQ_v2_15_p72.jp2</filename>
+<u class="imgInfHashRef">1</u>
+<collid class="imgInfHashRef">sclib</collid>
+<md5 class="imgInfHashRef">80667950baa159b01c3906d16885b082</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+</Captions><ItemDescription>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=11;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Canis lupus (Var. Albus), Linn. White <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 15, plate 72)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="12" sliceresultid="11"><EntryIdSplit><path>/s/sclaudubon</path><m_source>sclib</m_source><entryid>x-b6719890</entryid><cc>sclaudubon</cc><viewid>29376_0036</viewid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0036</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0036</EntryWindowName><ResultNumber>12</ResultNumber><SliceResultId>11</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0036/full/534,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>411</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0036</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 081</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0036||||||||||||||||||Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||Exhibit||||||||||||plate 081</istruct_caption>
+<istruct_caption_image_id class="fieldsRef">29376_0036</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29376_0036||||||||||||||||||Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||Exhibit||||||||||||plate 081</m_caption>
+<m_flm class="fieldsRef">2014-12-11 11:05:27</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</istruct_caption_image_title>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0036</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0036</m_fn>
+<istruct_x class="fieldsRef">33</istruct_x>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-33</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_iid class="fieldsRef">29376_0036</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6577</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<modified class="imgInfHashRef">2014-12-11 11:05:27</modified>
+<access class="imgInfHashRef">1</access>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29376_0036</basename>
+<levels class="imgInfHashRef">6</levels>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">5303579</size>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/7_/p8/1/audubonVQ_v2_17_p81/audubonVQ_v2_17_p81.jp2</filename>
+<width class="imgInfHashRef">8544</width>
+<u class="imgInfHashRef">1</u>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">955cc287b6453a6cefa8ad388dcf33c3</md5>
+<collid class="imgInfHashRef">sclib</collid>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+</Captions><ItemDescription>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=12;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Cervus Virginianus, Pennant. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Deer (fawn). (v. 2, no. 18, plate 81)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="13" sliceresultid="12"><EntryIdSplit><entryid>x-b6719890</entryid><cc>sclaudubon</cc><viewid>29376_0028</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719890]29376_0028</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0028</EntryWindowName><ResultNumber>13</ResultNumber><SliceResultId>12</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0028/full/535,412/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>534</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-39</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29376_0028</m_iid>
+<m_fn class="fieldsRef">29376_0028</m_fn>
+<istruct_x class="fieldsRef">39</istruct_x>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0028</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_title class="fieldsRef">Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29376_0028</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:38:33</m_flm>
+<m_caption class="fieldsRef">29376_0028||||||||||||||||||Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||Exhibit||||||||||||plate 087</m_caption>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0028||||||||||||||||||Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||Exhibit||||||||||||plate 087</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29376_0028</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 087</istruct_caption_plate>
+<access class="imgInfHashRef">1</access>
+<loaded class="imgInfHashRef">2014-12-12 17:07:31</loaded>
+<height class="imgInfHashRef">6592</height>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 10:38:33</modified>
+<basename class="imgInfHashRef">29376_0028</basename>
+<levels class="imgInfHashRef">6</levels>
+<ext class="imgInfHashRef">jp2</ext>
+<width class="imgInfHashRef">8550</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/8_/p8/7/audubonVQ_v2_18_p87/audubonVQ_v2_18_p87.jp2</filename>
+<size class="imgInfHashRef">6741884</size>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">ebc859cb3d397ad5106433de96949c31</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<collid class="imgInfHashRef">sclib</collid>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+</Captions><ItemDescription>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=13;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Vulpes Fulvus, Desm. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Red Fox. (v. 2, no. 18, plate 87)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="14" sliceresultid="13"><EntryIdSplit><m_source>sclib</m_source><path>/s/sclaudubon</path><cc>sclaudubon</cc><viewid>29375_0010</viewid><entryid>x-b6719891</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0010</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0010</EntryWindowName><ResultNumber>14</ResultNumber><SliceResultId>13</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0010/full/527,406/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>526</w>
+    <h>405</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0010</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_x class="fieldsRef">18</istruct_x>
+<m_fn class="fieldsRef">29375_0010</m_fn>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29375_0010</m_iid>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-18</istruct_isentryidv>
+<istruct_caption_plate class="fieldsRef">plate 116</istruct_caption_plate>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29375_0010</istruct_m>
+<m_source class="fieldsRef">sclib</m_source>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29375_0010||||||||||||||||||Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||Exhibit||||||||||||plate 116</istruct_caption>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 11:08:37</m_flm>
+<m_caption class="fieldsRef">29375_0010||||||||||||||||||Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||Exhibit||||||||||||plate 116</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_id class="fieldsRef">29375_0010</istruct_caption_image_id>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)</istruct_caption_image_title>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">20b51a16b26e02bb37d90e42c6019afd</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/4_/p1/16/audubonVQ_v3_24_p116/audubonVQ_v3_24_p116.jp2</filename>
+<width class="imgInfHashRef">8426</width>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">7535391</size>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29375_0010</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 11:08:37</modified>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6491</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0010</Caption><Caption>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)</Caption><Caption>Exhibit</Caption><Caption>plate 116</Caption>
+</Captions><ItemDescription>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) American Black or Silver Fox. (v. 3, no. 24, plate 116)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tY0A
++6vHtTwqMMgKfpUirWXrmprptoWEgR+xxmsWlYsvlR6D8qoXGsaba3KW811EkrtsVT3b0/UfnXH2
+PjjUTdzRTW8c8eflYHaV/DvXCRTSXvxAnurhzKlswkZN2AT1xn69azlJdBqL6nvCkMARgg0blAJy
+MDqfSsWw8U6Zdoi+cEmOB5Z459BXDal4imu9SbS7aZhBPdbp3RudnGVUDk5x+tDaRNmz1TcpQMCC
+p6GgAHpisKKLUL6O2jaBoLRedrvtdsdN2BwPatqGJ41w2OvbpWi1ETbR6Ck2j0FOAoxVco7kbhFG
+WwB70g2NnaVP0qbtRtpNDuVmTntRUxHNFTYZMo4rzzxdqU0s7Q4TCkivQkcNbCToCgb9K8r8Qzod
+QYEqxLH5e5pz2HHcwopJYmbIQADOVrLsrxTeXU/l8FwpYD68/wAq1NS8y3017nHBXaAO3+c1zFlq
+tpbaZ9nI865kdnZc4C88ZNYcrb0LdkjqQ4ltjLHIu1CWbPBGKxfCepCx8bHUJITN5Y29e7cZ/LNY
+d/r08VuYYrtAvdIlAH+NZVh4iFrcZ3kZbJO0HmtIUpLUyclsfTK+J4Wxi3bJ/wBoVKviS3OQYJcj
+6V4/aeNpjaLItvb3CKMFxJsI+oOahk+K8cStH/ZiSMOhSU4/lWyUuxB7ZHr1q5wUmX3K8fzqT+2r
+HdtMjZ/3DXlOi/EvTtQKwXVo9pno+7cv/wBauyjnjcB48PnkEHg09VuUkdZFfW04/dzIcdRnBqeO
+WOUHY4bHXBrjJo/MAdMBx3FdFoJY2rB/vA0mOxpEc0U4jmipAjhA/s2MdvJH8q8e8RPHBfOARuyc
+E/yr1eScw+GvOyQVtgcgZP3RXzp4i1C5/fTyyuPm+VSOppS1aSKj3I/EviMrapYRNlyDlv7oJz+d
+cuo+Uqp7c1R3vJOZJDlieSatRTxqSH44rWMFFaGbld6laddgyeTVIqBIpH3T29KvXEiFCBzVeOMy
+NGuPvvgVaIL8t2YtNW3jON/Le9QQCOPBYZPUilurWUSnCYUdM1Pp0LvJNuj5KYUkZA/yM1S2KNCP
+WFtEMSW6PgZBI/h7VvaX45vINLFnbjy5C3yseQi4rnBZzLZAxwqzsPndmGQfTFRWXmhXQlEz1J4O
+DSsmho9T0TVr+bTIJp7t3lK7mYNz1zXpvg67lurJzJJvx0z1rwawYeWkccpAAxgGvY/hoQLS5Tfu
+YY/CsG9bGjWh3R60Up60UiTG1BGbwgyK20/Zl5/AV85+MAVthjJAmGeO1fSZjafw+sY+89uo/wDH
+RXiGvWO6eaGaEMjEhlIqW7STLirpo8pJ+UMvbIal35AwQcf3hWzeeFrmCQtavvjPQMcGs2TRtSDf
+6g1v7SL6mLhJdCFlJXOFrV0GFL+/hs0ty88jYUjt/hWW2m38YJaFgK6z4ZXVtpnioXF+hCrG2Djv
+0qZNNOzFqmbTeDzbErNJcwk/w7+D+fWlh8MwwRubWeWNyOehz9RXo2o+JNGnhwpV89iK5OG/sbnU
+GhtN2ANzDqF9s1yydSOqZvHlfQ5iPw7NDPuEYcZyG6Y+tVW0S+ubsqbUL24PBGeDXpGxGxhPpVhN
+ML4Krj3I6UKtIvkicFbaBqVoVaWMSRJkqFGce1ev+ALZ4LWdmjZA2OCKx4LCQuoIz9a7nR4fJtAN
+uD3rSMnJ3ZEtEaBPNFNJ5oqyCvZ4FnAvpGo/QVm6h4V03UWZ3TY7ckrV6E4iRewAFTK3tS0e49Uc
+PdfDVZH3w3ox2UpgVVb4ZXGMC6hP4GvRA5p281DjEfMzzY/DGbvPEfwqEfCyXJLNbH0+XmvTic8E
+ZphjRuoqOSIOTPNf+FXsTgqh+shxWha+Ap7VNkUcEa/7Peu7CKD0zinDCnIAGarkQrs5i28JyIuJ
+WQ1qx6DEqKC3StTcaN9UoRQ+ZlSLS44zknNXQAq4XgUwvntTC/tV6IWo4tzRUDOc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0010/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=14;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0010</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Vulpes Fulvus, Desm. (Var. Argentatus, Rich.) <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Black or Silver Fox. (v. 3, no. 24, plate 116)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="15" sliceresultid="14"><EntryIdSplit><m_source>sclib</m_source><path>/s/sclaudubon</path><viewid>29375_0005</viewid><cc>sclaudubon</cc><entryid>x-b6719891</entryid></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0005</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0005</EntryWindowName><ResultNumber>15</ResultNumber><SliceResultId>14</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0005/full/525,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>524</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_id class="fieldsRef">29375_0005</istruct_caption_image_id>
+<m_flm class="fieldsRef">2014-12-11 10:59:01</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_caption class="fieldsRef">29375_0005||||||||||||||||||Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||Exhibit||||||||||||plate 125</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_title class="fieldsRef">Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29375_0005</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 125</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29375_0005||||||||||||||||||Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||Exhibit||||||||||||plate 125</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_x class="fieldsRef">27</istruct_x>
+<m_fn class="fieldsRef">29375_0005</m_fn>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-27</istruct_isentryidv>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29375_0005</m_iid>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0005</istruct_isentryid>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29375_0005</basename>
+<levels class="imgInfHashRef">6</levels>
+<loaded class="imgInfHashRef">2014-12-12 17:07:34</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6409</height>
+<modified class="imgInfHashRef">2014-12-11 10:59:01</modified>
+<access class="imgInfHashRef">1</access>
+<u class="imgInfHashRef">1</u>
+<md5 class="imgInfHashRef">93b448b65d49c6db00c80d9ade3736e9</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<collid class="imgInfHashRef">sclib</collid>
+<size class="imgInfHashRef">3655576</size>
+<use class="imgInfHashRef">access</use>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/5_/p1/25/audubonVQ_v3_25_p125/audubonVQ_v3_25_p125.jp2</filename>
+<width class="imgInfHashRef">8387</width>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0005</Caption><Caption>Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)</Caption><Caption>Exhibit</Caption><Caption>plate 125</Caption>
+</Captions><ItemDescription>Sorex Palustris, Rich. American Marsh-Shrew. (v. 3, no. 25, plate 125)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hF4p
++ynqKcYw2M549DistCiLy/akMfsKsbaQ7QQCQCeg9aNAK/l+w/Kl8seg/Kp9tG2nZCIfKHoPypph
+X+6PyqyBRgZx3pWQ9Sr5CH+AflSfZ0/uL+VW8U0inZAVTbp/cH5U0wJj7oqfyo2ZuWz3Ac08rxUu
+wygYVz90UVaK80VnYZYXoKivbj7LbM+CWwdoHduw/Gn2zb7aJ/7yA/pVDX5pbaxSaKPzHVwAue5B
+A/UitHog6li2vxc26vGmXYZIB4H41ZVOQzYZ/X0+lZ1vcW9qUsVeLdDGoYkjOee34Z/GryyAcZye
+9SFiWikzmoLi7itreSaRtqp1JFPmQuW5ZqneWf2qWGQTPGY2z8n8Q9D7Vn6Vqt9qSM5s1iQMBl2w
+SMZyBVRb6+TXJ5Z5VS1EBMaOCBw3J/IfrWcqq6l8rg7GnFqip5ouWVdjHBAP3R3NTx3Ud0FMbjaR
+uPPPsK5uXVYdXElu00RZto+RSDtJB5J+mMVMPssN6j/ZJV+X/Wk4UnntnntWcak29LNAo3OkVoxl
+VI+XsKkIyKwtM1BTZtcM3zSOWwewJwB+WPyrfPK10Jp7EsgI5opxHNFIBLIYs4B6Rr/IVW1kqLeD
+d937RHn/AL6FWrP/AI84P+ua/wAqzfFJQaDdEuqui+YmT/EvI/lVS2BbkGklbkXKmNdn2h2f0LZx
+j9M/lWtDGIk2KoUDoAOKw9B1KF7e5LTxbmuC2AQPvBW/9mrYiu4nX/Wx7iMgbh07VBTH27M6u7EH
+LHGPQVKQGUqwBBGCD3rKgvbaxs7q4u7iKKKORyWZgAFz/wDrqlp/inS/EUr29jcSeXGf3jspjDD0
+UnGe3SpEb0rmKM7UJAHbjFed+JPEaXSSwtHKka5Ri0bLntkcZ9a2de8RnQreRbPSbuUswCncnlH3
++8SB+FcRe+IL+a6SDUbSOCaQ5jkjk3Rk9wT64NYYhycbRBIr297c2bxRWatLheJSOGx3qxb+IL6Y
+SC6lCvtI2saooqwGXzHD+ah3LEc4P0BrP1XUIHIUMM5wAD09jzXNDnk+W3zKtZXZ1elayXuIrctg
+kjH9K9dQ5iU+oFfPulz+Vfwgja4YDI789q9+tXElnC69Cg/lXdQVk0Q3cUjmig9aK2AS3GyCNe4U
+D9K81+KGpvb3cNuJlRWiII7nNelqeBXNeL9Ct9UtvNeEPKq4B9Kb1QjxFNZlN0zeac4HIPBrp9Ht
+NQnkEk1yIkPIHBP5VpnwPCs8hWLABGCfpTJ/Dd7ArfZ57hR6KxxXNVWnulRa6kmr6MNSihtWlZYQ
++5zkZfA4ye3PpTtSuNKs7BbeWZJZY0wqpyAcdPaubvtI1mQbXmmIz71mz+HdREPzq7D/AHTWPI2k
+my+ZdCK21iOy1cKcSQSN+8j6gV1p8T6Mif6qMkfdXaMCuOg8KXksuRAcDnO000+FroSENC4yfQ1o
+4Rb3FznTzeMrO42b4wGRgUIPpWBqmpWl4zOURj1yBg1Evg6/ddywvj60DwVqbHBjfHsc1cYRT3Hz
+aGfZ37C7iUFiFwFA5r6e0zjSbTjB8pePwrwvQfAF6+pwyPC20MCd1e9ouyFE4GABxW6t0M2IetFN
+PWikAitUmeOmarKTinhjVAShVPVBS+VF/cX8qjDGl3GlcVhTBAesSH8KY8EAx/o6sPZadk0bjS0E
+RrHBzstV/AYqQWtsRk28efpQGpdxpqwB9ltv+eKD8KPs0A6RJ+VLk0ZNVoMUKq/dRR9KRmpCaYxo
+ugsIW5oqFic0VN0M/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0005/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=15;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0005</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Sorex Palustris, Rich. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Marsh-Shrew. (v. 3, no. 25, plate 125)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="16" sliceresultid="15"><EntryIdSplit><entryid>x-b6719891</entryid><cc>sclaudubon</cc><viewid>29375_0015</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0015</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0015</EntryWindowName><ResultNumber>16</ResultNumber><SliceResultId>15</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0015/full/525,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>524</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0015</istruct_isentryid>
+<istruct_x class="fieldsRef">28</istruct_x>
+<m_fn class="fieldsRef">29375_0015</m_fn>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-28</istruct_isentryidv>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29375_0015</m_iid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29375_0015</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 126</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29375_0015||||||||||||||||||Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||Exhibit||||||||||||plate 126</istruct_caption>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_id class="fieldsRef">29375_0015</istruct_caption_image_id>
+<m_flm class="fieldsRef">2014-12-11 10:29:55</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_caption class="fieldsRef">29375_0015||||||||||||||||||Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||Exhibit||||||||||||plate 126</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_title class="fieldsRef">Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<size class="imgInfHashRef">5271352</size>
+<use class="imgInfHashRef">access</use>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/6_/p1/26/audubonVQ_v3_26_p126/audubonVQ_v3_26_p126.jp2</filename>
+<width class="imgInfHashRef">8395</width>
+<u class="imgInfHashRef">1</u>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">a222f317b48803c17b308a9c55727739</md5>
+<master class="imgInfHashRef">0</master>
+<modified class="imgInfHashRef">2014-12-11 10:29:55</modified>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6407</height>
+<access class="imgInfHashRef">1</access>
+<ext class="imgInfHashRef">jp2</ext>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29375_0015</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0015</Caption><Caption>Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)</Caption><Caption>Exhibit</Caption><Caption>plate 126</Caption>
+</Captions><ItemDescription>Tarandus Furcifer, Agassiz. Caribou, or American Reindeer. (v. 3, no. 26, plate 126)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Dtx
+S7ad5a7t20bvXFOxUWGR4pKl20m2lYVxlLQ5VFLMQFAySe1ZEmuQRan5PmDbnymDHBD5GOPfd+lD
+sgNNbiJ5HjWRS6HDLnkfWpK5XWGRtW0zVNNcSSNc/ZriJZMBxhiN3uCtdYoO0BsZxzimhiUmKfij
+FVYLjCvFMO31FTYGKZ5Mf9xfypAQleaKn20UhkmKKKx9W8R2ek3cNnJk3Mwyg6KOcZY9hQ2krsW5
+sHAHPFJiuYsNcj1G11K11pRZyId4SRgB5TAbWDdDznkVr6FLLPoNjJMSZWgQsT1Jx396Sd2DViLx
+G6J4fvWkk8seXw2Ceew49TxXnmu2lrqOlL4ittTVrqK2EdxaTuPmXHIXuGzyOvNd54t1GDSvDtxc
+zrMwGAqxD5i3UDkHHTrXkGlagNSkN1qAVZPMbyQUAG4njkc8etRPRjieoafcJrCaSlhZTw2Nu4la
+R49qkhSMD15J5rq8V5vpfj9tEt/sOsWM8giGIZ7ZQd69sgkYPvWRd/F/U4tUMaaRAsHZJJDvx7kc
+Zq4yVg5Wev0uK8sX4yxqP3ugz57+XOD/ADFWofjPo5A8/S9Ri55wEYD/AMeFXdBys9JxSVm6H4h0
+zxFZ/adNuVlUffQ8Mh9CO1adMQlFOxRUjCuL8c6YWa11RCT5J8t05OQemB654/Gl8ceLJPD81nFF
+HMS53OUXIZeRge/Q1zh+JV4tk9w9gViV8Bp5FAI7cYJzWc+WUeWQ43TujoNB0GKG4hvtQjDuq4ij
+kO7yFHQD9e1bV/4s0bSwDeXLRA9CYmOfyFYsPiCPWvD0GpWs8apLw5x0PQj865rUPE8Bu3a7sRLa
+AmOAumNxA9/esZVHDRFKPM7s9Gsdc0jWYQbS7hnVv4TwfyPNN1qxsdZ0ubT7l1CuPlIIyjdiPcV5
+a0txqFgwjj8lhKSAjbdncEfh/KrF94n1HTLWKI+TPcKg3OOQT74PX8KdOupXUhTpuOqKs8Os6O7W
+V/ZG4hXiO5H3WH17VwviC6in1SWSL+FQCffJ/oa7U+O7u8tzBLNaLkbWR0OD/wB9Vj22j2LTK09s
+sgmRn3FiMEHIxz0xVc0UwjdnJ2t5dyyrCuxieASat3aPbagqzK4QoASykAnHbNbdnPHo8jSWs9qr
+dA0g3Y+lF5qU2oH/AImU0N5Af4RhSPdSOhq76lKR1fwvlj06C+umiy7sqxt2GAc/zr03TtRa4wHk
+Vm/KvDUV9LlFol2ZLRmVlAbbJGTj069asaVPqUGpIya6yOWwwebOaqM1bUU1rc+gKKjtmLWsTFg5
+KAlh3460VRBzni3UbKxiT7VJbLxnEvJx7Ac15pc+J9HnlZBcRjB7QNivRPGs1vFbp5sG4kZ8woCA
+Pc15xDPBezlY1iCjoFAz+WK5K1r6lxRat9Q0SRCI5o2frs20tlqlg/m+RH8xOHBUrzz/AImsjV5r
+CIFVso7mbHAbg/yP9Ko6frMkEw3+H3jVuSyKzE+5rla0NDqJ5LZwP3LEjoOtUrudFt2DwFEI+/s3
+Af1rSi1ixnMYdBAxHCzR7R+ZFakUUExBWGFs91FZrcLHlr2Qv3lRGVAMkSFvl4H0/Sujs9D1S0lh
+mWfELKIkDc4yu0cfjXZ3WkWUqKWtUL99qgbh6H1FKulQ+YsjGRIwwfygxK7gcg+1dKqXVhKJw0+i
+6zEjRmCCdT1K/Kf8Kjj06YsjNZltpy8afeGBnkEd/X3r0jag+ZEX86YkMk8rBkKg8AqapVWtx8iP
+M5oRcSy3n2dxKDuYEAFee4rYtNJNxqij7HLCd+QxTjr+NdvJptoQrzQZdDwWpiXSQ3arEJHO4cBM
+1XtXpYTgjvrdPLtok4+VAOPpRRESYUyMHaMiiusxIJoLe6j2TxLIvoy5qnL4e0q4TY1qoXphcrVx
+GOKlDGpaT3A5gfDfw2JTJ9lk3H/poalfwBoTqF8uZVHZZSK6UGlzUOEHuh3Zz0fgbQok2C2dgeu6
+QnNQHwNoMMpZEniJ7RuQP0rqM0hPtS9lDsK7Mi20SwtY1jSW4ZFGAGYn+lXBpdpIoIRgPcY/nVwK
+o6AClzVqEV0C7KR0ezJzsI+hqVNOto+kY/GrINITVKMew7sp3Ok2F1HsmtY2XOelMttK0+zx5Foi
+kdDtzj86uk00tTsuwC7qKi3Gii4WP//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0015/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=16;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0015</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Tarandus Furcifer, Agassiz. Caribou, or <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Reindeer. (v. 3, no. 26, plate 126)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="17" sliceresultid="16"><EntryIdSplit><entryid>x-b6719891</entryid><cc>sclaudubon</cc><viewid>29375_0050</viewid><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0050</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0050</EntryWindowName><ResultNumber>17</ResultNumber><SliceResultId>16</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0050/full/524,403/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>523</w>
+    <h>402</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29375_0050</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 141</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29375_0050||||||||||||||||||Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||Exhibit||||||||||||plate 141</istruct_caption>
+<istruct_caption_image_id class="fieldsRef">29375_0050</istruct_caption_image_id>
+<m_flm class="fieldsRef">2014-12-11 10:17:21</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_caption class="fieldsRef">29375_0050||||||||||||||||||Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||Exhibit||||||||||||plate 141</m_caption>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)</istruct_caption_image_title>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0050</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_x class="fieldsRef">43</istruct_x>
+<m_fn class="fieldsRef">29375_0050</m_fn>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-43</istruct_isentryidv>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_iid class="fieldsRef">29375_0050</m_iid>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_2/9_/p1/41/audubonVQ_v3_29_p141/audubonVQ_v3_29_p141.jp2</filename>
+<width class="imgInfHashRef">8377</width>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">8204582</size>
+<collid class="imgInfHashRef">sclib</collid>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">89a3165b04f8f075d6534e1f6c472eb3</md5>
+<u class="imgInfHashRef">1</u>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 10:17:21</modified>
+<height class="imgInfHashRef">6444</height>
+<type class="imgInfHashRef">image</type>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<levels class="imgInfHashRef">6</levels>
+<basename class="imgInfHashRef">29375_0050</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0050</Caption><Caption>Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)</Caption><Caption>Exhibit</Caption><Caption>plate 141</Caption>
+</Captions><ItemDescription>Ursus Americanus, Pallas. American Black Bear. (v. 3, no. 29, plate 141)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="77">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2YAAg
+EHn2p5UCoby9hsYt0jgMQdoJ64Ga8+8R+N7q1mj8tFSBwSrh+ucYrllJI01PQpZUiXc3AqpJqlpG
+jOZB8oyQK5vXNdLWVlHEp3TKjkg9iOa5TWb/AMqymZGxt759s/yrGpUtK0QSutTt7vx1odlM8ct2
+AVXJI+pGP0rRTXbd7T7RCpkGBgcDORxXzbqcjyXMchJO8AsSe5r16yupotGMjzKqCzjlKep2Agj0
+6c1V9mS9DttM8RWmpR5CvC+A22QYOCMgj1FT3mt6fYJvubhY1HUmuIu9Xtzp6Kvy3NgiBSg5K42k
+H+dc54nv2u9PiYttjdR5mOKh1mnZIaV0et2etabfrIba7jk8v7+D92ppr61t4fNllVE2lsnjj1r5
+78Oao+m3NwY3k8y6jeEJ2Oeh/OvSjqc+raM9teQAXMWVQ7eMY6Zrb2isDTTO+hliuYEmiYPHIoZW
+HQg0rBQcZGfrXD+CtUa50EWs8rLJZyvBlT2HI/nXbQlJEXgE46kVaswvYYYwTkYoqxsA4AwPaips
+M5zxjFvXT3y3yzcbSBjIxzXlXjOCK2sRGZ3d0UYRjwvHbj2rv/ilfS2elWQiYqzTZzxxivIfFXiT
+7dbQQlB5oUZOc/pQ4tzVgvoauj6qZ9OtzPzsBjbJzx/n+VHia/DQyLCcrtG4E8fdrz5jPsGJnGew
+OBSia8iwTKzJ6McjFJ4f3r3FzaF69dhNtOCEAHFelWUnm6FaIkpbdFDATjIBZuR+Wa8oW6SeTBYh
+ie/TNdjZaqlrp8SXMj4VldFTjkDA5/GoqpwS0JepqagzRai7POGnaTaqKeCMgZNWfFAP9mCDDKq4
+GR9K53ULa1d4rqGSVJOGwWzjmpfEPiItbIg5lI4z296xiueSsOGiZk2bvDcQ3LHLRuGGenBzXW3P
+ii8jkWYXCyMCcIenNedL9unYGGdy393NSx3k4i8q4AXP8fSuz2N3cJO+x6BofiZLBrvf80sz7wo7
+HHPNdP4X8W6rqnia1gDRJbNkOmOox/OvHXc/LHHjJPX1ruPAV4ttr9sJot7Z2rk4wfWn7JR1RHMz
+3+ikYkY+lFI1POfi6iNptluJDBmxj8K8E1NCt4/O7G0fpXvHxdwtpZyGTGwMSM9a8ElbzTIx5JYk
+1rAlltLdbmJDG5BAG5R1I9RUMisYJVJwqrhT69KfpwafbGmQxYLke9NuxJEHtmOSh6/hRfWwijbw
+7nzg8GrUcNyzrGjMq5ySTwP8802C5CAeaMY6HHFaCzF7YeWOpzls89RSk7bgXLoSJGkSOSMgA56m
+s2/JOpRxhTJ8u0BRk1rWFxa2ejXNtJatLeTMrrMW4TB4xx6E/nVCHVZNC1C0vkhSSeMH5JBwRmso
+PV2QWSKywT2zMk7NHIMbkbgj04qtcoqDlmY8jntWtqOrzarf3GqSRAPIQxRhkDAwMVjq0t47AIWy
+S1bxd1dhp0J9MdY1VpASglAHPbvXoXh547jxHpvlrsUTD5Qo6+przPE3nJEy7AGxt967zw5eLbat
+ZOEUMrr1PvUVejA+jmHT6UU4cqp9RRUFnm/xX0aXUtMWSHO9E4wOuDnFeORafbw2arcWt2JiMOTE
+ePpX0J4xtZbjTVeJnGzrt9K81e5WGTy5GJfoA5xXPVrSpuyGkmeb6fKum6jukVygORlcZ9KZ+6ud
+QlkuC6puLEY5bJr1B7GwliaSdIVGcZOSf5VRudE0m4kAjSKQjrtfkfgDWf12L3iw9mzjp4dMu7U+
+VvVgODsJo0O7WxBiuLVpIyfkPHB/wrsG0izgLJHbxEgfd3kYPbgfyp0Vpbxr581r5QHZ8D8snpXM
+8VFwcbNr1K9m7mH9ujDNsssKzZO6sfV0+136yiEokahdvUt34rs2/syQEHeSf4gpA/D1q5DZwb1H
+k4XtvQ7j+FKnio03fl1JcLnBvPcXSeWNM8qPu5OT6VU0pI7eKTznlU5IKoAM/jXrlzoNrJZlJQU8
+1ColVeE4746fjXPad4HsYLU3E0zjDsAbhAinngg5x05rvo1uek3YlxaZxNxbwHUIHUMPlDndzkDP
+U13ngyM6jrNqtvaxrCHBLsnPHpQmi6WtyTaXME8knDbz0+nbFdn4U037JqkQaMJgZAxiidW7UbDs
+ehHjAoprnmitwIvldNrqGU9QRmsi78JaHfOXlslDHklCV/lWkrnFSBzQ7PcZzMnw60OT7v2hPpJU
+R+GehshV2ncnoXYHH6V1u80u81k4Q7BdnIRfDTSIBlJZi/dnwaa3w707ztzXUwA/hCnB/Gux3nNG
+/PaodKm+gXZxs3w60+Q5jvp4umdigE/U4qF/htOxLxa3IpPILIT/ADNd2rcDinbzSWGo9hczOGg+
+H+pwTbx4icqeo8nqPzrRv/A8GoPHJcXReVF2hjGOB7DtXUbzSFz6VsqVNKyQXZySeA4Vj2SXpKk8
+hYwAa1NN8M6dpUiPDvZk+6GbIU+w7VsFzUZf2pxpwjsguwkb5qKryOd1FO4WP//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="77">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0050/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=17;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0050</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Ursus Americanus, Pallas. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Black Bear. (v. 3, no. 29, plate 141)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result><Result resultnum="18" sliceresultid="17"><EntryIdSplit><entryid>x-b6719891</entryid><viewid>29375_0044</viewid><cc>sclaudubon</cc><path>/s/sclaudubon</path><m_source>sclib</m_source></EntryIdSplit><CollName collid="sclaudubon"><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName><EntryId>S-SCLAUDUBON-X-B6719891]29375_0044</EntryId><EntryWindowName>S_SCLAUDUBON_X_B6719891___29375_0044</EntryWindowName><ResultNumber>18</ResultNumber><SliceResultId>17</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719891:29375_0044/full/519,401/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>518</w>
+    <h>400</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_fn class="fieldsRef">29375_0044</m_fn>
+<istruct_x class="fieldsRef">49</istruct_x>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719891-49</istruct_isentryidv>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_iid class="fieldsRef">29375_0044</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_id class="fieldsRef">B6719891</m_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719891]29375_0044</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29375_0044</istruct_caption_image_id>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef">29375_0044||||||||||||||||||Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||Exhibit||||||||||||plate 147</m_caption>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 10:38:56</m_flm>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</istruct_caption_image_title>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_m class="fieldsRef">29375_0044</istruct_m>
+<istruct_caption_plate class="fieldsRef">plate 147</istruct_caption_plate>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption class="fieldsRef">29375_0044||||||||||||||||||Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||Exhibit||||||||||||plate 147</istruct_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29375_0044</basename>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6404</height>
+<loaded class="imgInfHashRef">2014-12-12 17:07:34</loaded>
+<modified class="imgInfHashRef">2014-12-11 10:38:56</modified>
+<access class="imgInfHashRef">1</access>
+<u class="imgInfHashRef">1</u>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">47e86a07d6d41bbec822254da4927ae6</md5>
+<collid class="imgInfHashRef">sclib</collid>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">4346330</size>
+<width class="imgInfHashRef">8296</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v3/_3/0_/p1/47/audubonVQ_v3_30_p147/audubonVQ_v3_30_p147.jp2</filename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>29375_0044</Caption><Caption>Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</Caption><Caption>Exhibit</Caption><Caption>plate 147</Caption>
+</Captions><ItemDescription>Fig. 1. Spermophilus Townsendii, Bach. American Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)|||The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</ItemDescription><Url name="Thumb" width="100" height="78">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD20RjF
+O8selP25GMkfSnBcADJP1rOxZH5YpPL9qnxRipsK5B5dHl1NikpWC5F5dJ5Q9KnxRimkFyv5Q9KQ
+wj0qzim4p2HcrmAelMaAY6VaZcgjJHuKj8ogj94xx645/Sk0Fyr5A9KKtbaKmwycU7FNyFUseAOt
+VDqtmH2GbDe4Na2JZdoxVc6haKQGuIwT0y1JJqNnEheS5iVQMklxSaEWMUYrFHi/w9lx/bFnlOo8
+0Vi2fjK/1TWFjsbGI2BbCvKSGYevXj6YqHJLcai2dpRSB1xncPzpdwz1GPrVoQUU1ydpKYLdhnrT
+IplmTevA9DTAkIpCKQsGwAcZGVPrQjb0z0PQj0NJlDSKKU0VIFbVb2Kw0ya4mYKir3ry6TxPFLOx
+WQHnPWu78cQyz+Er0RH5gA34A818/T3UtuW2LnB61Tb6CaueiyeJrcqQ5QP2/eZIP0rKv76a9aQk
+EWkA+YM3LH6Z5rHtIpYLFbq42YK5wx6VSudXsdrozvI3baelc0pzk7LU1jTUdWWJpLCa/jktFkdQ
+BkKuTn+Vak2u3NnCpWT7Cc4GCCzD3Hb8K5UeIJ3Ux2qpAByMLkt9aiENxdOd2X4zkdjU8rvd6D02
+OmsfH+qQXAS5uGkt3barMBuB9fpXUx+KdQE3lmXcwGeWXGPyryy4hchFCF2DZNdfp+j26Wkc+qPF
+DIw+VWk2j9TVyqcsU7mTp3eh07eLNTikMjvHGijOSapx+N9TV5Ht2nMRJLMAME+vJrOudD83yngi
+iEasH4YnzAO1SXD3LF4ItNbyX53mQDH4YqY1W+pao23NS18a6tOxjSchUOA2B/nvXWeF9bvr68Md
+1LvDewGTj/61eWXLPbytHdyW8KHnZGeWPv8A/XroPh5qstxr0UZkYoCyhfQdqvnk3oKUEj2M0UtF
+bEmZ4gjeXQLxI1DExnIPp3rwLUJooJmit4d8wPOVwB+NfR+AykEZB6iuV1bwLpt9K08MKI5OSBxk
+0pq+pcJW0PCLpNQuowJZWMY6DoKqW+nDfjBYivbh4BCggRrjOeTmof8AhBJ7bLxQh3PTkcCueU5p
+aRL919TyeDSxE3m7SB+X860lt2kTYm1I+hC9TXcXnhPWWJAttw7KuMCktPAmpuxM8Pkxj+6w3Gud
+zqy6Md49DjfsMUKA7cHs+M4q1ZRwGXfOIZtwx++yfy5GK6W78A3sybYIGVv7zsT+NaNl4FmggVHs
+4pHAwXbrUr2vYd49zkks4bZmnhuTEOo8s46/iRSXuvrFHsZgxA4ORXT3Pw+v3csoTBOdoNSQfDg4
+RpbeFmzzk4x+lWqc2/eRXNFbM8jaWa/vZZXQsScYQEg/TPSu6+F9jJHrgeRHQBicMPau+tvA1rDg
+bIwB6VvWGkWunAmJBuPU11xUu1kZTlFovGikJorUyGK1PDH2qur08PzTuFiYOfT9acGOeQPzqDfz
+inB6VwsTZpCT6UzfRupXEPDHsP1p4PHNRBqXdQmA8t6UxnYfw/rRupC1UMQu+OEH4mjJ74pC1NJo
+uApNFQl+aKm4z//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="78">/cgi/i/image/api/tile/sclaudubon:B6719891:29375_0044/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;debug=xml;sort=medium;size=50;q1=lithograph;q2=American;subview=detail;resnum=18;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0044</Url><ContactLink>mailto:scl-dlps-help@umich.edu</ContactLink><ContactText>E-Mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Fig. 1. Spermophilus Townsendii, Bach. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Souslik. Fig. 2. Arvicola Oregoni, Bach. Oregon Meadow Mouse. Fig. 3. Arvicola Texiana, Aud. and Bach. Texan Meadow Mouse. (v. 3, no. 30, plate 147)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field></Section></Record></Result></Results>
+
+
+
+  <Assets>
+    <script type="text/javascript" src="js/_reslist.js">
+        <script type="text/javascript" src="vendor/sly.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.selection.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.stickytableheaders.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/sly.pagination.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/reslist.js" timestamp="1469476504"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_reslist.css">
+        <link rel="stylesheet" type="text/css" href="css/reslist.css" timestamp="1469476504"/>
+        <link rel="stylesheet" type="text/css" href="css/sly.pagination.css" timestamp="1469476504"/>
+    </link>
+</Assets>
+
+  <SearchForm><NumQs>2</NumQs><Q name="q1"><Value>lithograph</Value><Rgn name="rgn1"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value><Focus>true</Focus></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn1</Name><Default>medium</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel></Q><Q name="q2"><Value>American</Value><Rgn name="rgn2"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value><Focus>true</Focus></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn2</Name><Default>istruct_caption_image_title</Default></Rgn><Sel name="select2" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sclaudubon</Variable>
+</HiddenVars><MediaOnly><Visible>true</Visible></MediaOnly><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+  <!-- WUT -->
+<Facets><Delta label="SQL">0</Delta>
+<Delta label="facets">0</Delta>
+<Query>select SQL_CALC_FOUND_ROWS concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `medium` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`medium`) against ('+lithograph' in boolean mode) )  And ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1' </Query>
+<Query>select istruct_isentryid, concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `medium` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`medium`) against ('+lithograph' in boolean mode) )  And ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1' </Query>
+<Query>SELECT b.field, b.value, COUNT(b.value) AS total FROM ItemBrowse b, ( select istruct_isentryid, concat('S-sclaudubon-X-',sclaudubon_media.m_id,']',sclaudubon_media.m_iid ) as `id` , `medium` as `sortval`  from sclaudubon left join sclaudubon_media on sclaudubon.ic_id = sclaudubon_media.m_id where  (  ( match (`medium`) against ('+lithograph' in boolean mode) )  And ( match (`istruct_caption_image_title`) against ('American' in boolean mode) )  )  And sclaudubon_media.m_searchable = '1'  ) a WHERE b.collid = ? AND a.istruct_isentryid = b.idno  GROUP BY b.field, b.value ORDER BY b.field, total DESC, b.value </Query>
+<Debug>{}
+</Debug>
+<Field abbrev="is_part_of__work_title_">
+    <Label>Work Title</Label>
+    <Values>
+        <Value count="18">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value>
+    </Values>
+</Field>
+<Field abbrev="medium">
+    <Label>Medium</Label>
+    <Values>
+        <Value count="18">Lithograph</Value>
+    </Values>
+</Field>
+<Field abbrev="subject">
+    <Label>Subject</Label>
+    <Values>
+        <Value count="18">Mammals</Value>
+    </Values>
+</Field>
+<Delta label="xml">0</Delta>
+</Facets>
+<SearchForm><NumQs>2</NumQs><Q name="q1"><Value>lithograph</Value><Rgn name="rgn1"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value><Focus>true</Focus></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn1</Name><Default>medium</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel><Sel name="select1" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value><Focus>true</Focus></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>all</Default></Sel></Q><Q name="q2"><Value>American</Value><Rgn name="rgn2"><Option index="0"><Label>Image Title</Label><Value>istruct_caption_image_title</Value><Focus>true</Focus></Option><Option index="1"><Label>Work Title</Label><Value>is_part_of__work_title_</Value></Option><Option index="2"><Label>Image ID</Label><Value>istruct_caption_image_id</Value></Option><Option index="3"><Label>Item ID</Label><Value>item_id</Value></Option><Option index="4"><Label>Medium</Label><Value>medium</Value></Option><Option index="5"><Label>Subject</Label><Value>subject</Value></Option><Name>rgn2</Name><Default>istruct_caption_image_title</Default></Rgn><Sel name="select2" abbr="istruct_caption_image_title"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="is_part_of__work_title_"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="istruct_caption_image_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="item_id"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="medium"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel><Sel name="select2" abbr="subject"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value><Focus>true</Focus></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default>any</Default></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sclaudubon</Variable>
+</HiddenVars><MediaOnly><Visible>true</Visible></MediaOnly><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B464540___AUDUBON_V1_1_P1.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B464540___AUDUBON_V1_1_P1.xml
@@ -1,0 +1,987 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B464540___AUDUBON_V1_1_P1">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b464540</Param>
+<Param name="viewid">AUDUBON_V1_1_P1</Param>
+<Param name="view">entry</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B464540 AUDUBON_V1_1_P1</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1;view=entry;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>b9b774b9845b5e51e69b3949641b8de4</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B464540</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B464540___AUDUBON_V1_1_P1</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B464540%5DAUDUBON_V1_1_P1</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B464540%5DAUDUBON_V1_1_P1</ItemUrlEncoded><TitleForTagging>Wild%20Turkey%2C%20Meleagris%20Gallopavo%2C%20Linn.%7C%7C%7CThe%20birds%20of%20America%3B%20from%20original%20drawings%20by%20John%20James%20Audubon</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next/>
+<Prev/>
+<Self/>
+<TotalResults>0</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632773996</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;page=search</SearchLink>
+<BackLink/>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B464540]AUDUBON_V1_1_P1</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEIDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD0xrUG
+TJXPGalW2UYAHNW2QtKcVDNZzSf6u7liP+yFI/UV5tjca9sMYxmnxwBowccHkfSqkyXenQGSXURK
+udoEkIySew28k0y10f7Sgmv3uZM/djkkwAP90cD6c0+UV2XDCgwuQGPbPJqGSFVyzcKByaupawQR
+FII1gyOsagH+VZtxAYCSb+fc39/aR/KnYdzmJvFWivqi2iXCsoDCRthG1sjA5H1q80NvcoHhKSRO
+gdXU5BB9KwfG3h+2FrLq4gQ3CACVo1A3Dpvx6jNV/h9cTN4dto5DvWOSWEnuvJYfhgfrVuC5boLu
+46VNszqFGAxFFW5oj58nyH7x/nRWNjU9GztLc4HcmqE2rRvC4tWJbOwSFflB9ff6d6tXaQvA7Thn
+hTl4weGHv6j26VKJYpLeGZeI2UFeMYBFXYzZnwT30VyFuUE3ylk2gbh2JbnA/CtjzBsyVI46GsO0
+Vltbi7EhjLBshuQOT3PTkmrNnqH9oK0kETC1XhZXGPM+g9PemSOe/V5FjVSSVDnHYdOfTkfzrOvL
+mKWQiRDtCZz04HXmsbWdbttBtYvtkwjj3nKpy8gGSVUfU4/GvNfEXxB1HVDJHaIllbdggy5Hu3+G
+KpJsqMWz0LxD4j0qz0K8tL28gE0kbxrGDlmBHB2jnoQa818C6qIfEdnardMIr1GBQdFkAOCR74Az
+71w91I8sxlaRmkJyWJySa3/h/bpL46sQzbVQtKo9wpOK25LRDyPaJEXzXz6minyMDIx3r1NFcpVz
+ZvbmQX97AGOw2yyoB3CN84/JhUNvI8vhWOLLtJACruB/dYjr7ge9Y/ii+jsvE1jHcW7zQSOhkP8A
+Bsf5GB+h2GorLWLW300W1vaPLfSStFGkZ2gJhfmY9Mc+lW0Q2ad/E402DSoLtY54Yw0kIJO9OBks
+evJHB65NVPEfjW28PaZEYyHvJoQYoAeAeh3D+EDt9MVm69q8OgveSuEudQmlRbfcckbGz8w7DBH8
+q8v1G4nnkku7lzLcTPl5G5PJ5x2AqoxvuLqVtR1K71O7a6u5mlmbux4A9B6Cs945HB3MAKmdsseM
+AnioJT68itFpsbWVilOiRuM4Jq/4Pvjb+NdLlwf9eEwP9rK/1rKuW+Y4J5rZ8EWP2vxhpoIJCy+Z
+/wB8/N/StX8N2ZN66HuUm3zG47mimyD943Pc96K4Cx3ju3uZHDeUBA8bRq27nft3Dp0yVA/Cq+lT
+6dDp812f3CGGCWRwc/u12EYPXPD/AJVseLp4ktyJWVGhRZlLL97ac4zn6D/gX1ryTxDqwttPbSIH
+/erLJbyLjrGr5TB/4EwrWPvaGb0ZWv7qfxFrk17KHETP8kYOSF7D8K1ZtGjk0x4+UlyApI754P8A
+9c1kabNPaqivGAxGD16H6/0rWk1KUqWFvgjnc5wMgg/1X9Kt36COOu2a3kMU0ZRh1yKzncsxwfyr
+q7ryJpczyCeQcBVHHAA/pV3w34VOtXCTyBYrMk8jqwBwce2eM1opJIG2zndF8OvqkrT3GYbGEbpp
+iOAPQe9dp8PrOCfWb7VYoBHaW6eRbL6A/wBcdfrWp4ttZr7w7Z6fokOIZZApVF24XsT6Ctjw9p8O
+j6SunBl2r87ydNx7n8/0qZTuhLcSXeZnIPG40VYeBGdj1yc9aK5rGxB48mi/taIzrJ9kiTdNg4U+
+27oDg598Y7143eXbz6pJd8Ek4HHUYx+dem/F3WrfMOkW4BmIEkzddo/hA9+5/CvJlJTr0relBpXZ
+m9zRfWLkoFCxqAMZA68Af0/U0w3l7dN8z7wOScYAz9KqghhjvWnBKbbS7ldilHkUDd/EygjP0AJP
+1xWlrC3HyaFrM2jS6okLmwVgjSqMA++B1APGa9D0jVLGw0i2slkVh9mijaVF+UEgZ985JJ965jQf
+Ff2TRNQs7m7MbTReWgcZXaeCBjpxVCO7t/LuEtY5J7feCpZtnl8857elJrTUl67HrTQsyJDEqqI1
+CjdyIwTxnH3j3x0FMhtYnlLDdMFJG9xnoB+HUn8q8+l8ealbQxJAYdpyMuMsx9a1fC3jmOVDYXy4
+neQlGX7pJ7fWsUrq5aOoZsO3A60U3eG5xjPPNFZ2NDzvx9pko8YXziZHZyH27skAjj/9VcslpPKc
+CJuK6fxdHdS+I9QeOxm3GUgZQkkepNYM9rqEKJG9vcRDnllIJHHr/nmuqN0jNtEBsvJbMjLv6iNT
+kn/CnauxgMFqCB5cYLbem48n+lRz2UkDbXikDsMqpBya0hoV7qkaSrpt9v2jc6xZHoPrmqWjuxXu
+mjBVmI4yfwqe3vHs5VkG7gEBd+Bz1yPSrbaFqZd7dbS4MkWSyiE5AHcjtTJvDuqwBDPp9yqkFuYy
+OBwabaejJSLtwLSS3UxTHcBnCIXHOcgD0HrVGBobPUYGLhgXByVZT175HFWjoGp+QofT7gDPyfuz
+k5HGAP51mNpOoRzlFtZiVfYwCEgN6Vkl5lHtXmKecNRWJYtfDT7YNFGGES5BJBzgUVganoEdxIVJ
+zyDgcVKLmRgVOCKKKG9RDjKSysQCR3NK91IMAYxRRTuwIZp3zxgVUku5cdRRRQ2BUe4cscmqV85W
+MEAAnk4ooo6CM4FiM7j+dFFFQUf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B464540:AUDUBON_V1_1_P1/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/338,511/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>337</w>
+    <h>510</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B464540-1</istruct_isentryidv>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption class="fieldsRef">2013-03-06|||audubon_v1_1_p1||||||5404 x 8172|||120 MB|||TIFF|||600dpi|||Wild Turkey, Meleagris Gallopavo, Linn.|||Exhibit||||||||||||plate 001</istruct_caption>
+<m_caption class="fieldsRef">2013-03-06|||audubon_v1_1_p1||||||5404 x 8172|||120 MB|||TIFF|||600dpi|||Wild Turkey, Meleagris Gallopavo, Linn.|||Exhibit||||||||||||plate 001</m_caption>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_m class="fieldsRef">audubon_v1_1_p1</istruct_m>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 001</istruct_caption_plate>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef">2013-03-06</istruct_caption_image_digitization_date>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_iid class="fieldsRef">AUDUBON_V1_1_P1</m_iid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_x class="fieldsRef">1</istruct_x>
+<m_flm class="fieldsRef">2014-06-17 15:29:15</m_flm>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B464540]AUDUBON_V1_1_P1</istruct_isentryid>
+<istruct_caption_image_id class="fieldsRef">audubon_v1_1_p1</istruct_caption_image_id>
+<m_fn class="fieldsRef">audubon_v1_1_p1</m_fn>
+<m_id class="fieldsRef">B464540</m_id>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_master_dimension class="fieldsRef">5404 x 8172</istruct_caption_image_master_dimension>
+<istruct_caption_image_title class="fieldsRef">Wild Turkey, Meleagris Gallopavo, Linn.</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_resolution class="fieldsRef">600dpi</istruct_caption_image_master_resolution>
+<istruct_caption_image_master_filesize class="fieldsRef">120 MB</istruct_caption_image_master_filesize>
+<istruct_caption_image_master_filetype class="fieldsRef">TIFF</istruct_caption_image_master_filetype>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<u class="imgInfHashRef">1</u>
+<access class="imgInfHashRef">1</access>
+<size class="imgInfHashRef">4253578</size>
+<master class="imgInfHashRef">0</master>
+<loaded class="imgInfHashRef">2014-06-17 16:05:08</loaded>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/n_/v1/_1/_p/1/audubon_v1_1_p1/audubon_v1_1_p1.jp2</filename>
+<modified class="imgInfHashRef">2014-06-17 15:29:15</modified>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<use class="imgInfHashRef">access</use>
+<type class="imgInfHashRef">image</type>
+<basename class="imgInfHashRef">audubon_v1_1_p1</basename>
+<width class="imgInfHashRef">5404</width>
+<md5 class="imgInfHashRef">2e80e5794345d985cbe91eaee501ff57</md5>
+<height class="imgInfHashRef">8172</height>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<levels class="imgInfHashRef">5</levels>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>5</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:5/0/native.jpg</Part><LevelWidth>168</LevelWidth><LevelHeight>255</LevelHeight><LevelMaxDim>255</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:4/0/native.jpg</Part><LevelWidth>337</LevelWidth><LevelHeight>510</LevelHeight><LevelMaxDim>510</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:3/0/native.jpg</Part><LevelWidth>675</LevelWidth><LevelHeight>1021</LevelHeight><LevelMaxDim>1021</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:2/0/native.jpg</Part><LevelWidth>1351</LevelWidth><LevelHeight>2043</LevelHeight><LevelMaxDim>2043</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:1/0/native.jpg</Part><LevelWidth>2702</LevelWidth><LevelHeight>4086</LevelHeight><LevelMaxDim>4086</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:0/0/native.jpg</Part><LevelWidth>5404</LevelWidth><LevelHeight>8172</LevelHeight><LevelMaxDim>8172</LevelMaxDim></Level><MaxWidth>5404</MaxWidth><MaxHeight>8172</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B464540</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>audubon_v1_1_p1</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="false" sortfield="false"><Values><Value>Wild Turkey, Meleagris Gallopavo, Linn.</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=is_part_of__work_title_;q1=The%2520birds%2520of%2520America%253B%2520from%2520original%2520drawings%2520by%2520John%2520James%2520Audubon;select1=phrase" target="_blank">The birds of America; from original drawings by John James Audubon</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Engraved title page. Imprint dates: v. 1, 1827-30; v. 2, 1831-34; v. 3, 1834-35; v. 4, 1835-38, June 20. Originally issued in 87 parts. "The plates were published without any text, to avoid the necessity of furnishing copies gratis to the public libraries in England, agreeably to the law of copyright."--Sabin, A dictionary of books relating to America, v. 1, p. 315.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=creator;q1=Havell%252C%2520Robert%252C%25201793-1878%252C%2520%2528illustrator%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Havell, Robert, 1793-1878, (illustrator, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=creator;q1=Lizars%252C%2520W.%2520H.%2520%2528William%2520Home%2529%252C%25201788-1859%252C%2520%2528illustrator.%2529;select1=phrase" target="_blank">Lizars, W. H. (William Home), 1788-1859, (illustrator.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1827-1830</Value></Values><Label display="on">Date</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>100 x 68 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=medium;q1=Intaglio%2520printing%252C%2520hand-colored;select1=phrase" target="_blank">Intaglio printing, hand-colored</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=repository;q1=University%2520of%2520Michigan%2520Library%2520%2528Special%2520Collections%2520Library%2529;select1=phrase" target="_blank">University of Michigan Library (Special Collections Library)</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=source_collection;q1=SPEC%2520RARE;select1=phrase" target="_blank">SPEC RARE</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=subject;q1=Birds;select1=phrase" target="_blank">Birds</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=thumbnail;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_image_digitization_date" searchfield="false" sortfield="false"><Values><Value>2013-03-06</Value></Values><Label display="on">Image Digitization Date</Label></Field><Field abbrev="istruct_caption_image_master_dimension" searchfield="false" sortfield="false"><Values><Value>5404 x 8172</Value></Values><Label display="on">Image Master: Dimension</Label></Field><Field abbrev="istruct_caption_image_master_filesize" searchfield="false" sortfield="false"><Values><Value>120 MB</Value></Values><Label display="on">Image Master: File Size</Label></Field><Field abbrev="istruct_caption_image_master_filetype" searchfield="false" sortfield="false"><Values><Value>TIFF</Value></Values><Label display="on">Image Master: File Type</Label></Field><Field abbrev="istruct_caption_image_master_resolution" searchfield="false" sortfield="false"><Values><Value>600dpi</Value></Values><Label display="on">Image Master: Resolution</Label></Field><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Wild Turkey, Meleagris Gallopavo, Linn.</Value><Value>The birds of America; from original drawings by John James Audubon</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Wild Turkey, Meleagris Gallopavo, Linn.</Value><Value>The birds of America; from original drawings by John James Audubon</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Birds</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/001501351</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/res:0/0/native.jpg?attachment=1</URL><Filename>audubon_v1_1_p1_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B464540:AUDUBON_V1_1_P1" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B464540:AUDUBON_V1_1_P1" canvas-index="1" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b464540</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B464540 AUDUBON_V1_1_P1</Variable>
+<Variable name="lastview">thumbnail</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>Wild Turkey, Meleagris Gallopavo, Linn.</Label><Value>AUDUBON_V1_1_P1</Value><Focus>true</Focus></Option><Option index="1"><Label>Purple Grakle or Common Crow Blackbird, Quiscalus Versicolor, Vieill. (Plate VII)</Label><Value>AUDUBON_V1_1_P7</Value></Option><Option index="2"><Label>American Goldfinch, Fringilla Tristis, Linn. (Plate XXXIII)</Label><Value>AUDUBON_V1_1_P33</Value></Option><Option index="3"><Label>Ruby-throated Humming Bird, Trochilus Colubris, Linn. (Plate XLVII)</Label><Value>AUDUBON_V1_1_P47</Value></Option><Name>relview</Name><Default>AUDUBON_V1_1_P1</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P1;view=entry;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;lastview=thumbnail</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEIDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD0xrUG
+TJXPGalW2UYAHNW2QtKcVDNZzSf6u7liP+yFI/UV5tjca9sMYxmnxwBowccHkfSqkyXenQGSXURK
+udoEkIySew28k0y10f7Sgmv3uZM/djkkwAP90cD6c0+UV2XDCgwuQGPbPJqGSFVyzcKByaupawQR
+FII1gyOsagH+VZtxAYCSb+fc39/aR/KnYdzmJvFWivqi2iXCsoDCRthG1sjA5H1q80NvcoHhKSRO
+gdXU5BB9KwfG3h+2FrLq4gQ3CACVo1A3Dpvx6jNV/h9cTN4dto5DvWOSWEnuvJYfhgfrVuC5boLu
+46VNszqFGAxFFW5oj58nyH7x/nRWNjU9GztLc4HcmqE2rRvC4tWJbOwSFflB9ff6d6tXaQvA7Thn
+hTl4weGHv6j26VKJYpLeGZeI2UFeMYBFXYzZnwT30VyFuUE3ylk2gbh2JbnA/CtjzBsyVI46GsO0
+Vltbi7EhjLBshuQOT3PTkmrNnqH9oK0kETC1XhZXGPM+g9PemSOe/V5FjVSSVDnHYdOfTkfzrOvL
+mKWQiRDtCZz04HXmsbWdbttBtYvtkwjj3nKpy8gGSVUfU4/GvNfEXxB1HVDJHaIllbdggy5Hu3+G
+KpJsqMWz0LxD4j0qz0K8tL28gE0kbxrGDlmBHB2jnoQa818C6qIfEdnardMIr1GBQdFkAOCR74Az
+71w91I8sxlaRmkJyWJySa3/h/bpL46sQzbVQtKo9wpOK25LRDyPaJEXzXz6minyMDIx3r1NFcpVz
+ZvbmQX97AGOw2yyoB3CN84/JhUNvI8vhWOLLtJACruB/dYjr7ge9Y/ii+jsvE1jHcW7zQSOhkP8A
+Bsf5GB+h2GorLWLW300W1vaPLfSStFGkZ2gJhfmY9Mc+lW0Q2ad/E402DSoLtY54Yw0kIJO9OBks
+evJHB65NVPEfjW28PaZEYyHvJoQYoAeAeh3D+EDt9MVm69q8OgveSuEudQmlRbfcckbGz8w7DBH8
+q8v1G4nnkku7lzLcTPl5G5PJ5x2AqoxvuLqVtR1K71O7a6u5mlmbux4A9B6Cs945HB3MAKmdsseM
+AnioJT68itFpsbWVilOiRuM4Jq/4Pvjb+NdLlwf9eEwP9rK/1rKuW+Y4J5rZ8EWP2vxhpoIJCy+Z
+/wB8/N/StX8N2ZN66HuUm3zG47mimyD943Pc96K4Cx3ju3uZHDeUBA8bRq27nft3Dp0yVA/Cq+lT
+6dDp812f3CGGCWRwc/u12EYPXPD/AJVseLp4ktyJWVGhRZlLL97ac4zn6D/gX1ryTxDqwttPbSIH
+/erLJbyLjrGr5TB/4EwrWPvaGb0ZWv7qfxFrk17KHETP8kYOSF7D8K1ZtGjk0x4+UlyApI754P8A
+9c1kabNPaqivGAxGD16H6/0rWk1KUqWFvgjnc5wMgg/1X9Kt36COOu2a3kMU0ZRh1yKzncsxwfyr
+q7ryJpczyCeQcBVHHAA/pV3w34VOtXCTyBYrMk8jqwBwce2eM1opJIG2zndF8OvqkrT3GYbGEbpp
+iOAPQe9dp8PrOCfWb7VYoBHaW6eRbL6A/wBcdfrWp4ttZr7w7Z6fokOIZZApVF24XsT6Ctjw9p8O
+j6SunBl2r87ydNx7n8/0qZTuhLcSXeZnIPG40VYeBGdj1yc9aK5rGxB48mi/taIzrJ9kiTdNg4U+
+27oDg598Y7143eXbz6pJd8Ek4HHUYx+dem/F3WrfMOkW4BmIEkzddo/hA9+5/CvJlJTr0relBpXZ
+m9zRfWLkoFCxqAMZA68Af0/U0w3l7dN8z7wOScYAz9KqghhjvWnBKbbS7ldilHkUDd/EygjP0AJP
+1xWlrC3HyaFrM2jS6okLmwVgjSqMA++B1APGa9D0jVLGw0i2slkVh9mijaVF+UEgZ985JJ965jQf
+Ff2TRNQs7m7MbTReWgcZXaeCBjpxVCO7t/LuEtY5J7feCpZtnl8857elJrTUl67HrTQsyJDEqqI1
+CjdyIwTxnH3j3x0FMhtYnlLDdMFJG9xnoB+HUn8q8+l8ealbQxJAYdpyMuMsx9a1fC3jmOVDYXy4
+neQlGX7pJ7fWsUrq5aOoZsO3A60U3eG5xjPPNFZ2NDzvx9pko8YXziZHZyH27skAjj/9VcslpPKc
+CJuK6fxdHdS+I9QeOxm3GUgZQkkepNYM9rqEKJG9vcRDnllIJHHr/nmuqN0jNtEBsvJbMjLv6iNT
+kn/CnauxgMFqCB5cYLbem48n+lRz2UkDbXikDsMqpBya0hoV7qkaSrpt9v2jc6xZHoPrmqWjuxXu
+mjBVmI4yfwqe3vHs5VkG7gEBd+Bz1yPSrbaFqZd7dbS4MkWSyiE5AHcjtTJvDuqwBDPp9yqkFuYy
+OBwabaejJSLtwLSS3UxTHcBnCIXHOcgD0HrVGBobPUYGLhgXByVZT175HFWjoGp+QofT7gDPyfuz
+k5HGAP51mNpOoRzlFtZiVfYwCEgN6Vkl5lHtXmKecNRWJYtfDT7YNFGGES5BJBzgUVganoEdxIVJ
+zyDgcVKLmRgVOCKKKG9RDjKSysQCR3NK91IMAYxRRTuwIZp3zxgVUku5cdRRRQ2BUe4cscmqV85W
+MEAAnk4ooo6CM4FiM7j+dFFFQUf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B464540:AUDUBON_V1_1_P1/full/!100,100/0/default.jpg</Url><Caption>2013-03-06</Caption><Caption>audubon_v1_1_p1</Caption><Caption>5404 x 8172</Caption><Caption>120 MB</Caption><Caption>TIFF</Caption><Caption>600dpi</Caption><Caption>Wild Turkey, Meleagris Gallopavo, Linn.</Caption><Caption>Exhibit</Caption><Caption>plate 001</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P7;view=entry;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;lastview=thumbnail</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2QHn2
+qZBmo9u2pVxt681wXNyVQMUyWeOFC8jBVHUmm+YQK5TxlqrWFh5gJPO1VHVjzgCm3poCV2a0fibT
+prqSATbChA3vgKxPYGrt7dRWVlLdzEiKJC7EDPArwy/Mq+G2nJOyeVw3OdrZAH8v1rSn8fef4Th0
+YLI7SWpinnb+JyhHH0OMn2ojdq4pWR28HxI8MXBUf2h5ZLEfvEIxj1rbsNWs9WjeWykM0KNt80Kd
+rH2PevG/APgeHxBqEs15MTY2rAOgGDIx5C57D1+or2+O2itYEggjSOJBtVEGAB7Vbt0Em2Rviq5D
+buWGPpU0nAz6VCDuNIZpN1xTgTipfLGMmgKKgoaF3VynjGzhvdDuZYzveDLxvGckOOD0/EV1p46V
+4x4m1698D+P5zFubS7nZJJan7rhhgkehBB59sdKqEXJ2RLdtTlpriZNMS1ldhHEGY89yTioLG1mO
+m6nqEkeIreKOFDjjzHkXj/vndWfq/iMahfyzm0MCyHkBt3cn29at22qtfaZPaQf8t5IpJkz3QnBA
+/wCBVpZxV2iZyTPV/hJF5fh/UWx96+YZ+iJXePXnPgHxDpOkeGmivdQtYJZbyQhJJQGPQdPwrt7X
+V7W9mlhibLxkBwOcZ6VDHHYmk6GoSMNVlsYNQnGc0DF169vbHTJriyjjklj5KuCfl79CK82uvHfi
+NkJguIomAzhYVP8APNd94uFyuhXL2tw8MijJZFDEr3HNeMXVzPbMhKxSqxxyNp/Mf4VhO/NoxSZs
+6d8UPEkV0zXhtp7eLmXdHtOPQFe57VznjTxT/wAJV5El1brBeQlghiyVMZ5AOe49e+egrO1dHTW1
+txlYtokAz1J7/wBPwplppdzOz3sJRowwDk/wZztz7HH4V0U2k+Zsz95qyMBpCyEHmoRnO5AQR6Gt
+W/s2E42R7N33lPY+3tVf7M0VrKJIXDnkMRxXVzxtoSUs/N93mvUfBupS6ZeaJdPPKsd6xgnic4U4
+yqn88VheHfBkOqaZHf3k0scYGWCgcj60zVroNfWdvZ7vKtjthXcWIweMmsKlWM3yrobQi0rs+h2f
+C1D1psO42se/ltozSZ5IFQM0tQ0+21CAwXcIljJztNeQ/EPRdF0ee3hs5bj7XL85t9+UVfU9xmvV
+fFOtx+H9BuL9gGdRtiQ/xOeg/r+FeD+fPqF5daxqEhmmAMhLdz0A+mcCs2upM2tjK1K88zUAXA3w
+RFWPq3XH4dPzrovC+pQ6d4euC1usyyMgkGQCowQCAeo4Nc9DoGoagZjbRNPKYWncDrgck1c8OpIj
+SW8kZMDoCWP3VPrnpinOC9loKm7SKV+yTSPCoJBbzICVx16r+tMn1OzttNEe1p5JOik8Ad81HqUt
+vHI1taHzgjZWQHp+P9ayDBJLIiBVyTtCg5NXSgnbmCo1fQ9G0a71S90NGfZDFcAx28KptCoOrY/T
+nr7VlQ/2Xo92uoMzXckMmRCflAIPUjvVC11e6NvKY4yDEmzIPAGcD6dqxTK029CQOc8+vf8AnU8l
+pOzsaRknE928KeMIPEcbp5fkzJ/yzLZ/KumAw3SvHPhZFKdbkkCkJ5Z3fnXsbHJ+lVbUGc18XQT4
+YtVBxm7X/wBBavMWRv7Ogt1+9cSgH/dUZP6kV6h8W4mfw3azKfkjuhu/FWFcR4e0FPEmswWEk0sU
+KWrO8kfDKST0/wDHahrVGUl7w2x+Ilr4WE1tpWmpdXROx7qV/lbHZQBnb+PNc3fWGv6zJPrCaR9m
+trlWlZol8uLavVuT0/meleo2Hwr8NaJdrd3929wIzuWCUgK3puHVv0B9KZ4w1rSNYSCylKtaxHds
+8zYCfcA9B7itJVKcNIopQb3PEDnhIySWOOO5qa3jS0R7iRj5sbgAA8c12Ory6NOIIoVgBhR1VYuB
+zg57c8Y/GuPZf3jxumInIOT2IPr9M01PnWisJxSNEyCw0i2hO7zbxt8n+yoPyj8Tz+AqHStJu9Uv
+3trWzlnK4JKEYXtz6dKqapdi4jtwOCBnHpXV/DeS5PjhI4QXjltWEx/urgHP/fQUfjTUXa7CMuiO
+68KaPJ4X0h7jVXtrPc+SzPuJB6DsB9Oa662u4Ly2We3k82Js4fGM9q8+8eTS+ItSsdA0V1uZoS0t
+x5b/ACx9ANx7d/zrtdFtJdP0e0tZyplijCvtORnvj2qGVfUZ8SPLHge/EpGd0ezP97eP6ZrjfD7X
+ukaXJqVoFF1eyLaQ7hnaqr8zAeuVrp/ihb3V7o9nb20MsqGffII1JxgcZx9aXRNGuptK0zfEsDWs
+sz/vF7l3AOPoaTC3vFvUvD2hWtsLnWJLq7nIy26Zyzn/AHVIGK4bVGsb2YWttpyWkDHAtrcAyy+m
+9gCfwrvbvwhBqVxHLe3dzK2SZDuA3egAxgD9fetnTdH03SY/Ls7aOI93AyzfU9TWfK35FnjuueGb
+7R/DraoNLjiijdQImPzAE/eYc59OT36V57JLPemSW6YkgYVAMBeewr6f8S6d/bHhu/sExvmgZU/3
+sZH64rwuTwRrltaSzS6ZcbSnJC5O7H90c/jW8LIzkmziIisu4njYQOe57Vdh1C4jtZBa3Mtv5oCy
++UxXKjsSOo9qmh0q8DQQLZXDOzGQgRkncQQo6VpWXgzVpr2zspLC6igkmVZJXiKg88n6AA1rKVzJ
+JnqXw50eLTPCVvMIgk92POdiPmKn7ufw5/GurBxmiNI4IliTCoihVHoB0pm7k4IrHzNkbecjkA49
+aUIhHKL+VFFJliNwOKj8kNyxJPrxRRQhDfKAGATj6Cm+WPyGO1FFMCIwqgJXIP4VG56UUUwK0qKz
+ZKgn6VXICEhQB9KKKkR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B464540:AUDUBON_V1_1_P7/full/!100,100/0/default.jpg</Url><Caption>2013-03-06</Caption><Caption>audubon_v1_1_p7</Caption><Caption>5315 x 6747</Caption><Caption>121 MB</Caption><Caption>TIFF</Caption><Caption>600dpi</Caption><Caption>Purple Grakle or Common Crow Blackbird, Quiscalus Versicolor, Vieill. (Plate VII)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P33;view=entry;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;lastview=thumbnail</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAD8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2Yg7+
+ox6Yo25NS7KUrgdK4mbEYAWngjFZ+qaraaRaPc3kmxFBIA5ZiBnAHc1Q8NeI7bXreTynJlQ5dSME
+Z5GPYdM98UIDdY8daizzzTnIUZJxzTCQT0q0A2TOODz71Adwbkgj2qww45NRMKYxusaxJo7LNJp8
+01iBmW4hIYxe5TqR7jNOl17TVsWvI7uKWIAHKMDnPQfU03xDNZR6XMl9deRE6EZ87yt3HQN6+1eX
++GPC93qkskkEctjpLSmSMucSyDoOfTH/AKEcZqUk1dkNtOyFg1GbU73VJWF6zwEzwShw0MYJBK4I
++o44NaelX82kaSk2iabbTXd3IA+5yoz0/Q9vY1mXXhyXTdfu7NY3jhmVZYJWk3uVX73ueh4/3ab4
+Ynj1OSfTlmWEIHkh80jAyT+uTXNiXVVpUtbW07ouHK9JHpOm6fJC3nX92bzUCMs2MJGD2Rf4R79T
+3q+etY9pPcaF4diW9+zSXCA7nt02I/vgAc9Kxh4/sI5JYroGKQL8g2k7j2rqvcSWh2eMrUbCuOuv
+HlnbW5EIklNvtErEY3NnnH4BvzFdLp2pwarai4ttxjP8RGBnuB64qkFzK8aeH73XJrVowJrWBSTa
+btvmuem49NoHvXCaHfaroenWt3LF+4gu3hVkfPnLkhgR6KRgE+ox3r2sjiuV0Dw9FN4Xhguk+ZpH
+k595S4P5fzqFLSzJlHXQnvLeW/8As2rQOd0eViReflbhs+/T/vmvL7zwpqF7q7tHbOs8j5MjEBV+
+gFe3W8C2sCxL0XgV538QfFf2G7/sqz2pIVBnlHB5HC5+nJ+oqHLlVzSLszZs4otX0iXTlZ3Fn+6e
+4Y8MwxnB74/wrgNf0bSrW4Bhvpru5LYIgTzFB7DI4zx0zW94GvEl06aOeGO6lkICQFgFKqScgHjk
+k9a6OHxJpDOLOWI2NxCxCQToFwQDyCMqehGQatEtu1jg9BtZNQnlhto0klkd1Z5Y/uL8vzsD1I/m
+TXqGm6fDpdklrDu2L6nPPevOLaDWdT1a81TQ57fyTcANAxI83BHJwTgZHrzjpXoOmT3MkBW9V0ul
+P7xCBgf7pHVf1q7WJidBnNCYRAg4AGBSEUzzELbd67vTNYFiyN6V5Rqegi7+JN/5pVlKLOomHyjK
+AZ9+QRXqUc6zF9oyEcpn3HX9a4z4gzXUdiptYy0h+UMq5YA9cVNSn7SPKxw3OKuvCus2q/bLWaNz
+v2/6M+CvTAAHv2pbqKXVr610q4iU6rG5ElwrgKFPzMWwOTyfypugeKJfDaXMWoWrSS5JUljuVsY6
+Hj/JqvaXk8st7qb3Ftb3kq5MrvgKuATgdSxPGAO3oa3jboZTtc9S0uG80ixhtHtIngjAUPA+SB7q
+QP5k1q5DDcB19q4vw34otY9OgsYppdQmUEsY1klkYk55yoA/Piuwt5ZZog80BgJ6IzAsB744/U07
+MpNGhftItlKYs7tvGK8Z1LVPEUGqs9q0+VzhY0ztr2dnKjkZrN1Ce00mymvTCDIB8qgcsx6AVmir
+2RyHh/xTfwQWttf2zeZPeCN5TgAMzEvn0PI/XFd/PDFIhZ0DbeRxmvJ5rPS7C1uL3Vftl3dyKgW4
+ihcRwvk/cY4Bxwc9yK6vwj4hu9e0iIQeTGYFEcry5dmbH90EdeuSevaqaIT6HM+J9PNvbTeINRiT
+z2u0jihB4WMHkehY4wfoa0/DvgTTLiztr+8xcPJHukjPKgsORx0xmqfxM1B4/sNmbg5B82RIwQMZ
+ABIz6579q7nSLu3utKt5LVwYzGOAMbeOmO1NPTQSSuM0jSbbRNPSytQBGhODjk5OefU1bbNKxwab
+nNUWi8eRUTRIxHmRq205GRnBpfNQcF1B9CaaZU6+Yv51nYYtxbwXURjmjR0IIwwBrAvvC0UXl3Wi
+uLC8iXClF+SQAdGHf69a31dWzgggelMNymSpOMHGaaE0eRm0vPEkN7rOpS7pLO4igaER/IUDDdhu
+h6nivVIbeC0QRW0EcMfXZGoUfkKzrDR7K00qXTokZlmLNJIVG5yTnJx6Z/StSR1DYJA9KpJXdiUr
+BnIqMnmhpFA+8KiZ+3emUagpGPFFFSBHnrTXiRsFhkj1NFFADCgCgDI+hNR5yaKKpAIelV3PNFFM
+D//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B464540:AUDUBON_V1_1_P33/full/!100,100/0/default.jpg</Url><Caption>2013-03-06</Caption><Caption>audubon_v1_1_p33</Caption><Caption>4324 x 6898</Caption><Caption>122 MB</Caption><Caption>TIFF</Caption><Caption>600dpi</Caption><Caption>American Goldfinch, Fringilla Tristis, Linn. (Plate XXXIII)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sclaudubon;entryid=x-b464540;viewid=AUDUBON_V1_1_P47;view=entry;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B464540%20AUDUBON_V1_1_P1;lastview=thumbnail</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2+YPG
+vmx5YqOU/vD296d9oiS2+0PKoiC7t54GKlCmuM8cWN3PphW1kCwxTFmQ9ACAd5PovzfnXLN8qbRp
+c6jTNWs9Wjd7ORnVDtY7SBn605ZHl1do1ciKCIbgP4nY8fkB/wCPVw/grxJBpfh+SLU7xXMcrLGI
+lLE4GSMYz6nJ4960dK8Z6WzTyzvJE9zdHaCmcKAFBOOnAqVUjZXYrPqdkzCmkZ61w914/SK9uI4R
+bSRRzKiElvmU5y2R9B271raV4vg1JovMtXgjmcxxybgy7h/C3ofT1q1JMV0bzLUDirLDNQvgVaKK
+kik98VnWrvdu1xvPkZKxjH3v9r/CptYm2WwgRwsty4hTnnnqfwGTUqxrEixoMIoAAHYVQCeKrm6t
+tBnltTIGX7xiPzgHj5ffOK4qx13VmRrqc3f2eJVj/fptS4yWzuBB6AAfjXo13H51pNFtV96EBW6H
+jvXFr4W1Cbyzf65eW6KmTFbvjAHGNxJHTHauGrTm6l4t7fI2pTiotM5Cee1TV51h227wBLmCExE4
+JGXQn6dAf610+maboN5Y/ablfIjkRY4y2I138lmXnnk9+wFZml+GdNh1Ce/nV7bTLRi5aVyTKf8A
+aJ6+pAwOg55pmra6lzdovkZijXckaDKKpPp3PfiqpqKjzPYmslzaFt9J0nRZZYvmvpn3Kzuo2qDj
+qO5z3FS6ZrVjpQvLbWZfIhkCgIVOSwAAIAGeABz7VVMlzHPujx8pCsBHnb+J5zWclnDc6ukE4eQ3
+A2FZDyMn+Etx64x3rbQwO70TxAbqeYCf7XZs+Ip052H0b0/Gn614pstOtZ5I3FxJDgOsZyEJOBn/
+AArk7mNPClnLDpDCZo5VN7byZOFZflY9Mr2yOPbrVGwaC81Rr0W6QQEYu7WRiVkQkZKkDGRwceo4
+x0qnzJaD5uhv6TrWneItUjmQOJ7ZVfE2MsWIBIx2H4da3DdSX92YrVtsERIlmH8Tf3V+nc155b23
+hu01Yo15JDIn+tQFmGSclVIHQDgkkk44r0fS76wvrFW05l8hPkCgY2+2KcbtajTNpnqtMw3x56El
+T9CP/rCnFqwPEerTWkC2tjGZr+Ugoi/wDI+ZvQZwOfXv0pt2QkWL3SBezLGzCOzjH+rUffJ65rk7
+XwvZNqotLG9uks4efMRshJM5KKe3Y12Flpr2+k/ZZLiSWdkPmTu25mY+/oM8e1cVp3hfxLodtcPB
+co0ThyUVzuB3EhtvQnBxispLpbQ0hFNO71O2sH0202WNrLHvbcQN2WcgnJJ7nIOa4C6trVPEMpmt
+RI8h+ea0O3Y2c5UY+YD/ABqM3N8l/YQwoqszG5njUY2/MAQc8gY/PNX/AAJqkF4ba0NuhuBvMwmH
+yqoI+575z15qVPn0khypSjFSTKOqtqVp4itNSS/t4pVi8ppmfcsidsjB6+nrzwat2GqT3TXED38M
+nnNkjaAsAX7zsAAOByB681R8Rajpt488tvFco/IDmQFGAPdccemPpWFazGG62XFoBAyASkcMy9sH
+pj+Yqo3lK/QycrI37GDwjp1w6S3M1885ILrGR5AJ4645x1P6V3eiaDb6GkotppJI5dp+fHGM9MfW
+uds9H8MeLnaW2S6tZ4AARGQhK9F4OQeB9a7SNDFDHGzbiihd2MZxWsfwBLqSk1i6lrGn2GpwQSoH
+uXAJI6qucD6kk8D61tv8q52sx7ADrXPweFVuNeGs6g5adW3Rwo3yIcYGfUj+tJ32QG7LLHbwvNM4
+SNBlmY8AVwE9/wCIPEWtyWGmag1na+YXMxjIBhxjIOM5BB49/at/xtFJPp0dvFfC3wfMdfLLllHf
+jpiub0e3t7hmuLZbgGOVikkkh4QcgEZxjJwaiTd/IqE+X1KeuWQs9Qtxpxa78xxDI8hzIRwOvuTx
+71iR2+q6dNLeFI45xKyhS2FGwL17Y9/fNduNOfXL+HZaPC8cm7z1c+VvHPIx147GsXVvC+pWM9/5
+4SaCeIM534EmODjpjtx+Wax9na7R0QqrltL5/eYkN5p02k3Md0JTMHMkSwyjHOAV6EE5wT7KauRa
+h5llaW8mlmSC3UrumfOcnPBABH8VQRvDbG2eOAPPghIVcnzQBjGccHk/Wums5ob7UIrS9sgqSws5
+8o8hgvft6egrWlPmV2ctVRvaBveEtL0+FJNT0+4aSC4QKEY5MbAncD9CBXQuOaq6Tb2kNij2lkLS
+Ns4TbtJGep+vX8aEY3Fw0pJ8uMlEHqehP9K1jZLQa0NXZWbf+INK0q5FvfXXkyMMgNG2CPqBitrb
+XH+PZ50s4LaLyAkmSzTFMDH+8f5CplLlVxWuR65d3N3bzS2kRjgSRIpBKgbzc4I4/u/MM/jWPb3W
+qTXEdje6b/ZsHkMquigLIACcdcg8j357VzsXiPUF1F0ike4acggwZk3FABgAZGcDOcHpXY6W+p3d
+nNBfJdRiUIY5boMAH/uksB1zgfT6VgqnNLqaSpSirtGZpep2Vk01rdStEWdViVNwKseNwK9uelba
+S6brblpNRaR5BhFRfugdjx1x+FRal4XtrTQmvBAwv5eJHPJXOc4/QVR8KWF3p08v2i1ClgfnlGNo
+wRx7/wCNbNaWMU3ewGyMV1M0EQuFiicqIxknAJAx1wSAPxrk/D15dX+sSxzEMWgfL52FQBzjHf8A
+wrvtJVZtdDKfJIYsEHT6flWxL4a0z+1P7Rito4rggrIQvyyKeoYdPx61HI5Rsi0tbnG6fc38+vCK
+G9eMSPkxq5YFexweg/w/Gu4VFhiSJOFUYFQ2+i6ZYXRubWzjilKbNy9h7DoOg/KpmNXRpyhH3ndl
+Sab0NhW7Vl6n4ftdXvYZ7j7sakFQM7+ehz2xnjvmtU7fUUzft7iqcVJaknnkPgC2t9eNjbx3kESx
+efFqEb4KSbgQox2x2+tN8VeItdtbmbSb60hWyLqBeojEMDggYx174Hp1r0lXBpJFZsbSB7EZqPZK
+1jR1XJ+9qc/4l0m41hrNIWkK5y3OET/aPcn0FU7/AEya1tbSS7lMsdtGkSpn77Y5JrpzLIpKl1z9
+P/r1G264Qq+wgcj5eh7d6txuZJa3MDRpUXVZoyg/ejdyOjDn/Gt6RsVAmnwxXjXY/wBYwwQOmfWn
+StmqimlqMhkaq7mnO4yfmH51CzgnrmqA3UY1IQD2ooqBsjPBp2TiiimBH047UhABzRRQAxyRVVyc
+0UU0BXeq0hI5FFFMD//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B464540:AUDUBON_V1_1_P47/full/!100,100/0/default.jpg</Url><Caption>2013-03-06</Caption><Caption>audubon_v1_1_p47</Caption><Caption>5241 x 6601</Caption><Caption>123 MB</Caption><Caption>TIFF</Caption><Caption>600dpi</Caption><Caption>Ruby-throated Humming Bird, Trochilus Colubris, Linn. (Plate XLVII)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B464540:AUDUBON_V1_1_P1/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0002__xz111ffbb66842f49d5f2e023e5131778d.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0002__xz111ffbb66842f49d5f2e023e5131778d.xml
@@ -1,0 +1,2940 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0002__xz111ffbb66842f49d5f2e023e5131778d">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="q1">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">3</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0002</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0002</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>05f1eb036fff47cad0a68395481810bc</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0002</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0002</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0002</ItemUrlEncoded><TitleForTagging>Canis%20%28Vulpes%29%20Fulvus.%20Desmaret.%20Var.%20Decussatus.%20American%20Cross-Fox.%20%28v.%201%2C%20no.%202%2C%20plate%206%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="3" name="S_SCLAUDUBON_X_B6719890___29376_0038" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038</Url></Next>
+<Prev><Url index="1" name="S_SCLAUDUBON_X_B6719890___29376_0008" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008</Url></Prev>
+<Self><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0002">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776097</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;q1=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0002</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/543,419/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>542</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_flm class="fieldsRef">2014-12-11 11:08:59</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_plate class="fieldsRef">plate 006</istruct_caption_plate>
+<istruct_caption_software class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<m_fn class="fieldsRef">29377_0002</m_fn>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0002</istruct_isentryid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_iid class="fieldsRef">29377_0002</m_iid>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_m class="fieldsRef">29377_0002</istruct_m>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_x class="fieldsRef">8</istruct_x>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_caption_image_id class="fieldsRef">29377_0002</istruct_caption_image_id>
+<istruct_caption_image_title class="fieldsRef">Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</istruct_caption_image_title>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-8</istruct_isentryidv>
+<m_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</m_caption>
+<istruct_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</istruct_caption>
+<collid class="imgInfHashRef">sclib</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6704</height>
+<levels class="imgInfHashRef">6</levels>
+<u class="imgInfHashRef">1</u>
+<size class="imgInfHashRef">4388975</size>
+<md5 class="imgInfHashRef">19e1a423cc71ca925526f7d7fda88428</md5>
+<ext class="imgInfHashRef">jp2</ext>
+<use class="imgInfHashRef">access</use>
+<loaded class="imgInfHashRef">2014-12-12 17:07:37</loaded>
+<master class="imgInfHashRef">0</master>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/6/audubonVQ_v1_2_p6/audubonVQ_v1_2_p6.jp2</filename>
+<modified class="imgInfHashRef">2014-12-11 11:08:59</modified>
+<width class="imgInfHashRef">8686</width>
+<type class="imgInfHashRef">image</type>
+<basename class="imgInfHashRef">29377_0002</basename>
+<access class="imgInfHashRef">1</access>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:6/0/native.jpg</Part><LevelWidth>135</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>135</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:5/0/native.jpg</Part><LevelWidth>271</LevelWidth><LevelHeight>209</LevelHeight><LevelMaxDim>271</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:4/0/native.jpg</Part><LevelWidth>542</LevelWidth><LevelHeight>419</LevelHeight><LevelMaxDim>542</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:3/0/native.jpg</Part><LevelWidth>1085</LevelWidth><LevelHeight>838</LevelHeight><LevelMaxDim>1085</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:2/0/native.jpg</Part><LevelWidth>2171</LevelWidth><LevelHeight>1676</LevelHeight><LevelMaxDim>2171</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:1/0/native.jpg</Part><LevelWidth>4343</LevelWidth><LevelHeight>3352</LevelHeight><LevelMaxDim>4343</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:0/0/native.jpg</Part><LevelWidth>8686</LevelWidth><LevelHeight>6704</LevelHeight><LevelMaxDim>8686</LevelMaxDim></Level><MaxWidth>8686</MaxWidth><MaxHeight>6704</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0002</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Cross-Fox. (v. 1, no. 2, plate 6)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank">Lithograph</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0002_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0002" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0002" canvas-index="51" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="sort">istruct_caption_image_title</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="q1">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">3</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0002</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value><Focus>true</Focus></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0002</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0002__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0002__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
@@ -1,0 +1,2944 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0002__xzc425f4d9542a7a3a827c3ff1ea499b6c">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="sort">medium</Param>
+<Param name="q1">lithograph</Param>
+<Param name="q2">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">2</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0002</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0002</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>c304cbfd3eb4634518df72df88a5e35a</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0002</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0002</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0002</ItemUrlEncoded><TitleForTagging>Canis%20%28Vulpes%29%20Fulvus.%20Desmaret.%20Var.%20Decussatus.%20American%20Cross-Fox.%20%28v.%201%2C%20no.%202%2C%20plate%206%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0010" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010</Url></Next>
+<Prev><Url index="0" name="S_SCLAUDUBON_X_B6719889___29377_0048" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048</Url></Prev>
+<Self><Url index="1" name="S_SCLAUDUBON_X_B6719889___29377_0002">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775484</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;q1=lithograph;q2=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0002</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/543,419/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>542</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_m class="fieldsRef">29377_0002</istruct_m>
+<istruct_caption_image_title class="fieldsRef">Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</istruct_caption_image_title>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</m_caption>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_iid class="fieldsRef">29377_0002</m_iid>
+<m_fn class="fieldsRef">29377_0002</m_fn>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_x class="fieldsRef">8</istruct_x>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_plate class="fieldsRef">plate 006</istruct_caption_plate>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_image_id class="fieldsRef">29377_0002</istruct_caption_image_id>
+<m_flm class="fieldsRef">2014-12-11 11:08:59</m_flm>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption class="fieldsRef">29377_0002||||||||||||||||||Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)|||Exhibit||||||||||||plate 006</istruct_caption>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0002</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-8</istruct_isentryidv>
+<collid class="imgInfHashRef">sclib</collid>
+<loaded class="imgInfHashRef">2014-12-12 17:07:37</loaded>
+<height class="imgInfHashRef">6704</height>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/6/audubonVQ_v1_2_p6/audubonVQ_v1_2_p6.jp2</filename>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<modified class="imgInfHashRef">2014-12-11 11:08:59</modified>
+<ext class="imgInfHashRef">jp2</ext>
+<levels class="imgInfHashRef">6</levels>
+<size class="imgInfHashRef">4388975</size>
+<type class="imgInfHashRef">image</type>
+<access class="imgInfHashRef">1</access>
+<md5 class="imgInfHashRef">19e1a423cc71ca925526f7d7fda88428</md5>
+<width class="imgInfHashRef">8686</width>
+<use class="imgInfHashRef">access</use>
+<basename class="imgInfHashRef">29377_0002</basename>
+<master class="imgInfHashRef">0</master>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:6/0/native.jpg</Part><LevelWidth>135</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>135</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:5/0/native.jpg</Part><LevelWidth>271</LevelWidth><LevelHeight>209</LevelHeight><LevelMaxDim>271</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:4/0/native.jpg</Part><LevelWidth>542</LevelWidth><LevelHeight>419</LevelHeight><LevelMaxDim>542</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:3/0/native.jpg</Part><LevelWidth>1085</LevelWidth><LevelHeight>838</LevelHeight><LevelMaxDim>1085</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:2/0/native.jpg</Part><LevelWidth>2171</LevelWidth><LevelHeight>1676</LevelHeight><LevelMaxDim>2171</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:1/0/native.jpg</Part><LevelWidth>4343</LevelWidth><LevelHeight>3352</LevelHeight><LevelMaxDim>4343</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:0/0/native.jpg</Part><LevelWidth>8686</LevelWidth><LevelHeight>6704</LevelHeight><LevelMaxDim>8686</LevelMaxDim></Level><MaxWidth>8686</MaxWidth><MaxHeight>6704</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0002</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Cross-Fox. (v. 1, no. 2, plate 6)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0002_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0002" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0002" canvas-index="51" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="sort">medium</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">2</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0002</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value><Focus>true</Focus></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0002</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0002</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0002/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0010__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0010__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
@@ -1,0 +1,2935 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0010__xzc425f4d9542a7a3a827c3ff1ea499b6c">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="sort">medium</Param>
+<Param name="q1">lithograph</Param>
+<Param name="q2">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">3</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0010</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0010</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>05d54b7c15be81f1627e63047a1856db</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0010</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0010</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0010</ItemUrlEncoded><TitleForTagging>Scallops%20Aqualicus%2C%20Linn.%20Common%20American%20Shrew%20Mole.%20%28v.%201%2C%20no.%202%2C%20plate%2010%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="3" name="S_SCLAUDUBON_X_B6719889___29377_0025" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025</Url></Next>
+<Prev><Url index="1" name="S_SCLAUDUBON_X_B6719889___29377_0002" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Prev>
+<Self><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0010">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775485</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;q1=lithograph;q2=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0010</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/538,413/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>412</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_x class="fieldsRef">12</istruct_x>
+<istruct_caption_image_id class="fieldsRef">29377_0010</istruct_caption_image_id>
+<istruct_caption_software class="fieldsRef"/>
+<m_id class="fieldsRef">B6719889</m_id>
+<m_flm class="fieldsRef">2014-12-11 10:50:51</m_flm>
+<istruct_m class="fieldsRef">29377_0010</istruct_m>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_title class="fieldsRef">Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</istruct_caption_image_title>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</istruct_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<m_caption class="fieldsRef">29377_0010||||||||||||||||||Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)|||Exhibit||||||||||||plate 010</m_caption>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_plate class="fieldsRef">plate 010</istruct_caption_plate>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0010</istruct_isentryid>
+<m_iid class="fieldsRef">29377_0010</m_iid>
+<m_fn class="fieldsRef">29377_0010</m_fn>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-12</istruct_isentryidv>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<collid class="imgInfHashRef">sclib</collid>
+<ext class="imgInfHashRef">jp2</ext>
+<use class="imgInfHashRef">access</use>
+<type class="imgInfHashRef">image</type>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">4726b7070d4ee3d4410f18174a814436</md5>
+<u class="imgInfHashRef">1</u>
+<size class="imgInfHashRef">3053212</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<basename class="imgInfHashRef">29377_0010</basename>
+<levels class="imgInfHashRef">6</levels>
+<modified class="imgInfHashRef">2014-12-11 10:50:51</modified>
+<access class="imgInfHashRef">1</access>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">8602</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_2/_p/10/audubonVQ_v1_2_p10/audubonVQ_v1_2_p10.jp2</filename>
+<height class="imgInfHashRef">6606</height>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:6/0/native.jpg</Part><LevelWidth>134</LevelWidth><LevelHeight>103</LevelHeight><LevelMaxDim>134</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:5/0/native.jpg</Part><LevelWidth>268</LevelWidth><LevelHeight>206</LevelHeight><LevelMaxDim>268</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:4/0/native.jpg</Part><LevelWidth>537</LevelWidth><LevelHeight>412</LevelHeight><LevelMaxDim>537</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:3/0/native.jpg</Part><LevelWidth>1075</LevelWidth><LevelHeight>825</LevelHeight><LevelMaxDim>1075</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:2/0/native.jpg</Part><LevelWidth>2150</LevelWidth><LevelHeight>1651</LevelHeight><LevelMaxDim>2150</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:1/0/native.jpg</Part><LevelWidth>4301</LevelWidth><LevelHeight>3303</LevelHeight><LevelMaxDim>4301</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:0/0/native.jpg</Part><LevelWidth>8602</LevelWidth><LevelHeight>6606</LevelHeight><LevelMaxDim>8602</LevelMaxDim></Level><MaxWidth>8602</MaxWidth><MaxHeight>6606</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0010</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Scallops Aqualicus, Linn. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Shrew Mole. (v. 1, no. 2, plate 10)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0010_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0010" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0010" canvas-index="4" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="sort">medium</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">3</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0010</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value><Focus>true</Focus></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0010</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0010</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0010/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0025__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0025__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
@@ -1,0 +1,2947 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0025__xzc425f4d9542a7a3a827c3ff1ea499b6c">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="sort">medium</Param>
+<Param name="q1">lithograph</Param>
+<Param name="q2">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">4</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0025</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0025</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>93349693d42e6dc10dadf59f77f1ca50</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0025</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0025</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0025</ItemUrlEncoded><TitleForTagging>Mephitis%20Americana%2C%20Desm.%20Common%20American%20Skunk.%20%28v.%201%2C%20no.%209%2C%20plate%2042%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="4" name="S_SCLAUDUBON_X_B6719889___29377_0049" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049</Url></Next>
+<Prev><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0010" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010</Url></Prev>
+<Self><Url index="3" name="S_SCLAUDUBON_X_B6719889___29377_0025">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775487</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;q1=lithograph;q2=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0025</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/412,533/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>411</w>
+    <h>532</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_iid class="fieldsRef">29377_0025</m_iid>
+<m_fn class="fieldsRef">29377_0025</m_fn>
+<m_flm class="fieldsRef">2014-12-11 11:07:17</m_flm>
+<istruct_caption_image_title class="fieldsRef">Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</istruct_caption_image_title>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_x class="fieldsRef">44</istruct_x>
+<istruct_caption_image_id class="fieldsRef">29377_0025</istruct_caption_image_id>
+<istruct_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</istruct_caption>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 042</istruct_caption_plate>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_caption class="fieldsRef">29377_0025||||||||||||||||||Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)|||Exhibit||||||||||||plate 042</m_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_m class="fieldsRef">29377_0025</istruct_m>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-44</istruct_isentryidv>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0025</istruct_isentryid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29377_0025</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<master class="imgInfHashRef">0</master>
+<levels class="imgInfHashRef">6</levels>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<collid class="imgInfHashRef">sclib</collid>
+<md5 class="imgInfHashRef">eeb56fd0572b0d85f37e6cbf5250cee1</md5>
+<height class="imgInfHashRef">8523</height>
+<type class="imgInfHashRef">image</type>
+<size class="imgInfHashRef">4987180</size>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<modified class="imgInfHashRef">2014-12-11 11:07:17</modified>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_9/_p/42/audubonVQ_v1_9_p42/audubonVQ_v1_9_p42.jp2</filename>
+<width class="imgInfHashRef">6579</width>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:6/0/native.jpg</Part><LevelWidth>102</LevelWidth><LevelHeight>133</LevelHeight><LevelMaxDim>133</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:5/0/native.jpg</Part><LevelWidth>205</LevelWidth><LevelHeight>266</LevelHeight><LevelMaxDim>266</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:4/0/native.jpg</Part><LevelWidth>411</LevelWidth><LevelHeight>532</LevelHeight><LevelMaxDim>532</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:3/0/native.jpg</Part><LevelWidth>822</LevelWidth><LevelHeight>1065</LevelHeight><LevelMaxDim>1065</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:2/0/native.jpg</Part><LevelWidth>1644</LevelWidth><LevelHeight>2130</LevelHeight><LevelMaxDim>2130</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:1/0/native.jpg</Part><LevelWidth>3289</LevelWidth><LevelHeight>4261</LevelHeight><LevelMaxDim>4261</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:0/0/native.jpg</Part><LevelWidth>6579</LevelWidth><LevelHeight>8523</LevelHeight><LevelMaxDim>8523</LevelMaxDim></Level><MaxWidth>6579</MaxWidth><MaxHeight>8523</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0025</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Mephitis Americana, Desm. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Skunk. (v. 1, no. 9, plate 42)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0025_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0025" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0025" canvas-index="39" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="sort">medium</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">4</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0025</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value><Focus>true</Focus></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0025</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0025</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0025/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0048__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0048__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
@@ -1,0 +1,2948 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0048__xzc425f4d9542a7a3a827c3ff1ea499b6c">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="sort">medium</Param>
+<Param name="q1">lithograph</Param>
+<Param name="q2">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">1</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0048</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0048</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>6b117652b143168654450308f66a3c0a</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0048</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0048</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0048</ItemUrlEncoded><TitleForTagging>Lynx%20Rufus%2C%20Guldenstaed.%20Common%20American%20Wild%20Cat.%20%28v.%201%2C%20no.%201%2C%20plate%201%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="1" name="S_SCLAUDUBON_X_B6719889___29377_0002" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Next>
+<Prev><Url index="17" name="S_SCLAUDUBON_X_B6719891___29375_0044" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719891;viewid=29375_0044</Url></Prev>
+<Self><Url index="0" name="S_SCLAUDUBON_X_B6719889___29377_0048">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775483</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;q1=lithograph;q2=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0048</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/544,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>543</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_plate class="fieldsRef">plate 001c</istruct_caption_plate>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-3</istruct_isentryidv>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</m_caption>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_m class="fieldsRef">29377_0048</istruct_m>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0048</istruct_isentryid>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0048</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption class="fieldsRef">29377_0048||||||||||||||||||Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)|||Exhibit||||||||||||plate 001c</istruct_caption>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_x class="fieldsRef">3</istruct_x>
+<istruct_caption_image_title class="fieldsRef">Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</istruct_caption_image_title>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_iid class="fieldsRef">29377_0048</m_iid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_flm class="fieldsRef">2014-12-11 10:41:06</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_image_id class="fieldsRef">29377_0048</istruct_caption_image_id>
+<md5 class="imgInfHashRef">e96ecf681e7e8d8efb9b562c26fcfa97</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">6718</height>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">7880555</size>
+<collid class="imgInfHashRef">sclib</collid>
+<modified class="imgInfHashRef">2014-12-11 10:41:06</modified>
+<levels class="imgInfHashRef">6</levels>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<access class="imgInfHashRef">1</access>
+<type class="imgInfHashRef">image</type>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/_p/1/audubonVQ_v1_1_p1/audubonVQ_v1_1_p1.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<width class="imgInfHashRef">8698</width>
+<loaded class="imgInfHashRef">2014-12-12 17:07:33</loaded>
+<basename class="imgInfHashRef">29377_0048</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:6/0/native.jpg</Part><LevelWidth>135</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>135</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:5/0/native.jpg</Part><LevelWidth>271</LevelWidth><LevelHeight>209</LevelHeight><LevelMaxDim>271</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:4/0/native.jpg</Part><LevelWidth>543</LevelWidth><LevelHeight>419</LevelHeight><LevelMaxDim>543</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:3/0/native.jpg</Part><LevelWidth>1087</LevelWidth><LevelHeight>839</LevelHeight><LevelMaxDim>1087</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:2/0/native.jpg</Part><LevelWidth>2174</LevelWidth><LevelHeight>1679</LevelHeight><LevelMaxDim>2174</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:1/0/native.jpg</Part><LevelWidth>4349</LevelWidth><LevelHeight>3359</LevelHeight><LevelMaxDim>4349</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:0/0/native.jpg</Part><LevelWidth>8698</LevelWidth><LevelHeight>6718</LevelHeight><LevelMaxDim>8698</LevelMaxDim></Level><MaxWidth>8698</MaxWidth><MaxHeight>6718</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0048</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Lynx Rufus, Guldenstaed. Common <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wild Cat. (v. 1, no. 1, plate 1)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0048_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0048" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0048" canvas-index="23" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="sort">medium</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">1</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0048</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value><Focus>true</Focus></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0048</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0048</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0048/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0049__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719889___29377_0049__xzc425f4d9542a7a3a827c3ff1ea499b6c.xml
@@ -1,0 +1,2943 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719889___29377_0049__xzc425f4d9542a7a3a827c3ff1ea499b6c">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="rgn1">medium</Param>
+<Param name="select1">all</Param>
+<Param name="op2">And</Param>
+<Param name="rgn2">istruct_caption_image_title</Param>
+<Param name="select2">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="sort">medium</Param>
+<Param name="q1">lithograph</Param>
+<Param name="q2">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">5</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719889</Param>
+<Param name="viewid">29377_0049</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0049</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>b32adaa7bf4a320c81ab5a0e397b5aad</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719889</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719889___29377_0049</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719889%5D29377_0049</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719889%5D29377_0049</ItemUrlEncoded><TitleForTagging>Castor%20Fiber%20Americanus%2C%20Linn.%20American%20Beaver.%20%28v.%201%2C%20no.%2010%2C%20plate%2046%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="5" name="S_SCLAUDUBON_X_B6719889___29377_0001" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001</Url></Next>
+<Prev><Url index="3" name="S_SCLAUDUBON_X_B6719889___29377_0025" marker="c425f4d9542a7a3a827c3ff1ea499b6c">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025</Url></Prev>
+<Self><Url index="4" name="S_SCLAUDUBON_X_B6719889___29377_0049">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=lithograph;q2=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632775488</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;q1=lithograph;q2=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_MEDIUM___LITHOGRAPH___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;debug=xml;size=50;q1=lithograph;q2=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719889]29377_0049</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/534,414/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>533</w>
+    <h>413</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_title class="fieldsRef">Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</istruct_caption_image_title>
+<m_id class="fieldsRef">B6719889</m_id>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_fn class="fieldsRef">29377_0049</m_fn>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_id class="fieldsRef">29377_0049</istruct_caption_image_id>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719889]29377_0049</istruct_isentryid>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719889-48</istruct_isentryidv>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_plate class="fieldsRef">plate 046</istruct_caption_plate>
+<m_source class="fieldsRef">sclib</m_source>
+<m_flm class="fieldsRef">2014-12-11 11:14:32</m_flm>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_iid class="fieldsRef">29377_0049</m_iid>
+<istruct_x class="fieldsRef">48</istruct_x>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</istruct_caption>
+<istruct_m class="fieldsRef">29377_0049</istruct_m>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_caption class="fieldsRef">29377_0049||||||||||||||||||Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)|||Exhibit||||||||||||plate 046</m_caption>
+<access class="imgInfHashRef">1</access>
+<height class="imgInfHashRef">6619</height>
+<modified class="imgInfHashRef">2014-12-11 11:14:32</modified>
+<collid class="imgInfHashRef">sclib</collid>
+<size class="imgInfHashRef">5020737</size>
+<use class="imgInfHashRef">access</use>
+<md5 class="imgInfHashRef">bf6d9153b928aec507046ef26268127c</md5>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v1/_1/0_/p4/6/audubonVQ_v1_10_p46/audubonVQ_v1_10_p46.jp2</filename>
+<loaded class="imgInfHashRef">2014-12-12 17:07:30</loaded>
+<width class="imgInfHashRef">8535</width>
+<type class="imgInfHashRef">image</type>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">29377_0049</basename>
+<levels class="imgInfHashRef">6</levels>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:6/0/native.jpg</Part><LevelWidth>133</LevelWidth><LevelHeight>103</LevelHeight><LevelMaxDim>133</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:5/0/native.jpg</Part><LevelWidth>266</LevelWidth><LevelHeight>206</LevelHeight><LevelMaxDim>266</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:4/0/native.jpg</Part><LevelWidth>533</LevelWidth><LevelHeight>413</LevelHeight><LevelMaxDim>533</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:3/0/native.jpg</Part><LevelWidth>1066</LevelWidth><LevelHeight>827</LevelHeight><LevelMaxDim>1066</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:2/0/native.jpg</Part><LevelWidth>2133</LevelWidth><LevelHeight>1654</LevelHeight><LevelMaxDim>2133</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:1/0/native.jpg</Part><LevelWidth>4267</LevelWidth><LevelHeight>3309</LevelHeight><LevelMaxDim>4267</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:0/0/native.jpg</Part><LevelWidth>8535</LevelWidth><LevelHeight>6619</LevelHeight><LevelMaxDim>8535</LevelMaxDim></Level><MaxWidth>8535</MaxWidth><MaxHeight>6619</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719889</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29377_0049</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="false"><Values><Value>Castor Fiber Americanus, Linn. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Beaver. (v. 1, no. 10, plate 46)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1845</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Lithograph</Highlight></Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/res:0/0/native.jpg?attachment=1</URL><Filename>29377_0049_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719889:29377_0049" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719889:29377_0049" canvas-index="43" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="rgn1">medium</Variable>
+<Variable name="select1">all</Variable>
+<Variable name="op2">And</Variable>
+<Variable name="rgn2">istruct_caption_image_title</Variable>
+<Variable name="select2">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="sort">medium</Variable>
+<Variable name="q1">lithograph</Variable>
+<Variable name="q2">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">5</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719889</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719889 29377_0049</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. I; [title page]</Label><Value>29377_0022</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. I; Contents</Label><Value>29377_0027</Value></Option><Option index="2"><Label>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Label><Value>29377_0048</Value></Option><Option index="3"><Label>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Label><Value>29377_0050</Value></Option><Option index="4"><Label>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Label><Value>29377_0014</Value></Option><Option index="5"><Label>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Label><Value>29377_0005</Value></Option><Option index="6"><Label>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Label><Value>29377_0008</Value></Option><Option index="7"><Label>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Label><Value>29377_0002</Value></Option><Option index="8"><Label>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Label><Value>29377_0009</Value></Option><Option index="9"><Label>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Label><Value>29377_0004</Value></Option><Option index="10"><Label>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Label><Value>29377_0047</Value></Option><Option index="11"><Label>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Label><Value>29377_0010</Value></Option><Option index="12"><Label>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Label><Value>29377_0006</Value></Option><Option index="13"><Label>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Label><Value>29377_0018</Value></Option><Option index="14"><Label>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Label><Value>29377_0020</Value></Option><Option index="15"><Label>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Label><Value>29377_0046</Value></Option><Option index="16"><Label>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Label><Value>29377_0013</Value></Option><Option index="17"><Label>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Label><Value>29377_0003</Value></Option><Option index="18"><Label>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Label><Value>29377_0011</Value></Option><Option index="19"><Label>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Label><Value>29377_0015</Value></Option><Option index="20"><Label>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Label><Value>29377_0034</Value></Option><Option index="21"><Label>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Label><Value>29377_0040</Value></Option><Option index="22"><Label>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Label><Value>29377_0045</Value></Option><Option index="23"><Label>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Label><Value>29377_0036</Value></Option><Option index="24"><Label>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Label><Value>29377_0035</Value></Option><Option index="25"><Label>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Label><Value>29377_0023</Value></Option><Option index="26"><Label>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Label><Value>29377_0039</Value></Option><Option index="27"><Label>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Label><Value>29377_0038</Value></Option><Option index="28"><Label>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Label><Value>29377_0030</Value></Option><Option index="29"><Label>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Label><Value>29377_0031</Value></Option><Option index="30"><Label>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Label><Value>29377_0033</Value></Option><Option index="31"><Label>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Label><Value>29377_0019</Value></Option><Option index="32"><Label>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Label><Value>29377_0024</Value></Option><Option index="33"><Label>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Label><Value>29377_0029</Value></Option><Option index="34"><Label>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Label><Value>29377_0043</Value></Option><Option index="35"><Label>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Label><Value>29377_0021</Value></Option><Option index="36"><Label>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Label><Value>29377_0051</Value></Option><Option index="37"><Label>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Label><Value>29377_0028</Value></Option><Option index="38"><Label>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Label><Value>29377_0044</Value></Option><Option index="39"><Label>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Label><Value>29377_0041</Value></Option><Option index="40"><Label>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Label><Value>29377_0017</Value></Option><Option index="41"><Label>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Label><Value>29377_0052</Value></Option><Option index="42"><Label>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Label><Value>29377_0026</Value></Option><Option index="43"><Label>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Label><Value>29377_0025</Value></Option><Option index="44"><Label>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Label><Value>29377_0042</Value></Option><Option index="45"><Label>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Label><Value>29377_0032</Value></Option><Option index="46"><Label>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Label><Value>29377_0037</Value></Option><Option index="47"><Label>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Label><Value>29377_0049</Value><Focus>true</Focus></Option><Option index="48"><Label>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Label><Value>29377_0001</Value></Option><Option index="49"><Label>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Label><Value>29377_0007</Value></Option><Option index="50"><Label>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Label><Value>29377_0016</Value></Option><Option index="51"><Label>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Label><Value>29377_0012</Value></Option><Name>relview</Name><Default>29377_0049</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hUG0
+fSniMU5Vwi/SnqtZ2LGhBUgX2pQKeBTsA0KKXZTshQSTgChWV1ypBHqKBDCgppQelTEVGRQBEyD0
+qhqMYNsfqK0yKo34/cH60MaLij5RUTzSpJtEG5ePmBPc/SpF+6PpUgoQFb7VKpANs3Ppk9/pSi+O
+Ri3l59VIx+lWwKdQIrLdMzAGBwCQMkH/AApXujGxUQs2Djj+dWDnHHWlXOOcZpgU2vuOIJD07H/C
+m/bGLAfZ3wTgH8KvUhoAz1vw2MwOCccYpL//AI9z9RV41Sv/APj3P1FJjJ0+4v0qQVHF/qk/3RUo
+FJCIZ7Rbh0Z2IC9APqD/AEqM6fn/AJbHpj7tWQsmf9YMf7tKVkLcOAP92mIhSzMUrSLL1XAG3pwP
+f2qP+z3baTck46fL169eferhD4Hzj34pAJCBiRfypgVBpzhcC47AHKnn9afDaywSKTPuQAjbt6++
+c1ZxJ/eX8qaRJz8y9PSgANU77/UH6irnOOTzVO9/1B+tJjRNDzCn+6P5VKM4461BA2YIz6qP5VMD
+SQAvm4Odnt1pw83HOzNANOFMQn73Bzs9qP3vYJ+dK27HynBoXdxkigAzJg5C57c00l89Fxn17U8m
+mk0AMG7HzAA+xqre/wCoP4VbNU70/uTSYx9tzbx/7o/lU61BbcW0X+6P5VOppIB9Lh8/KVA9x/8A
+XpBTucHHWqATEnqv5UfP6r+VRs9wmCRGR7ZJ/lSLJK/3VXIxncGH5cUCJfnzyVx7Cg0Lu2/OBu/2
+elIaAGmql5zCatmqd7xAx+n86TGOtjm2i/3R/KrK1Vtf+PWL/dFWFoQEopwpg5pQBmmA4jIwehoV
+Qq4AwBScUED0oAU000YFNOB0oAQmqt3zC1WWNU7s/ujQwQy0Y/ZIP9wVbBNFFJDHBjinBjRRTACx
+o3GiigQFjTGY0UUARliaq3bHyCf89aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0022/full/!100,100/0/default.jpg</Url><Caption>29377_0022</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOMB
+F47CpBGPSlQfIv0p4FQihoQelOEajoo/KnAUpIXqQPrTATYKNg9KdvT+8PzpPMTGd6+vWgBpjHoK
+YYx6VMCD0INIRQBWaJc52jJ9qjaMZ6CrTCoW60rATIPkH0pwFCj5R9KGBIGGIpgOApdoPUA1SeaQ
+OQH447A/0p8M7mTDNkegFMC1tA/hFAUdNgoDZUnBH1pr54IYj2/yKBD8AdBimmqgmkBOWJ/z9KmW
+ZiANoJ6ck/4UhjmFRN1qZulQuOaAJh0FOPSmjoKDwKAKcoPmnr29acikkERDGevNRS/604HYf56V
+Jb8MRsRh78H+VAi6GAG3a34g0PyopR9z7u3jpTZMFOcUAUSuZCDkcn+GpolMYGA3rypqBdoZs9yQ
+OBj+VWoWjHAK7j6Y/pQBITxmoX61K1Qv1pMZP2FBPymk7Chj8poEUZv9YeDnA7H/AAqSKLdhhwc8
+Hb/9aq8xHndug44/wqSCMMPmkVf90qaANM/dP0pj/cHXt0pEUohy5bPrSSEbBnHbrj196AKBC7zn
+jnnirUcm3qHPp8pNZ7SJkn5eD14q1btBIAvlIT6kLzQBYEgfOAwx6gio360/y40JKoqn1AxUTnmk
+xljtQfumjNB+6aAMyXcJyxycAHvViGQseCc/3SSf6Uxj+/HTt6f41OiRFsAx/XA/xpgWhvKHeFB9
+jSP/AKsYz+FPwAuB6Ux8bOaBGQxxI2ckZORk+v1qePOwbMhevBaomKmQ8jO71H+NWIzFuyxQd+dv
++NIZZzlQaifrUgZSuEIIHHBzUT9aGBNmnDkYqPNPBpgRtbbmyH/OpEt1Xnc2frTgacDTAXtSEZGM
+mjNGaAKxtfmJ8w8nPf8AxpRBtXBkf8CRU2aaxpANxtGMk/WonPNSMahc80AKGO6pdxxRRSAAxpwY
+0UUwF3HNJuOKKKAE3HFNZjRRQBGzGq8jkNRRSGf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0027/full/!100,100/0/default.jpg</Url><Caption>29377_0027</Caption><Caption>The viviparous quadrupeds of North America... Vol. I; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NAcV
+IBTU6CpAKixYzO1SzcYrLu/ENpaTQxMHd5jhdo/nVy8V5ImSMhW6ZIJGKoppNksjzbXMrLt8xmyR
+9PTrWU79ARj6l49h0+fyvsMrsHCkA+uMdKrn4kwQlXn06dIGO0SA9x1rVn8NWpsHhgUCaRdrTE4c
+85znHWuS8e6RFDpiRJJsiiXcFByzdST+NQlO+43Y09Z+KWnadZie2tZLknnG4Dir+h+M5vEFpHeW
+liq2z85d/mPqAO/NeHBIA6xyOGjJBXnqtdBHqEOlsSzFYWOU2EBfbA9aKlRwtZFRSZ7xb3sNwoI+
+Vz/A33h7VHLqdpAGMrlQhwTjPP4Vxnha9t7gLfrORvIUx4C8+pH5966Ge9gvg8Fk6NOoLFT0PY1s
+noTY0YNTtboKbeVXBNWj0rD0aO4t9v2lUVmznZ068YFbvUZFMRXb71FPYc9KKVhkiDinngU1OlOb
+pViK0hIbIqvPMkUTSOwULzzVhxXIeMNSe3tzbxMQZFwQRWUmMbqnjNrSYJaQrcFWwyjoK4DxPqd9
+qzm8uYpIONqRhsgj/CqV/qq6WhlknZGY42r1J+lcrc6xqOsSbd7xRngY64+tLmS1YlFyegye6RZQ
+PlVlPHPQ1Wu7hLpAA/zjqM03+zF27s5+bBJzSPpkYcgPhvTHNEasTX2TR2fhLUrgPbRTTFjgsymX
+A2joCK9JtzJcgebPHboRtCR4+Y/3Tj/GvC7S5uNKkJUK6nghuv4HtW5/wkksqYKysepBJ6+vFJRU
+pX6DaaVj1O58ZR6feJBZRRvCg/eNk5Ddxg13Oj366npkVyhyHGa+c7W6j+w315eyFZCuLePncXyO
+f/11638J9cGqaFPasuHtnHOMZDf/AKjWy8jNprc7putFK4+aigQ+P7oqvd39vbKfMkAwM1YTha4r
+xN5c4uRHu8xImYYJwcDpQ9hGrP4q0yGMO9zGFJ255PP4V598RtbtmjjksnWW4YEgK+dg7k+lUJIY
+LbT4XvzfFLiIsjQjAHqxB69vpmuY8RWb+XbSpO7iaJWVsEEqcev1FYOT3sacqMARm4kNxdTl2z1J
+rRsYopGURDeQevTFVNCtoblmW4K7Q2DuHFXtP/0PUC1uu9N+Avt3/pWEtXY1WiuXrmMxxKqoxL8L
+tXr/AJzWa9v9l5cdu55ruLaWwkuY2nnt4gykKGbueOlc54q0i5tpScfIfxzRFNbjUrnOLm6uBEuO
+TjJq5fwCBFhjlUzKDnbRZRpBAZ0jLsflG7se5NSxW3LPdTJGHO4yO3FbJ2BmDK0rFXfccd29a9l+
+B7b4tVJJBHljH/fVcDqdjbSaL59hKs0ath2AIw1d18EYZVbUpSCImVR9TzXRGfMjCcbM9fbrRSMO
+aKCA6xke1ebX8NxBq5mjEku0kEMTtIPUGvRi2IyR6V5v4r1a4sFEkaphnwSx/QDvWVWbitC4R5nY
+Yk05spbKSFPIDDykcK+xccjkdfesXxNpwu2a7ikaULEViTaFEbdAWOecentWNPrOpXc7RwRMBuwz
+L0x7HvULaXf3+VmmZEb7wzk//Wrl539o1cbHPG0k01FRGWQyH5WXkZ9aqSvfTEQxMUjXIG0YLepP
+1rtbnQt1rAkOFkg4QdQeaiOm3P8AZ0g8uK3mxtR85JqY1EncU1dI4F45YH2MTuz0rvdBmu57AWmp
+OXgx8kkg+ZPYZ6j2qDTPCrmA3E3FwenmgjBz/hUtzo984RftiW8ZzufqxGeMVrOqpLlQQhb3mYd9
+bxi68jzdkaksWPG3/wDX6VBbaPNfPmNWMQ/jYdfpXRWulaZZvxE91N3kkbdVh7+GFBsQLjgKtONR
+pWiNq7uwXR/s+iPBbsMyDLbvUdBXofw1geG1mHlpGgUDC+teXSeJP34hYdSOnFe0+CrR7bQY5nBB
+uAJB/ukcVpTUr3ZE5Jqx0ZPNFQu+GorczFQjYAaz7zRLS7zuUgn8anjlO2pFlNS7NWYaow28G2ZX
+KyESc4OOPyqvYeBoYpmlvLo3D5+VQu1FH07n610/mn0oEp9KxlRpt3sVzSMmXwxEVPlMqE99tZdz
+4QlWFhDNamZuQ0sRIU+oxXV+cfSgyZHIBrP6vSfQftJnmtz4L8TsR5Or6eOehif/AANT23w71WeZ
+H1DUbR4R1WONga9BDhTwopxmPpWkaFOInOTMWHwXpMEBjSLkj7x5NY9/8NLC6mWWK7eI4w3yA5H6
+V2PnH0phmb0rVRiugrs5PRvhtomkXpvJQ17Pggeco2j6CuwQJFEscahEUYVQMACoTIaaXJqrhYJn
++f8ACiq0rnfRSuFj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0048/full/!100,100/0/default.jpg</Url><Caption>29377_0048</Caption><Caption>Lynx Rufus, Guldenstaed. Common American Wild Cat. (v. 1, no. 1, plate 1)</Caption><Caption>Exhibit</Caption><Caption>plate 001c</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BF4F
+SbaEHFPxznNTYY0LilxTqQkClYQmMUHFRyzLEjSSMFRQSSTwBXmHiL4kXs0kkPh2NfKQkPdTL1/3
+FPbnqaTaW4bnqWRS5rwS88b+LtOmjc37OGBOHiTGR14Hbmt7SvjDIrx/2vZx/Z2ODNb5yp91OacW
+mFmevUYqpZX9vqFpHdWsqywyDKup4Iq0pzV2AMU1lp7DIIyR7ikC4XGSfc0rAV2XmipGHNFTYY6B
+vMiR/wC8oNPY7RmmwJ5cKJ2VQP0pHcZHIAHNUIeTScGqj36RgliP89qcl9E1yYWIVwobB9D71Dkk
+OwX1lFf2M1rKW8uVdpKnBHuDXBa1ptvol1byXF5bsArbUlbDHjqBXoxORXKax4HsNY1mfVbh3eZr
+U28aNyiEgjdj15qZR5kC0Z5Omr2l1qEkdywZCSwkI+U8dqwprZGt5gg+QyZ/DtXdeI/hfcWVrbS6
+QPPMUW2YcAsR3x/npWBa6XM9iSYwT1NZxbi9TVpNJoreEvF2p+EbraP3+nOcyQMfu+6+hr3zRNas
+tc09L2xlDxN1HdT6Gvn6e0QqygYJPOa1/AmtS6B4nt4DJ/ol03lSLnjJ6H8DXRGVyHE993CgVk6n
+rMGmIrP8wyN2D0FSx6tayNEFmB8wgA9ifSnzK9ibF5utFLkHmikAPIsMLSP91Rk1xt14lgmR7O0u
+N90QShI6ZH+NdHrrvH4fvmiGX8lgPrivnyy1Wax1dZnJxuw2ewPf8KHtoLqdNPHr73TD+1rtjEwa
+Q7vlHcYxx7Y613Gl+JLTULJftLrHdIQJ4txGD2I9q4FvEsuq2Mfk3S2jxykliv3x2rn7i9ZdW86C
+Zmdic7eS2a5VNyumjWUUtj2VfGEIe5P344W2jbzxj/H+VUrjx6EjVo7Rst03HFcPa6p9mttpt3Vc
+c59fXFMbU5NQlRLSISY4Y9MfWsva1L+RLidJc+ONR8w7FXy3O3BHTtVW3hSJpsgAMofj9a5vUo9V
+hmjEdrDMFwzEyBR9AK3hcSeT9oMXGMPH3ANNtytcuGhyt/Nm4kVATzmsiV3jljl5V1O4fhVvULgL
+chFkzCcuxxyeeBWLc3bTOQcljwAOwrpp3uN2sdlL4tluAySsXDjqxra0fxIYzCqkMFcMQwz07V5S
+bmSO4KKwO0AEHtXV+F7VNRvog1w0W5gOD0qnGK1M2mfRdvIJbaKQDAZAcenFFMs4Rb2UEIdnCIF3
+MeTxRVklDxRcLbeGL6RmCgRHknFfO5vLaXcWaIvzgbhX0jqduL7Sri2K7hIhXb6186eJtIi0p2eG
+xfeWxs5IFJsaRShiYpK80gjKj5AnIA9K0NBVo5Vcxct/G4/lXMpa6hdfej8pPTpWnbDULeze3WRc
+Eg7s+lc9ZXVkaQsnqdrJB9p5SfA9FPWqc2lzWUDXUc0i3DAbSpx17VzCXmpxgLEx3Kc5FXbXxLqF
+uHj1K1a4h/h+bBFcqpzWxblF7mzZ3+p2luLm8gS5iYn5wwDYB7dj9KqeI9Uvnto57C8RIJEBVUX5
+vxNT6d4q06dPse8wx5JWKVeMn36H6VcnsreWIrMyCIktucAEA9gABxV83K7yVibX2OCGpPJEvngP
+IBjjvT44mklZ5Z4YSw3HJwR/Wtq6sNNsJGns4TcBByH+ZQfWsuS0e7Vp2gVWbHzZ2gf0rpjUTV1o
+JrXUzp4reK6j2TLIWJDEZ9Kv6VeSWWpRPFkhJASeg/OoG063aRQb+FXU5wDmuj8MeFZ9a1WGK1JM
+IYGZ+qgZ5NWncT2PoixmEthbSc/PErfmKKVU8qNI1+6qhR+FFWZkiHisnU/DWnarnzoSGPVlOK0E
+JxTg5o0A5H/hWWkFiRNOue2Qf6Uz/hVul4x9rnx6YFdpuNLuNQ4RfQd2cJ/wqmxEu5dRmC/3dg/x
+plx8LdNYYN/cbvUKP8a77caXcalU4dgcmeWy/BzSpeupT5PcQjP86IfgvZjPla7eL2wYwR+RNepD
+72e9LuNaKKFdnntr8IdOiXZPqt5MmclMBQa0Jvhh4fn2iQXBQDAQSYFdluOKQsafLHsF2cfa/C7w
+lZyCRdMErD/nq5YflXUWtnbWMQhtbaGCMdFiUKP0FSsxphY1QCs3NFQMx3UVNwsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0050/full/!100,100/0/default.jpg</Url><Caption>29377_0050</Caption><Caption>Arctomys Monax, Gmel. Maryland Marmot, Woodchuck, Groundhog. (v. 1, no. 1, plate 2)</Caption><Caption>Exhibit</Caption><Caption>plate 002</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V3d
+qlEeO1EY6VKBSAj2c0u2pMUUAM20YxTyKjPWgB1BYCsfxJqdxpOhXN3aQia5UAQxMCQzkgAcfWs6
+5v5dX020syHt7i7keGcI+DHsBLYP/fOPY0aAdTwaMVR0u3ez063tnnecxIE82T7zAdCfer4p2GmN
+xTSKkIyCKbtwMZJ+tFhkDDminsOaKiwD0HSpRTE6CpKokKSgmmlqADJpjGhmpmaYhkoiO3zdu0nA
+z61zDXNnp/jO4jkcGRofNhjAyS5wrEfgo/Osrx1Ffi4+1GRlgjx5O0E/N/Q5rmba+upfGFjqk6Tu
+sUypkIcFSDk8++KzctbFJHswG0AelSKeK5qLxpost59lkuTDMTgCVSAfx6V0SOCoIIIPOQa2ESig
+imJIGYj0p5qRkLdaKG60VIyROlPJpiHgVQu7tobnAYj2PSmI0DTSKoNq0MSFndNoGSc4xWbP420e
+3Te7zFTwGSJiD+lS5JbhY3W4BJ4ArOu9c0qxgaW4v4FReDhwTn0wOa4LVfFt14huvslrE0NqzbRv
+4D/X+8fYcDvWBrWl22nW5Y6gHusjESRjGff0FR7XXRBY3/EXxHs5ZYorOyuJokYlnb5A30/+vVCx
+1+z17Vbe3m8y2CKSkbnG9sjGD+dV4LFHs1TYGON5IHNYWq2CeUZUZkZD8pHakpXeoJHaax4Tk10r
+BZsqNF8wc9qn8Ga5c2k9z4b1V/38IJiJOc4GcfTHP51c+F+s/wBrabcrcc3duwSQ/wB4Y4Nct49D
+2/jOC4t5PLmETF2HGFB4J/MitktAPSbXUoS8eZMFVx1yc+ldBHIsiblzj3rwC11a7uru1gS4AhY7
+nlVuQQOh/SvbtAd30S2LyeYdvDn+IdjWVOT5uUb2L7daKG60VoMEPArk/Et/9lum3PtGPWupjbgV
+wPxBuMzRRQLG8hGCW6L9aG9CbGemqxXYKG4RW3AKkhOG55pL3TY7OFUMiSTuwkKrg7gOhOO3Sua/
+skyBZJJ5JdpztgGz8MitnThdgu2xba2QbVeeTP5k1yTnFuxai0XY9MuZUVppAuASqBQAOP1p0fhw
+X1o8ihT8uVY9D+NR3+tWMIRrrVopih+WK0QyE/iOKp2PjfyrCVLgpDbh9sMbKfM2Y5Lf0pcyW7FY
+1beweDTsyjbLGccc5HtWXf6WbmINDiRHPG05yaybv4gO5MVtYvNHjGXDDHv15rlm1XWJNTe+srp7
+N2bcccLkew6/jWilHe4rM7zwpput6LqNy1mPKM5VWaSLeoHPbIq34s8K69eq17HdWE8iochYSjEc
+9OT6msC1+I+v28YW4js5wP4vLIJ/I07UviD4gv42ht7JIARjdHGzGtVVh3HyvscfY+baXvmywl5I
+2OVVipBxg5r6D8F3P2nw/BJ5cifKAfMbLZxXgljpGpXN5uSG5aZznIUcnvwSK948Hade6bowjvHB
+34ZUMQRl9c4Jz2pRac7obTS1OhJ5oppPNFakkcbfKKzdV8OWesSrJOXUj+4cZq5Gx2CplY0hGKPC
+Fj5Xkl3EQ6AcN+fWmp4H0cEmVJJucgSNuAP0rfDGlBNZOlBu7Q+ZmC/gnR3l3mJsAYCg8D3qrN8P
+9FkYF0lOOeD/ADrqdxoycVH1el/KPmZyo8AaF5m4wytxjBbir0Pg3QI8EadEcf31zW3mjJq1Rpro
+HNLuUE8O6RGPksIB9EFOfRNPdGQ26BTwQBirm40hY1oqcOwc0u5UtNJsrJAkNuoVem45I/OrpYYq
+IsaazGqSS2FqxxcZoquzEGilcD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0014/full/!100,100/0/default.jpg</Url><Caption>29377_0014</Caption><Caption>Lepus Townsendii, Bach. Townsend's Rocky Mountain Hare. (v. 1, no. 1, plate 3)</Caption><Caption>Exhibit</Caption><Caption>plate 003</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JVp4
+WhRRuQzCPGXC7unQdKlAOC0u2lpaoBu2kK1JUcuCu0sAT696AGkA8cVGyD2qvKXiO8kkDnnqPx70
+9Ck0gYAfN94dsY/xNTcBWjFRMgzTxd2xufsscqGUDJRT0Hv6UpHNPQZaWqtg3nSXU5PJlMQHoEJH
+88n8adf3RstPnuQoYxIXwe+K83l8dXEVyz6f5VsblvmWf54g543ZGCvv1H0qXNJ2Y1FtXR6pS14X
+c654307UPtb6o7knPllQUI9NuMYruvB3xHg8QXK6bfwfZdQIO3HKSY9PQ+1EZxlsDi0d1io5lLLw
+P1xUtZHifXI/D2g3GoOod0AWKMnG9ycAf57VZAs8Fv8AZ3lkm8oKNxc5GPz615prfjC4smltLaaQ
+rK22MRLiR/b2/CsLWfGGu3WnwNeyQpAsrkpCpB9gc9hziu4+H3g+OOyXXtTTfqF0N8Qb/linbHua
+wlFylZbG0eWMeZ7lbwNpHiBdS/tDUGFrbkHFs4zI2e7elehEc0IpL4kALL0PenEc1rGKirIiUnJ3
+Y+WGO4geGVQ0bgqynuK4bU/hLol4jGzmubOQ9Nr70z9D/jXeCniiye4k2tjxTXo9f8I2NlZ3toLr
+TYQ0ZuFO4MCePdCM/Q4rA1KxmtdStp7Z/mKb0lHyDBwQfbgivoeaGK4heGaNZI3GGRxkEe4rzTxP
+8MLhme58P3ZUHk2UzEof9054+lZyhZ8yKU76M9AOp2NjpUV1cXMcVuIwQ7t7fqa5DU7/AMMeNZJI
+l1qVhaxs5hVSqnAySNy4JHtmvNbbVLzQZZrPV7W7eRF+WwuWIQnIBKk5x8ucY9qg1E2d+sd1pRuo
+IlkCvbyYDRkjluOo7U/aJrUTg09CKzt4dd8TaVYrGyrcTqrc53Ip7++BX0iqqiKigBQMADtXh/gL
+Tkm+Ji+SuYbKBnJ68nj+te4mik7q456Ow01EetSmoj1rRmZKKcKYKeKEMWuY8barPpWn2ksEwiMl
+yIyS23jBP8wPzrpXdY42d2CqoJYnoBXhvi7xYPF+tx29moTT7R/ll/ilI7+w9KzqyUYu44q7Ox8V
+R2nij4c3moXMUYu7NGaOXurKc/qO3vXH2sMA8PRXj/KjRAsQOpx/jWa+pC3MyG5lktrojFoGJNyw
+bOSPTI5PtVuG5uNc1a00IKVaaYLMUGB/ebA7KP6VyVW6ijbc3pPludn8I9HMGl3mtSL89/JiMkc+
+WvA/M16MapW1pHp6R21uojhVAqADgY4/KrXmDo3yt6GuyGisc7d3cCaYRzTjTSapgPFPFMWqUz3d
+3O8FpKII4zh5iu4k+ig8fiaSEYXxMup7TwFqLQEhnCxsR2ViAf0rwawRJYjbo7ISB8ynHfHNe8eK
+LLWJ/D1/YSfZbq1miO64lPltEOpJAGCR2xivH7Tw8rRh7k/Z7SL5wCfnkbsT/hWNbl3kzWmm9iC+
+t10m7S7NzHNcCIErHz5A7L9cEfia9C+EegOyz+IrpWBlzHbBuu3PLfj/AI156bWPUL8WIbyomO9y
+evXgV6N8NLzULLVrvQ5HmubFF3xybTtiP93PQZ9Papg05Xe5U04qyPTpE3r7j171Ghbj+JD3PUVP
+TTxXTYwI2php7VETzQxkymkjRYgwRMZYseepNIpp4NNAUNZ0+bU7IW0cwiVm/eZGcj0rlrz4eLcL
+k3zlgDsG35V/DNd1mjNRKlGTuyo1JRVkcn4W8G2nh60uBdKl1PcN87MmRtHQYNdHa2dnZBvslmkO
+7r5aBc1ZIB60cDoKtRSJbbAHIzgj2NIxPagmmk0xDST3A/OoyeaexqBjzSYxwY1IrGiikgHAmlya
+KKYC5pMmiigBMmmMTRRSAYzHFV2Y5oooYH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0005/full/!100,100/0/default.jpg</Url><Caption>29377_0005</Caption><Caption>Neotoma Floridana, Say et Ord. Florida Rat. (v. 1, no. 1, plate 4)</Caption><Caption>Exhibit</Caption><Caption>plate 004</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUA7
+U8IKVRTsHHHX3qUhiBRS7RTgKcBVWEM2ik20l1OtraTXDKWWJC5A6kAZqhoWvaf4j01b7TpvMjJw
+wPDIfQjsaALxWmFBU5FUru+gtZo45ZEQuMgu2B1xSAcy1Ruo8lePWtJhVS4XJFJopF9aeKaop4po
+kUCloFLVCGsodSrAEEYINeSWcT/D/wAdi3Q7dNvG5XsVY4B+qnj6V67XmnxU1TR0t7e0lmP9powd
+BGMlFPXd6ev4VM9rl097HpHWuD1yRNR8caTY7sqs3mMAe0Yz/OtO/wDGWlx6NJNa3kcrqnJRgdnH
+U1V8GaK7lvEOoKTd3S5hVx/qo+34nrUt8zshrTVnWkVWmGSKtMKhkGSKpkosLTxTFp4pIQ4UtJS1
+QivfXkOn2M93cOEihQuxJ7AV4RolsPEuvS3mqKXFwXnlIOMAfdH0zgV6F4z8H6j4qvtxmVYIFxCm
+7AOcZJ49f5Vx96p8Pl7SyDSXE22KFQPvuSRke1YVJ6pWNYKyumX9A0SLXtfFoqounWTCS6WMYEj/
+AMKfQY5+lesgBVAAwB2rF8K6KugaPDZsqm4ZfMmlH8bnrmts1pCPKrESldjDUTdalNRN1ptiJlp4
+qNakFJMQ4UUlVNS1Wy0iye7vp0hhX+Jj1PoPU07hYg16+l0/SJbiFAzjgZPTPevN/Dt4L/WNQ8Q3
+du0zadGsdtCoz87Z5A/CtHVviZot9A9nH50TEjbLIo2/lnNZXhPVYNE8WXthdTRrZaoo8mZWG3dz
+jn3zXNNuU9H0/E0SaWprab8QL24us3UNv5W/ChG5A7gjOfTrXbWOuaZqchjtLyKWQDJUHB/I1x1x
+8Plj8RWRtmlNg6sZ3LDIIz/Pj9auw/D2Cz1S3vrPUriJoXD4ZA2eemeOO1c2HeKg2p6rzCXK9jsW
+qFutSmo2616DZBItSCo1p+cDNCAdXjfxJvk1TX/sGZH8grHFiTCK5+9xjk9BnPFeg654y0/RG8uX
+cZT0Xpn6Dqa4a+sr3xNNu03QJ49zFhNMPLTOc5y3NZ1G2rRNIJJ3kcRN4Wmk0M34FvtYkRp5q72x
+wTj8KbbadNNoht71WjeP5oHJAI6fpmvQrT4Zaw0WbvVrazCgkLaxliD7scVy9ho+jteNaXk1/NdM
+xWGeKUMjNnAyCBwayl7llLS5V09jr/hr44e+/wCJBqsub2IYgkJ/1igdPcivSzXz/wCIfDt1p90L
+61H2e9tGBbDc5HcV654L8Sp4m0GO4bAuogI7hPRsdfoa3g76Gco21OgNRN1qVqibrV2JJFNPzxUK
+mpAaEBH9jtjefazbR/aNoXzSo3AemasZAGaaDS5qgILsRXVrLbtK8YkUoWQYYA9cZFYum+FND0y5
+W4iieWZDlHlO4qfYYxXQHBGDSjAFS4Rbu1qBh65oH9qyxyRsiBgVlyOo7fjVHw54LtfDWoXF3bXE
+zGddrRkjaeev1rqSaaTT5Ve47u1hpNRseacxqFjzTAVSakBNFFSgHAmnZoopgGaM0UUAGajYmiig
+CMk4qFmOaKKGCP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0008/full/!100,100/0/default.jpg</Url><Caption>29377_0008</Caption><Caption>Sciurus Richardsonii, Bach. Richardson's Columbian Squirrel. (v. 1, no. 1, plate 5)</Caption><Caption>Exhibit</Caption><Caption>plate 005</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UqQ
+LSqOKdjnOfwrKxoJilApeKMipsITFOxTSaUNTSFcMUtNkcIpYngDJriLv4q+G4FIt5p7mXtGkDrn
+3yQOKpIDucUYrzuf4peXDDNHpDyxSMVLCUDbgZOcj2q9F8TNMaONprO7jeTGIwFZsHocA5obSKSb
+O1xTGFKr+dErLuXcARkYI/A0BSFwWLH1NDQEJHNFSEc0VNhkijig04dK43Xtd1HTZbgWkJlKnIBP
+bvTk0txJXOvoxXGW/im8Of8AQ5WyM5yMDj60o8VTTxsI5YIZ/wC47g4rNzQ+VnY7aOlcLf8Aja+t
+yiWsEVy567CSB7k9vp1rntV8TXlwjfa7+RCw/wBWoKrn6D+pNJVVstxcnc9Pu9VsLFS11dwxD/aY
+V5Pq2h2er6pLc6FqOkXFy8m9ImBhcew7H9K5+11W3fVZLac7G25OTkE+1aKa1aWEyytEgnGdqg/d
+Hv74/nQqsm7cpfIkr3MdPE9tPI1lfxC3PKyOAT8wPoO/BFdZ8PU8rxOglH2lJ0fy2kGTFjkH8siv
+KtaZJdSuLu2ASNn3bMY259Pauu+GesXtx4w02FCzMWZWA6eXtOc/lmr5LtSGpaNH0OKU00EZxnmp
+O1asyRGRzRQx5oqRj84TPoK4jxJ4h0+xs57+bayR8YXBYt2H1rtmUPEynoRjivAPH8QsktLeJSkP
+2pt+O5HQ+9Z1NbIcSpqGrX+rg3WpXMkFoTlLSJyqge/qawzq+lQzRtBaKhDD5/4h759elJ4klMtn
+beXkRjqf61hRWaykLjJPqazjFSV2VKVnZHpDeOdOsPDscsMayzABNgOMt3J/nXAat4ru9UufMYCN
+B91VPSsy6tbmKXbLBIiKTtBBHHqKj8lprgBY9pOMIBiqpUYQ1RM5uWhPHfy/bEumb58jH4dKS4vL
+hrhnkYktzu9a1rbwhq12JEjsgjJF5pEj7cr7VUl0y9t1MNzDgH7p4YH6GuhNEmeZpHBLEgV23w31
+qx0C/uNUu3YOqeVEEGSM8k/pj8TXEmF4nMMmQOozVhYJIoxPCrYHDDqDVvYaPoGy1t9VnW6sr3zE
+ZeV3nPX0r0GxleWzjZ/v45+tfPfg1oZJEnsbpRcqMtCxww9vce4r3rRJ2n02N3ADY5xWPNrYbWho
+N1opG60UxDgeK8t8daXBqvnaadsc7/vImP8ACw5r05W4rL1bRYdS2yj5J0B2sP61lVjJq8d0OLs9
+T5180qTpuowmOZPlZX4z7j2qnFA1hqaxbRIv3kPXivSNbtrXM0Gu6U8xjY7JBGQQPYjmjQNM0K5u
+E/s6FpJVHImJJQfjXJ7eyehry3K1reQzWYju9NEkWOQUz/OqOm+H/Ds2oO8av55PEckn3foK9Bub
+CdLf5Io4ccZZcg/SuH1KCSKZ2urG7Eob5WjjZyfcEAAVxqrJNrVGippkluradrLhZfs7owCh1LAx
+g5BHOceuK0NR8O6PrlrEb6e2j1J8nz7eT5ZMcBscdfaubt9aluG+y6vYuLYnCyTRnK+5YdP6VvnT
+LOGNbmB7tpQuI12iQY9vzNd1OulZS3JcHY5DVPAl4UkEkygW8e5ZyMqy56Z9RTNI0VtKnWO7BG/j
+LDKsPYg4rto/DuvW4L6frEqwEZMHk7l9+GzVOHw9qF/ctGN0c23krE0Y+uM4/KtnWi1ZMlQ6mZee
+Alu9t1os32a6XkbGwCfbHQ1674KtNSsfDsFvqsiyXSjDOpzn6+9Ymg+EruzCJcSMwU535Kt/9eu4
+jQRRhBnAHerpcz+ImdugrthqKikbDUVqZio/FLub1H5VUjc1OHzUpjsTFUcYdVYe4pqW8EbbkhjU
++oUCmb8HpTg/FJ2ESkK3UAj6VHJkAnykYDp/nFJv9qXzPaloBCNkuVNrGQeuRx/Kpo4Y0GPIiQDp
+sH/1qQPjtR5ntVKwEwCAYCgfQUmFB4AH4VD5vt+tN87/AGf1qkBOzHsRUe9u5FRmb2/WonmOOn60
+NjsEz/P+FFUZZyX6frRUcw7H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0002/full/!100,100/0/default.jpg</Url><Caption>29377_0002</Caption><Caption>Canis (Vulpes) Fulvus. Desmaret. Var. Decussatus. American Cross-Fox. (v. 1, no. 2, plate 6)</Caption><Caption>Exhibit</Caption><Caption>plate 006</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23Zxg
+cfhSmBHHzorfUZp6jgU8CsbGpW+wWp620P8A37FUrm50e0yJFtgw7bB/hWuV3KR615P4tsLwa1sV
+lkaHEm2M84OcZzwOhqZuS2GrM9H0+bS9Tg86yFvKgOCVQcGrTQW0SF2jiRVGSxUAAV5X4atta0+S
+WPSLiITOS8kJ+ZSMcHJ/Hp+lU7y68WazpSXtxFPe2KyMJEiIXG08gheaFPTYTR6RceJdAt877yDj
+uq5/kKwZ/iLoq3Zigs7m5jUcyxRrgn2BIJrN8H+IvC15K0EukQWdwgyJJsODj3bkGqieK/EGqX93
+NpsbC2hJ8i1towSyg4yfWmrvcDsNH8S6dr5K2KyJIoJKTQlTgeh6frWpJECRkVieDvE0viC3uI7m
+F4ri2ID7hgnOeo7HiuikHIqrDLi1IBTFqQU0SyK5nS1tZZ5CAkaliT7V5noRPirxkdRuuI+fLRCV
+yFGM/rXZ+NJlh8KXu7PzqEGDjkkVx9nqMXhnwTbX9rF/p94ogt1dehydzfTv+VZTbckkNbG74qms
+/D1qk9kLWC9z+6AX5z655GR9apva3d9olm1hqiWFtEh+0lm2FnPO4kdc5H51zTaRearoep6mbwzX
+FuELOWJZupYZPoMYxxWZpfiW0isJLbVkaWKDDxxAn98c8KT7E5HsTUc19baDXYsXHgnU0Rr2zktt
+Qj3bnNo+W/EVs/DFTZatfWFyjR3Cx5CuMHG7PT6EVgwa9qi332rSobXTdyHKQJn5evzbic/pVew8
+V3c/jvTtRvpI2COIZZo027lweWHTjP6U4NX0L5Wlqeh6HCsHj3xCsQwjCNj/ALxAJ/UmuofrXC2n
+iXSbXWdV1TTzdXou9pI2BFBAxwWwT+VdnZ3JvrGC5KbPNXdtznH41qQaa08Via74itPD1gLi4DOx
+HyRp95qp+HPHGm+IYbjasltPbp5kkMo52f3gR1FCZJX8YWF5q00Fil2kUMmdkZwNzgE565P0ryrX
+P7ZtLmG01Od3Npt8sFs4XOOP0rq7XVrvWvFVnq8mFtUudi4YfuxtbaD6ZPWtHx/pb6vcWklpGGkj
+RlkcYwFJGMn65rNtayKe1iOO01jTvDyWNpZuy3cKvPIyhsgjlR6YB/GuOufDd0Ns0trJ5adyuOTX
+smq6zB4d0WF7jDTlVjiiHV3x0+nvXnGtaxKYd2tXsiebkmKADuOMdeKOVLS41LTYS0XQbHQp457v
+zL+ZfJ2xDcUzjj8+5rjNQis9LumDajbuVz+7jBLHj8qgka81G6Wz0ZXitQVQuRgDccAse3J616n4
+Z+EulaUVutWb7fefeKsf3an6d/xq1Fbi5meT2w8V6shTTbWYxMMAIhIxXvHhOG+g8K6dDqUZju44
+tsintgnH6YrSt9V0jzvsNtc26yL8ohXC4+gq03Wjmi1oLU81+JJml1OOJJnjC2gKlTjksc/yrjbu
+a405o57b5GurF4WI75Iz/Wuy+JM/katbebLbW8TQ8SysSW68BR/j3rhptYtjaLbR3kt0EbcgS1BA
+78Z561j73Mx3VjtPDiWWm+EGnvbgROD5uMjOQMKMfr+VWtN8f6CLI299b3ISR/MmkOCCc56Dtx0r
+gp9fhlZVuon8vG1xPb4zz1yOhrP0zRDqF9EySvLag7mDcAijVIT1Ov1HxGdcv7rXbmAvZ2/yWsJb
+bhM4yPc9T+HpXMafBe+OvEcVnaCRIVbJLHPlpnkk07xbeS+ZHpVsyBGIXanTjgV1/haHTfDHhuX7
+ZuT7UFEzRviWX/YjAGeM89uafOlq92B1Gq6Pp2g+FYNE0tEMlzcQxM4YbyxYEMfyruY40iTauT6k
+nJP1NeW6J4Zj8UNeXsRaxji+W2jJJfPUM2TwOgqm2pa34N1hY7mSZ4w2542fKyL3Iz3xWTxDi05L
+R9VqHKbnj/SDG6alCpG5wC69Y27H9K6rRr46lotneEfNLEC317/rV6OS21TTo5Qqy286BgGGQQR6
+VHBbQ2cCW9vGI4k+6o6DnNVGnyTclswvcq6x4d07XYFa7tYpbhIysUjrkpn0rg/Do/snxTBE8Kxb
+naCRMcZ7frivUoz8o+lY2p+F7XUdXtdS3PHNC4ZghwJMdMircL2a6Ana6PO/F1iZtSkgnTBlmOCV
+PC5znNYVzqNjptk8Nk4KxpggOAf16mu18Q6jDc+LZoMsDCixIdpKk9Tz+P6V514utxcF5U2ICxJX
+Iyx9vWsaND2fu3vqym76mPYq8/2vUZH3SY+UE9z3r03wNYWVxpV9dXDSz6pb2wChycKu08r+Oc//
+AF6ydI8By3PgebVjnzRBm3iHcZ+Yn646e1b/AMOLR7rV7i7UD7MtsI5Ae5fBx+hrSom5Jev5EXsy
+LSNbm0XU4rjrbS4S4XB6eo9x1/E16DrmjWviDS2hkCliu6GXGSh7EVw/ivwzJpbC4gYvZO+Dxkx5
+/pXo9sEFnCIzlAg2kdxisMJSlGMqVTZFSa3RS0azk0/RLOzl2+ZDEEbb0yKsP1qdulV2612ctlYl
+E0f3R9KlHSq6NlRipQT61aQM8dMV9eXmoXH2aZt9xIynYcj5uK4vxBZ6mJ4IHtZwgfI3Rkda+mFw
+OwoZVYcqp+ozSUbO47mf4ctPsvhjTbZ1wVtkDKfUqCf51Do+gxaJqOoPbKq292VkVR/ARnI+nOfz
+rVLyL6H6CjdIRwVH1FVYkbeW0V5aS20yho5FKkH3qLTrdrPTba2ZizRRqhJPXAqyWphb3osr3GNc
+1Ax5qRycdR+VQMeetJjQ6E/u1+lTA0UUIQ4E0hcg9qKKoBolbOOKcXOKKKTAZuJNLk0UUhkUpKrk
+VnvO+7tRRSYI/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0009/full/!100,100/0/default.jpg</Url><Caption>29377_0009</Caption><Caption>Sciurus Carolinensis. Gmelin. Carolina Grey Squirrel. (v. 1, no. 2, plate 7)</Caption><Caption>Exhibit</Caption><Caption>plate 007</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25YwO
+BUgQelKop4HNZJGhF5EZ6xof+AilFtEP+WSf98ipgKXFOwEQhQdFA/CjZU1JiiwXICntTGQelWCK
+Yw4OKLAVHjBHSqskQJ6VeIYj5gAfrmoXUZqWiky8KcBSCniqRIoopsjrFE0jnCqCSfYVzFtqXiPV
+1a706GzhtCxEX2jJLgd+KYjqTRXj2u6hr8uq3UOqyGORQPKt7aYFFycZwDnn1Na+heLtR0mNtNvo
+HvPKI2SljvCnsTg5x+FZKtHm5XoaOk0rrU9JIphFNtpvtNtHNtK71zgkGnmtDMhYVA45qy1QOOaG
+Ui0tPFMFPFJEmbqWuadYo0c8gc4wyKM/n2FZNt410UWs8EBWGa2hLx2xwC6gcBcda1G0bSrQTXb2
+iuy5kZny+O5xnpXiWruftd5q15lzcyN5SKORn7oHsBWdSco2NacIyvdiXd3e6lNMbq3hmmmnV/tE
+bhtgJ3Fc+oHFWrydNUSSOLR5pZkB3ZIbAYjaevXg1WtpH0HwokflFpJBjcy4CM33c/nn8KbFdRaD
+Eds6Sb9vmeWxyy9eTjPNYy8ilI734X+IIv7CbR72Vory0djtmOMRk8YP1yK9CV1fJUgjsR3r5qm1
+IXMkqWKOPObliefp9K9I8GeLvsmhvZ3Lma4tnVFQnBZT7/WtVV7mTXY9MaoG61KriSNXH8QzUb9a
+0bEWFqC9vorKMNITz6VMprk/G8/kwwlnVF6EscD3qHKyuIbrviCe909odNKojqTJMzDAXPTJ6ZGe
+a8s1jV7IvDYKVuFBDyTRsQEYD5dp79eeMf0TVtSlvg9raEtaBhkEffAP8vatW1OmQstszpE1zH8o
+C4w4XPHr/Kuac7e89TaGqsc1f6s9rNDb3USTWySrO6BuWT0P4HFdjr3h+HVfCkeq6TG720yiTaFA
+kUcjkd68z1mNUuJtuDuOcr39PpXSeFNZn0bXTd3d3K8LQqPLAIV02427exHHSrfK4qRLvF8rKel3
+EWjw3CvZpPIpAbzMqdvt6HOPzrQ0yeKwlScPs8yYMink7eMDP41ialdSXepXF2E8qJ2O0Y5AznpV
+fUbadZY7hnL2qKrLN2APtWMmpWvuxvR2R9O2Epn0+CRjksgOakbrWT4Svo9Q8K2FxHu2tEPvDBrW
+brXXF3ijPqTL2rivHPh661B0vbfMuyPZ5ZGcZ7gfjXaKelPBHofyolHmjYL2Z5DZeHprS2USwrFJ
+jkspJJxWfqVlaafNArSmOcrlyYywYj054+le4YDdQPxFQT6fZ3SlZ7aJweuVFc0cJJO/MX7Rdjwl
+tLsVkFxczRSBRlIlULu9z3pZdSsimVg3ry37pMgEdq9gbwp4cJYHTLbJ6/JTrbwroEEge30+FGX+
+6CBUywcpayZXtEfP9+Ybr99GohViSVkb94fw9Ko6Z4Z1fW9Ra1tLG6e3lZVeV9yhQDmvpuLRdLgc
+vFYWyOf4hGM1a2qgwq4HsK1p4dx6kuaM/SNMh0bSLawtxiOFAoqy3WpSeM1C3Wui1lYglWpAahU8
+VIDVICQGnA1GDS5qhDiik80uAKbmjNACk0wmgmmE0gEY1Cx5p7GoGPNJlIkjJKj6VIDRRQhDtxzS
+5NFFMBdxo3GiimA0k0xmNFFICF3OKpTSsG4ooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0004/full/!100,100/0/default.jpg</Url><Caption>29377_0004</Caption><Caption>Tamias Lysteri, Ray. Chipping Squirrel, Hackee, &amp;c. (v. 1, no. 2, plate 8)</Caption><Caption>Exhibit</Caption><Caption>plate 008</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21RTg
+pzzjHalUU41nYoTFLtppkVRkkAeppn2uHeE8xcnoM0mhXJsUbaAwIyDxS5zQkK4m2l20U4DmqsFx
+u2jbT8UhFFhkTK2Plxn3ppU4561NTSKLAVyvNFSEc0VNhjwOKjllWNGdmAVRkn0qXoM1wXiDXJLI
+3SIMowORnGfpVoTNTVdZiliRLdldWY7s8YxWU15cS3StBIylR6DH51wN1rdxdBl2rGnQKGwc+tRw
+alccSJcEFFA8vdwVHaspTVyeVnrkGsR6bp2btvujPBGTW3Z3Ud1bpPE2UcZBNeLpdz60igRkFGxt
+ZuleneG7uKaxFuieW8GFZQc/jVRfQTTR0YanA1CtSCtAQ/OaWkFLigoSmmn000DIj1oocfNRUjHS
+sywOyjcwUkD1r571PX3fW5nmh8phJuCFtynnpX0G+fJfHXaa+YvEEsb6zPvlCqHPOMg80mwCeJrm
+9ae0uX+ZixSRvmXPbB4I+lEd1NBOY5IwzHJyeA1QxQJPE2y43MOqqp+UfX06UJa+RY/amm8yPzCj
+KR0rKWmo1rozdsvEVlZLvFrJNcHgqn3V/E1o2fxJuLC5MkWnSIp+8AwbP6CqPh2C0mieUhdg5/Ct
+X7NpF2CWIRiPUfyrndZplciOg074rQXJ2yGGNv7svyH+eK6ODx1Zuyqzx5PdWryl/Cdnf3fl20ys
+BycHkVp2vhGDTbmI/bJdgOJMvhfYVosRFaMPZ32PTpfGNpCm4oXH+zT7Pxnp96uY87x1QnkV5le2
+Udmkjx3jFwmI44ZC4Lf7WePyrFkbV2PmC2fdjhkGD+lbQqKSuJxse5rr8JbBXrWjBOtxHvTpXj2i
+axdxyFNTkkwOE3SDI+temeGr6K+0xpIVYKHK5bv71ald2JaNVutFDdaKYhDzGR6ivmnXdHdPENzb
+zjZIJjtIHUE19KqeK5Lxb4QTWJUvbfC3CAhgFHzVMr20GeGaTbXFwWt7faxfP3uAAPWpYRIZZNP3
+MrOSCq5KvWtfaLqPhqWa+awcHJK4yBGO5PUHP6YrIHiNVkjvRaxi7jY7to+Qr2x3z0Fc05Tvorr9
+R6GhbM9naPZOjhGOWMRAOfxzWQ1tfBn/ANIlCk9e5+tNfW578ktcKjM2SqripXvL2JB5boyofukA
+800rO9g3LGk32oaNdmeMtJkYZW7irr6lPdwSrLcTJvbcU2gg/jWUPEDI6rPbDj7xU1ftL+xuhv3g
+eobqKbSveSKTaVkWrDXWtHSK6j3RMwUSDgD6iu6mijjsw8hDJjJ28ivMr7VdNNs6RyIxIwOOppLT
+xdNb262+CygdNvWlNPRxRUUup2t/BbG3WaGSPy26FWr03we8b+HYDGcjofrXgGmaZrPiK5C2NlKX
+b70ijav59K+gvC+kPoPh62sJZN8qLl2/2jya1pppkTNcnmio2bBorUgRG4p+/wBiaqoTipQxpXGS
+PHFOjJLErqwwVdQQRWW/hPw7J97RLA85/wCPdR/StIMaduNSwsYFx4H8LSId+jWwB/uJg/pWHP8A
+C3wlIjBY7uDcc5jlYfzruyTik69alWEef2/wo8LQFt819NntI+f5LTh8IvCc0hZVux6jeR/MV3oA
+HQAfhS5NWgOJh+EXhCFg32KVyP70xrY0/wAC+G9Mffb6ZDuxjLjd/Ot7JpCTVDCNIbdAkUSxqOAE
+TAH5Upfimk1ExNFwB3+aiq7sd1FTcdj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0047/full/!100,100/0/default.jpg</Url><Caption>29377_0047</Caption><Caption>Spermophilus Parryi, Richardson. Parry's Marmot Squirrel. (v. 1, no. 2, plate 9)</Caption><Caption>Exhibit</Caption><Caption>plate 009</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xV4p
+4WlQcU/FIBmyjZTwOevFLigZHspdlPxS0CG7KNlPooAZspClS4pCMj0pgRFKjZMVYC4GCcn1pjCg
+CsV56UVJiilYdyZRxTsULTxQwGUVz934hjtL9oJJAnP8RyP/AK1XY9btGUebIEJ6Ecg1HOOxp54p
+NwqkdTsycCdWPoCKrXWv6fZsizTBWc4UdSaOdCsa4YZpc1xCeNZBPcP9iL26AbcNtbHr71q23i6x
+mhieSOaHzBn5l4GOvNCqRY+VnR0VxWt+P7awaL7HsnU4LsTxj2I71ynifxtPc3e+zu3S3Qhoth2k
+/Ud6rmQcp7BimMK5Twf4kvNY8uO6aNyYd5YDBzn0rrSKadwasQkc0U/FFFxCrUnY1GnSng0PYEeS
+69JPcapdmIWzlWKngHB+tZUS6mYxDG0fyHOFJwP1qr8QtOu9J8V3E1usixXLeYCuQGz1H51g22tX
+6eWTezBE5ZiCQMdveuSV+hrdHYvcarAgV54ATwCw6fjxWZ5epae4lSWIk8qWbv69ea4rXpL7U/8A
+TjOzRFtobOOcZxj+lVNOuXtHYuHlGAcZwDjsfao5ZtXbDS56lPf6nqxKlooNowU2MAT3+YDpRF9o
+t7IQX99I0a58tY2XYvJ9cc81yOl+Kprq/KX0vlpIfldVyAT0B9qZf2VjeapE6a8biMo0jqxKlCOo
+9PX8qShNvXQpWN59LN75kUM6rbwpvcPgkD65Peuba7CTzxKv7qNcln5CjAxz9apwahqNrHNb2jFr
+ecMoP3iQCPy6Co2+1a9qrTOivKQqhUXA4GBgfQV1U48qs2Jns/wmaW9sbm+mdGwfKTCbSAK9GauR
++G+k3Oj+Fo4LuIxSs5YqTXXN0rWOxlLcjJoppPNFAhUPFSA1XQ8VKDTEZXiPw5aeIrExTKolUfJJ
+jla8xufhfrNuJI7aG3niOdreYFbFex5PYj8qcGOOaylSUilKx4Sfh94ghCiLSJWdfvb5Yyp+nNUr
+vwF4kSRmOiysuOPJYE5/OvoLdSGVQcFgD7moWHS6lOoz54tPBnixyqR6RLHHnJV4wvbqc9a1IfhP
+r11teW3gtyOArOOn4Gvc/OT++v505XDDIOfpV+y8xc7PHrP4U6o2wzm3hdHHKncGX/P8q7LQvh1p
+ekyieb/SJu5YYGfpXYbjSEnsaappA5scAFUKowB0FNY0ZPc0xjWhAwnmio2PNFACI2BUm73qpG5w
+KfvOaALO6l3VX3HGaN5xQBY3Uh2v94A/UVXLmjzDQBMsSKScD8qkBA6VW8w07caALOaN1Vw5oLGg
+CYtUbPTCT61G7GgAZ+aKrPIQ2KKVx2P/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0010/full/!100,100/0/default.jpg</Url><Caption>29377_0010</Caption><Caption>Scallops Aqualicus, Linn. Common American Shrew Mole. (v. 1, no. 2, plate 10)</Caption><Caption>Exhibit</Caption><Caption>plate 010</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F4p
+64IyP5UqDinEVNhjdtG2lFBNFhBtowKMmjnNFgFwKD9K4/xx4yg8P6e8FrcIdUcApGFLbR6nHT8a
+5nwV8RbrVtSjs9RMaSE/fzgMv+NK6vYLPc9VoqrcanY2kJlnu4UQDOS4rlriy/t1W1G4u7mC16oY
+5iox04FU7AjsuKijlinBMbBgCQSOma5C4t3trbbHe3TQtgYupSyfiQc1oWeoaZoGllElSZ8tI62y
+7hnjPsO3U0hm8RzRRBKLi3imClRIgYK3UZGcGipGWE6U49KROlOxVoQ3FG2nAUuKLkjCMVxnxA8X
+nw3p8dtZlTqNz/q8/wDLNe7H+Qrrb+9t9Ospru6kEcMSl3Y9gK+btV1W68U+I7jU5A2122xof4Ix
+0H+fes6k+VFRV2TWyteTtJcsZJJiWeV2yWPuaik0uJyZy5VgOAvFS3ayxbFiUBicYHb/AD/WtCDw
+zfTRC4nuTbIw4XGSx9hXJG+5u7HOufLdvOcyKvTLV2/hzUtY1nyftt1KmmWpBjCqPnYDgDpmo45f
+DvhK3cG3/tHVJByJcHZ+HIH86y28Y6pHKGFrarEnKxhMAfrW6uS/I9QN7mJY4rdRGowTISSfxqrb
+28L3qIC+x3y8KyfIfrWN4Y8QXniewuEuUUyQHcWUAcYNXtOdhrEMcIGSwq3czeh6LgAAADHtRS9K
+KsQ9OlRTXIibHGaqaxq8OiaY95MrMoIUKvcn37CvKdT8a6ve6gZIbpbMrnZGsasMe7HvUymluUot
+nq0uoyDopC+oA4/OuO1H4m6fYXcsC/aLgx8fuwME+gNcqdV8W+J7UQC6treAAq7qNpcepHJz7Csy
+/wDBmqadam5+S4hRS5MeQQAMk4PWs3Nv4R8q6lLxV4y1fxRL5Eqm3sA2RCDncf8AaPeqGntskIKh
+CRwWP9QKgdmkC4+WTGSG4JrU02FQfPKh3IxXPObe5aVjovD+lfaLtbmYhoo+RjkE1eu759Sv5rKz
+k8qeMbRIQCsYOf1wCfwrNu5ruHTozA0iW5+UJCw3AerH19qzodWltNOcWtuBJOjI88hyxOMEj9aI
+aDauYNrbtcXjAEvI8m3cf4uetaOo6dPAzh1xt9as6HbO+rWkcUZ8zIx7Ht+tdF4ku7W41ea0jsTK
+qEI0qy7QzdzjB75rVXfvBdLQxvDGpQab4VvPInEd3LMRLkjIUAcD1z/jW94Tiu1vLSe4dzJJNuAP
+UKexrLh8NQSXWyCLywcFyzZ2/jjrXo3hjTmjYMYNkcIAQlccY7VfM5S0IlZKx1JHNFDdaK2MyveW
+cGo2MtrcoJIZFwymvHtd0lbS9kttNkhuwgOQVJaLHuK9mXDLg9CMVxOq+GLuC4kOnJ+7l5dic5z2
+xWNZabFxk0zye2ub2wvlMEk0ew4OOhzwcity5u79o1kmvJZAThYQdqsfcCrt3pMdrcgzMHYt8y57
+579+tPjhe8kSSKAFY8osjZ2rzztHc9vwrkqTaRpFq+qMm40sy2kkt55aFwNgz0b1Hep9Mt102Eta
+xM8n/PWQ/wAs1qanbwWNuZHYyT5GDJk1Qi1ryFB+xR3BJwBKxA/IVjGbexMnc0prlHsRMkULRjIu
+Bs53ep+v9K5XXWu0t47lY4VtmbYqqenbpXSx64YraSO10eBJ5x80cLb847kbffue9Y/9i6hqMAS+
+u4rWAvnyY13N+QrVzSady4pKOpe0sNpY8m23TanKAHYdIQf681oW1glgV8/LuTk+q9+afDE1uzWl
+pBtJXdv6vLwck06fR9cumjtoYzG3LB2yOOnT/Gn7WU3aOxnbqaFu5MwhTyopWOUXt+ld9pYlWwQT
+OHfuQK4/w14QuYJ4r3U5xJNGeFHTpj/P0ruSQBgV10aclrIhsax5oqNm5orawgRuKdv7YNVkc4qQ
+OaLjM+Tw1pstw05iKljuKg8Z9amt9Ds7eMIoJUdAQOKubzRvNZuEXug1MG/8E6bfSI5kmjCj7iH5
+T9RWbN8P9MeFI5J5tqd9oGT+FdhvNG81HsKXYV2c1aeE7C0VcXUpwMcqOfr61px6FZSDEgkYjuV2
+/wAq0QcEkCnbzSWGo78o+aXcr22jWFo++GHB9zn+dXvlXoAKi3nFNLmt4xjHRITu9yUvjtmozJnP
+BFMLmmM5qrgDPzRVdmO6ip5h2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0006/full/!100,100/0/default.jpg</Url><Caption>29377_0006</Caption><Caption>Lepus Americanus. Erxleben. Northern Hare, summer, natural size. (v. 1, no. 3, plate 11)</Caption><Caption>Exhibit</Caption><Caption>plate 011</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UHp
+TlXJPy4pyipAKkYwIKNgqSmk1LGJsFO2ik3Um+gQ7aKMCqGpXk0Foz2oR5UZSUb+Jc8ge+M1Pa3c
+V3bpPC2UcccYI9j70+thljApMUZozVCGtkAkKWPoKaMkZKlfY1KKCOKTGVWHNFSMvNFSMeoqUCmJ
+TieKpiQjGm5BpjybagEpznNTYCwy5/iIqBoT/wA9Cfwpr3BABPFR/aRuGDTsIiuIDvDZbOOtc8mr
+vpertatvWKQ78nlc45/ofx9q6liz88geuOtNWwjll8wwoGXo7DLD8e1J7jQxL9igOAQR1qdLtWHP
+Wp/swVcFqyy8b3bwEBZFGQexq0wsX7WczFyTjYxXH5H+tW+1Y6xLa3kUqsUD/u3TPBJ6HH+eta6n
+igCNutFKetFTYB6013A7inL0rJvUleQmPOaYEtxdQqCTMgx1ywFV/NkeMyAqsQ/jY4FYt1p8oO6V
+hg+vY1qxz6ffwPY3wEhIBMTDPQdqUmBaFrIy+YXEgxkKvf8AGse2m025vQ906PIjYjRX3Rxn3IPJ
++takLK7G0t0eKBI8DPGPpTo9LtNOiESySSN1AYj+gFZPUZp7lSMNw5PTHelJ2lVJG484qC2t2WOP
+cBhTkADpUd5fwWcpaY7SehJ4q0BblIjiLMe1cve6pZacJL67mCqRhFHLMfYd6ZqniI712QyTQ4yd
+vyjHrk15t418QW99dWsFiMyRg73OBtB7cZp8y6FJdzrR8RLHUb61gj2rEjglpWCbiOn059a7zTL0
+30JcwtHj1IIP0I6189xaXFc23BPXLH0r1v4Z2NxYaJNHNIzR7xsDHOOKFJbA0dmRzRSnrRTIAH5D
+9K8r1vxnqtpfzRxJFFsbaMgkkZ/nXqSHiuT8R+FYr6VriNQHbk1E20roaPO7nxbq+oIwlu2jJH3V
+XAxVP+1b+91BI7nVHt41yTITjGPp3p+raVLb74kU8cfdyKzoLMR3UIvWYw5HmFV+bbnnHviudzb6
+lWPWPC/iSyvv3QuklvIMLMSdu9f7wz1963RrelrdOJLhTITgYBxj69K8pMtitmf7FiuEnY4UlAB1
+/M8D+dYjS3k5dbnUJmdOiFsZrOFWV7MqSiey6j4002yHl/aEEnYD/Csy81WN4HvtryPHEJQ+cIC3
+3QfTj1ryswyqV2BgxGee9XcS/ZjB5vynBZVJxn1rXnbJWhveMdXup7kQthItiZ2DALY5/WuRW3Ec
+jY2ncc7uv61onTr2+uo4ds0k0hCo0jcH862T8PtUSRIo543cEeYqdEB9z9K0imNsyNPtZJpgigk+
+le1aJbC00qGPbtO0ZrmNM8IR2s48mWSRkI3M/AB7445rtR8qBR2FXGLvdktiE80UwtzRVkhG/FSb
+h0IzVVDxUgY0ARXGmWd0cyRAmsjUvClrcRsYY4w2OBjGT9a3Sxo3HFRKnF7od2eff8K/vZHZhIkB
+xwVuDkH8FqCfwFrtxOHOpWG1U2qHTzCf94sCSfxr0csaT8KlUYRVkHMzy1Phrrccob7bYuu7OMsv
+9K34PAl2YzG2oW9tEcEi3iJf8ZCc/lj6V2SjBNOziqVOIcxQ0vw9Y6VbCOFf3n8cp+831NaXlRZy
+EAPfHembjS5NaWSFckLBRgD8hTC+RTCxpjMaAFL80VAzHNFTcqx//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0018/full/!100,100/0/default.jpg</Url><Caption>29377_0018</Caption><Caption>Lepus Americanus, Erxleben. Northern Hare, winter. (v. 1, no. 3, plate 12)</Caption><Caption>Exhibit</Caption><Caption>plate 012</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24Djp
+T9lC8UrMBioGG2l2ikDDmqkuoxq7JGrSMvXA4FRJqKuxXLlG2olm3clWX3OOaeZACOetUkK47FKQ
+BWfqesWmkWhubt2WMf3VLE/gKwrH4keGtQfYl95UmcBJ0KbvoTx+tVoFzrKUgVnR6tBK4VTlT/EC
+OKvb+cdqSalsO47AqNgc42nHrxTgwzS5BFNoLldhzRUjDmipsUSAfLVC71CC2ikkmkWOKPDMzHAF
+aAOEzXkHxE1oT3x06IO9tGQ8u3ufTHcUNisaWrfF3T7OQxWNnNebTgyF/LU/TIJP5VNonxT0nV5l
+tpEeyuW4CSkFWPoGFec6ppcbhZYDujkXcpArl7m0kgk3BWG053AdKzU+YcoWPpD+1TdQMsLBZVI2
+5PT3ojvHjiCPMWdGAY9+a8o0zWWlggmjmLTGMbgD0Ydc1bPiOeLUI3fhR97PQ1nze9fqYts9I1LU
+LS/sZ7eREkyuCu7HPsa8e8R6faCbYlmbV0UF1DA5z06V0Gq69ZeQk1nGwlY/M4IAX8utZAuobu8k
+nu1kLOgUOoyB17f1pwlN6yLi1scY/wBoilJgklTH8QYirFp4m8QaZJut9XvUI7GZiv5HitHVh9jn
+DhQ0L8pjkEVi3O118wKFDdAK6ou5Vj0zwl8Vbu6vYrLWfL+chVuFGOf9of1r1zT7tbtCynO3r9a+
+SlJVgw6g9q+jvhxqg1LRlZ23TGNS/ueh/UUNCaOxI5opxHNFSUOAyhFeEeIbSa48SX6bHQlS4T+9
+jjivdl6V5Z4vvbePX1BHkXUbfu2xnOeoI9DUT0BGFpekTw6QlvcDGCSFbtzWff2DxxvBJGvzNkBe
+crXRNrduX2zphtvROmfaoMwa5CrIsaJFKM/aOAR3HrXM3rqUc1a6EXglaIbCrfLg7SB71XvLNrdo
+czmVmznb/wDXrp5ptLS6FnaRq0gYFzEgBC+3pWT4mlht9Ut4ot3lLFu55OSef5ClCbbsTJJmRcGC
+OIoI3DgbiWP+Bq3ptnJfWxe3Eiyj78ak/gfpUUUE2qXyQ27IsqqxYuOMCun0aJdKBjkeLzCNrMDn
+P+fetedoXKjno9AubpnhkSQLgn5uxx1rnNRtTZxQKc5ZMn8zXdazHbrdBotOvprhmz5sI2qf908/
+yFVJvD95ri7JbVrNRuYMSCdxx19uvQCtI1Nbsq2h5+AQOtfQ/wAKbFbfwnBcFf3ko5Ptk4rxK88O
+T6ZeRRXcsYjkcKJEOR15r6D8FG2i0YW1vKZPJAUn04rZyTtYlnRN1opG60VIBGeK8v8AiLaTJr0F
+xFJGqOmGJ6gj/GvTozxXJeKfDC6tced85BAyM8ZqZxurAeOyWuo3MscESjdIpOSdoA//AFVUb7fG
+j2kClSjbXwcEE16PeeFbppYJoo9rxAL1wCB0qtH4XvFkdpII23KV+5z9SfWuW0l0HdHFW2l3Ni4m
+WeSOYgFieRmr0N1FcyKl00UrtyMkHbXT3vhW6uGwokQP97HYYxWfH4QmspJGjmlVnABCjFRySevU
+TkjPW0gu7tlslMsigM8kZOEP1xVpNU0/S5j5gkedyCyyL8oI7+tPtfCd7b3DyQySgvyTuwaS48EX
+N3OJZiXPfc3NaeyctGxqYsHiq+utogUlS21Y1HHPSl1X+1UsHuLm8gUyAAqjfpUy+DntrbapZckE
+gPjp9Kp3mhlI/mJC/wDXQk1UKCRXOctc6ib+B4pFYlMbWLdMGvXPhEJDodzJISWZxyTnPFcJp/g/
+UdRcIkUiw5+8xwTXs3hvRU0LR47VRhur+5rojG2iJbNYnmimM3NFUIRG4FSbvbNUonJAqcMaVwJw
+FPVRRtT+6PyqLJoDGkwJSqEY2iq8lpAxyYFYU/caNxpWQEKQQZwtuBUyW8JHzRKD+dJuNLuNUhWB
+7O2cYaJSPpUK6VYI24Wse71IzU280m40xjlVIxhEVR7cUpbjmo2Y00saLgBYZoqu7HdRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0020/full/!100,100/0/default.jpg</Url><Caption>29377_0020</Caption><Caption>Fiber Zibethicus, Cuvier. Musk-Rat, Musquash. (v. 1, no. 3, plate 13)</Caption><Caption>Exhibit</Caption><Caption>plate 013</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EIKc
+qnHIApyisjxPrA0TQ57pSPOI2xA92Pf8Ov4Vm3ZXLLtxqNjaSLHc3cETt0V5ACfzq2u1gCpBB5BF
+fP09rc6gbi/mfcR80k9y+CxPYD+ldZoGvvotvbwzXLb4clkHIaPAJ79sg/QGsFiE3YrlPS7vUrGx
+kWO5uI43boCasqFdQykFSMgjvXkHi3VLS/19JGu3iWSIdAdpHI7c5r0DwxLeW2g+ZetG9okYkglU
+5YpjPIpwquU7W0Bo3ytRlK871H4jXYwlvFFG8pxEpGSB6k9K9CtJTPYwTE5MkasfxFVTrRqO0RON
+iIhy2DHhfXIqtNH8wxWiwqtKORWrQkXRUDLa3xlhYI7p8rBhkrmrAqjf27xyLqFspM0Yw6D/AJaJ
+3H19KVrqzA5rxF4Zdo4JIDDFBE5abjbldpA6D1IrgdRspYr8WMMMjJLlQ4jAYrgAnBPv616X4t1W
+P/hGGe2kDNdFViHfIIJ49sciuX0PT3ZJZrwia4D4DtkkEn0PSuCpFUpLlRondamRa50iBotT043J
+jIMdy0QZU9zjOO3tWzoOrXy40eV/PsrmHZEMhTGCMfKcc4P860bW6gttXudLvrfzQ0YchVwMHjB/
+WoJ9PTR7j7TpaRtHbAvAZjlVyASMcf7VLnlGW9rbjsc14q8Danp1zbvaJNewFMu8UZyhB6cE12Xg
+LVbm4t3sruR2aJRs8zO7HTv/ACpll8UNJkt1N3FcJIPvskeV+vriumOu6ULIXgu4PLMXmqNwDFcZ
+6da6YKF04vQmUZL4kX2FV5OorjvDni+78ReK5bNGRbWCFpJFRc4JICqW9evTH6V2cg5FbxkpK6IL
+QqtqGpWml2pubyYRRAgbiCeT9KnLBFLHOBzwM15D4ys4tS1H7fJcC7iZj5Yt5MlAOgPp0zxWVar7
+ON7Alc7O5vtPiunvbNo5YcFjlVZVc45HOQTTLCaS8W9uLR4UYlJGxyGPp7H/ABrg9B0yeaJdRVCy
+yyiPCksF2gnknkdq6G51BrMQyWT/AGeXymaRmyVmIY/KR6gkYNcKrNz992RoloF/4Q1Sa6fXIr2Q
+Xu3eYwgUk8ZXnggdq56412W60vUIZpDDcKAjxEYBX1AP1NdGnxMMsXlahp3kFX2vNHKCn1wecV5r
+cW899epcSTARy43MhySCc4q61Om7NM0jN7yPVvCXhLTTon2y7hjuI7uNXCuvKnnofyritfu76wa4
+SS2FsHZlUMuTgdgPQcVoWnxJ1C30tJLXS4FsbTbApdyT6bsf56110VvZePtCVrh3W5iPXAGwnrgD
+scfpRNRklCG6/Ezcm22znvhddWEFxLam2UXdwDItyvRgMZXoMHv+delyda4bwx4GuPD3iMyysk1m
+FZ4XXqrnjBH0Jrun610Ydz5LTWpDLC15j8SLqzW/isY7eGOVU8+acKoZVz64zXpq9K8w+KGlQ3M0
+d+kp84IIXRVIPU4PuOcUsTd09BLci8H2az6bJqckEr2yhmhbzCrddq8A8/iO1Z+rteanPZWOnWEr
++Wxdwp+Y568Dt0rqdBk0nQ/D1s15PIJVByVR9o3c7cd/8a4rXrwax4hSTw8tyZgwy0aspDdCc/wj
+Fc3s1GMe5rFc1zZ0jS9Dsrm8m1O4tYZJYHhMVwMtC4I5O4ZGfUcdfWudg8PXmoXNzHpogmghy/yT
+Lggc/Lg5/T8qW8m1fTZWkugyz4wRdQkE4wQQwxnoOea7fwLrugX1vJevDp2nanCvlTZVY9w9R04O
+P0q4JSaTdrClBrVHH6Zo81h9rsNes7iysbr50mhUOvIOCD09D1zXo3gnSBpsVw8d/DeQybQropVh
+jswPQ4xxWtotxb3VrNZb4J0gbapRw6tGfu8/TI/CsO8gHhXxDBe25Eem3TCOePOFXJwDj2JB+m70
+FaqnCLUkiH2OwaoH61YPSq7jJrdiLC1ja1oel3FvcXVxYxyOqFmbcyk4GexGa2FpxAdSrAEEYIPe
+hq6A8EW2inIaRGw5JAyfw966DS/DaXWmvci9mgk88Bd3zhsY6/xDHsa9D1rw5Bq/2bD+T5GR8q9V
+OOP0rB8TaBc6XptteaOrS/ZFcTxE/NKjEEn6gjNcCoVqcm73RV0c5qt94i8PxtYa1bNcWUuY1nB3
+rzxwxHX2bHTrWN4R0zSIb2a51S2F0u8IGK7o9p4IwOVcdeeozXsP2S18RaHb/boHaOaEFo2YqeRy
+Dg1514h8Maj4VvodQ0f97ZoBGodjmP5sqH/vLuxg9v1rrlT+0hxk1oLr9tH4D1yy1PQSy2t0pMkA
+bdHIB2/I8Guu8QTW+ueCGvoFV0eNZY93bPBH15IrkLiZfE+i7LVVhngmG61lP/HvMeCuf7j849Dx
+340VM+ifDRFugQ8r+YqJ82FJ3gfoPzqFFxbS2Lk+aKb3Ov8ADl62o+GtOu3+/LbozfXHP61ebrVH
+w/aNp/hzTrRh80Vuit9cDP61eauhIxJVp4qMGly3qPypoCUUvXg0wGlLEDgZqhD+nApk0STxPFKg
+eNwVZSOCKaZWx/qzTTK+OIzQM8f1G2Xwt4zjQ7jbswhl55kgk6E+6nv7VrXRbVdd0Xw7K7kWUzGf
+sHVTuGfqoX/vqvRZ7O1vFzc2sUhIx86BuKjGn2aXjXi20YuCADIF56Y6/So5SuYsHgVETzTmJ7kf
+lULHmrsSTAnNOBooqRjsmlyaKKYgyaMmiimAmTTCTRRSAiYmoGY5oopDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0046/full/!100,100/0/default.jpg</Url><Caption>29377_0046</Caption><Caption>Sciurus Hudsonius, Pennant. Hudson's Bay Squirrel, Chickaree Red Squirrel. (v. 1, no. 3, plate 14)</Caption><Caption>Exhibit</Caption><Caption>plate 014</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD23aAM
+npUioKVRUgFSMbtpdlPApcUAM2CkKVR1zXbLQNOe7vJAAOEQfec+gri/C/izWdf8WKjqEsijMYVX
+hFxwSfXOKTktilFtXPQSlMKCrBFebat4gufDPiyM3k8r2jI8WHYkAkZRvzwPzobsCVzuWMZYqGXd
+6ZqFoxmsbwZrF5r2mXN7dMhQXDRQ7Vx8q4GT9Tmt9hzTTBouKKeBUZdY0Z3YKqjJJOABXn2r/EfU
+tKv50bRYxaBiIZJJSplUfxDjoalyS3CMXLY9DmmitoWmnlSKJBlndsAD3Ncjf/Evw9bmWKKSW6ZQ
+RmJPlJ+p/nXmOueLNZ8WkLcuLawU5EMfAPue5rn7abypZnjA8qPH3uQxHrUOpfRGypWV5G9KLvVb
+zz7hZXU8xozEgD6nrXq3gez07T9FkuEkH2g83LuMbMdvoK8/Pj6HxPYW9hc6OtuY2CyX0ZOyEeqq
+B19s1rWFxZabbarBb6qL1ri2YRlAfbOQeByQOCfvVneUJ3ewpS5lY72x8VaPqVwYLa73Pu2jKEAn
+2OMVheP9Miu4baSSIOrHy8Y79V/r+dccfDWt2vlx3t7aafC7Ap506q31OOTj8K7XX0Fr4Os41u2v
+HWaIefv3GQ55OefeqjOUk+ZEKyehzfwl1Ao2saHIfmgm86MH+63B/UD869IYc14/4DJi+LN+iH5Z
+LZy3/fQr2JutbR2FLcknkMVrLIImlKqSEUZLe1eK+J4vEeutJfXdlOqW4O1TEFSNevHc/U17ctYv
+iXxBaaLpV1JPDJLtTbtEZ2ktwAWPFRJJrUcXZ6Hg0zLFbhXfhuu2naN4d1LxfefY9JhWO3iI8yZz
+hE9ye59qTR9EvPF2uRadYArCmDNNjhF7n/CvorR9Is9D0yGwsYhHDEuOOrHuT6k1FKnbUupUucjp
+/wALbCy0lLM31wZBliyhdpc/xEEHPp9KpSeF5LABtVgWRbeQSw3ML7U4IJ3J2OBjgf416RJv2HYQ
+G7ZHFctrt/bXqf2JqVvJGLoeWJ4zuVHPC5xzgmipyp+Zkm9zlNd8XRXzeVHbWV3ayxgx+chUq2cF
+SQcjtz71zEU8yXtutv50cAk3z6ezbtuOA6NxuH154qzqOgHRryWx+02VxdxxAGMRsNy44Jx/FVax
+uZItKuLq5il3QQmOGU8gDOSM/jXIpSdVpmmljR+GsZvviNrF+gPlwwFM+7Nx/I1663WuA+DtiIfC
+tzqDD95e3LNn/ZXgfru/Ou/brXoR2M5PUnQ1Bqml2mtabNYX0XmW8oAZc46HIOfqBUq1KDTsSZ2h
++H9M8O2httMtlhRjlj1Zj6knk1q5wM0grlr3x1Z6drk2m3NvIBGVHmqc5yAc4x2z61E6kYL3nYdr
+lbxNrWpQ6dPOiS2MOdiSPgEn2HPvXD6Bouq3+pI8M0sGTy/8WPU5z6d673xZbPrdnAlhfpuZfOij
+2hlkx/8Arrj5PGF74ftLrSr+xW0nkQrHNFHtB7Z9fXmvPq05SqXctDSNrbalvXktrpZ0WZZtRlUv
+cxxKdzlAOQ44GAM4rjdalFt4NiiOd0pLD1roPDk1vNputaqHYSQoLa3KtjrwfzyK5Pxy7wJb2ZY4
+Kgqo/h9q1ik3fuN6Hr/w4tmtfh9pKMMM0RfH+8xNdGx5qn4dQR+FtKQAACziGB/uCrbHmu2LurmT
+J1qQVEhzUoqhGd4gvjp+jTXAleErjEipv2+5HpXj2py3VxqUepzt9pjIyZbZd27AODg9O2fpXumA
+wIIBB6g14/8AEbRrXTdRhn0+0ksWfJaWI/JIe2F6AjnP1rmr04yV5FxdiTSPFVpPp9mkk6RXsEzB
+FI2jDtwFHoAWzn2rS8T+FbnxJepOJIoo1YRD+JnXu3XA71wgn1G607deaZFeWoYDzUASQ89R3NS6
+d4kuNOMtva6jOoX7tpej7p6dcZrOMF0KXkO06BrXUptItpN1s1+cEnOQg/8A1flWdru7WfGUNjbn
+JMgQZ6Ve8N/aRcXep3QTfGhA2HHXnP61zMUsjaqbrG5w3Q98mko2uxu9j6V0yw/szS4bPzTII1wC
+ew9KlbrWL4Q1K51TRhNclnZcKJMYVsDBwe/PetputdkEuXQye5KhqYVAtSq3tViJBVTVXEenSsYh
+K2MIhXdljwOKtZpDJt/hY/QUmroZw+pabFo2krf6gGaQEs7DkR+igep6Zry3xBNLrgWR/JiZMeXG
+iAHk+vU8V9B3CW1yFE8IkC8gOuR+VYtz4S0O5jjX7FtCyB9yLgkgEAZ9Oa5/Y2d4lJnl1/AujeFI
+oVI3zDc/qay/CPgq/wDE4eeAm3tFJDXD/wATf3VHf3Nex6t4K0nV4UinEqqnTy2wf5VsWlpb6bZR
+WlpEI4YlCoi9gKuNPuNz7BaWsdjYwWkIxHDGsaj2AxQx5p7PnqMVAzfNWuxmSqxp+8gE0UUARNcu
+B0FIl1I3ULRRQA8TuT0FSeY3tRRSGG40xmOKKKYELMaiJOaKKYj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0013/full/!100,100/0/default.jpg</Url><Caption>29377_0013</Caption><Caption>Pteromys Origonensis, Bachman. Oregon Flying Squirrel. (v. 1, no. 3, plate 15)</Caption><Caption>Exhibit</Caption><Caption>plate 015</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29RTw
+tCioNRuhp+nXF4IjIYkLbVHLe1RYZY20hKg4LAH0JrwzUPjFrcsrxfZ7e0U8ABSWH4k+tcVe+JL/
+AFC/N215IZgeH3kcVnKVnsB9TlowCTIoA681E97Zxkh7qBSOoMgGK+UW17UriUAXEkjEjqxJY1Kb
++aU7rmUptypAbBz7+1T7RroFj6jXWNLZwi6jalj0AlXP86tJPBIcRzRv/usDXyIbgxTLLHccKcjL
+c9a7jw9r01uzE3L7eoKvWqYWPofaDRtrx248YXK2jKLh0fbgPk1wUvjvxJbXj/Z9XuVHoWyPyNNO
+47H09tphWvB/CvxY1z7dbWurSQ3VsWw7umHA9cj0r2/S9RtdW0+O7s23QPkKfpTaESlOaKkI5oqb
+DJVFcV438VSaWWsrdMybNxOeuewrtk6V5B8UppH1cxFUVFUfOB8x46UptpaAkeX6zdTXkMhvYVE5
+kzG4HYnkVRh092t0mlfYnTPp6k/rVq+ZHdUXhwMZJz+vtSWSm5uFQcIOAThg3v8AWoblJAkkWIrT
+7QUht0bYv/LVE6/jTLnRFhYnZK2GAJfPU+/SutjEFtbRwoCoQggD+M+v61i+IdQD3NoAwUSbTtA6
+Lnv6miNlohMy5dF2W+4xbix4459PzrMa3ltmWSJpFfPUcYNemWGnX186bv3EIXaHUcueDkf41U13
+TbaBiZmeXAySTnb6/TtVqSGrnEJqV0/7u6fcuOGzVaa3kM4CAknkY71PeW7Pcv8AZkYqBnAOfx/n
+Rp8ssmYU2lvvKxHI9q0QytHuSZpU+Xg59K95+DlxdyaFdwTurQxSDYO4J6/hXijWyh3ZnwDj5SOv
+vXrHwZcJNfwNz8oZOe2eeKZJ6yRzRSnrRUgSr0rxv4hSC91zyIQsgY4Yc9MYz+dexZ2xk+grx63a
+FPE+sSXqGUR43vuGI92T/hUyVxo8u1GZbd5LeGIGQDYzjnHrVnRoz9oiHKs3XPTHrn8RXUazb2Vr
+qEL21qvlS9XKE456578Vg6jefaZbea3ICQhxuP8AwEfzBqOmgzo7ayl1O4vbRYkWGKEM7g9CcY5+
+meK5S7RBr8AnfzIo5QuOwA6/zFdTp9v4iFkFttsX2t98pZMnnp19BiuN1xZLfUJYmjYZQDc3Gec5
+/Woi7uwmj3ZpLZ7K3EABhMS7djY56flXm3ieQ2s1xHCgBfLEkffOeazvB2r3ieZbvO3kBSyqRkE1
+qNfQ/Z727Rl85ZQkZaJcgDr2o2ZS1OIiAeVzMSABjKtjI/CqTAI8rW6usZICFzg4611LeItQurRl
+XTYBcZ4uEjANZP8AZt5f4WRgke7c2Tnn/Oa2i7PUZd02Cyu0BupZBIBj5TjIruvhebiDxjNbx5ay
+8piHK9/TNchp/hYu2c7lzjOcV638OvD50sTXDOzbhtHPFJSXNa4SWmx3bHmig9aKozHZHln6V4rf
+apbWniTUQqmeCTmbr8uAcZHcdTxXs4+ZSPUV5rqngae3uru7N8my4GwgR4Pfv64qZuyLhucReaja
+X6RwxXMrOHOwbQI41PTjjj8M0af4fWzvzd3htpFiYlYQ2SWDfyPX/PEtxHo2ih94IkUBdoIY5HYj
+sOBXKX3iW5lkxDiNQeMcVnzt7IHGx7A2qZSMKquDDn5VwA3B/rXCeLrmy1F4Ymh2zRsWkkJHT+6D
+3rirrXb+Xg3DYB9cVn/aJJSS0pb361EYW1E2d1YX+k6dbbZldnBO0DgY6fWpNOu9H3TXM13HFuJ+
+XOSoH8/yriJQk0JdJCTGAG9/ep3slFhHMih5DxtDfln8KVl1drjT8jcuNas472dbcq8WcI+08ipL
+fWrby8M20k+nFcgHZiSIw75wEUcDHrxVhLO9kG8W4VfY1tyxS1Y1I7uz1YlsROpIIwF6GvWfA05u
+bNpmTZkYwK8F0k3VrGSLTe5OAFJzj8q9w+HcWpLYzzXcAgtnI8lGBD+pJ/Os4W9pZFSb5TtWPNFR
+seaK6DEVG4pZY454zHIAynsaro5208EZ6CjcZyuo/DXRtQd2LSoXOSSdx/Wqknwk0BoNiiTf/eJx
++gxXcbzShziocIhdnmv/AApfR1ZiJdwI43KeD+dSW/wb0iFmZ7l3yMBduAK9G3mmEAnJH61Hsovf
+82F2cNH8KNHWIxsylT1xHj9c0+5+Fumy7fs8iREDBJiyTxj1rtFQc5JP41Ih2jA6fWj6vT7fix88
+jzvS/hBY2El00t6ZhKQU/d4Kevfmrll8LtPs7t5Dcs0RbcECYIP1zXclzSFzVOhTerQc8ijBoWmW
+4Xbaxsy/xMuTV/IVQFAAHQCo2bPUUzOOgrSMYxVoqwm29xxbmioC5z0oouKx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0003/full/!100,100/0/default.jpg</Url><Caption>29377_0003</Caption><Caption>Lynx Canadensis, Geoff. Canada Lynx. (v. 1, no. 4, plate 16)</Caption><Caption>Exhibit</Caption><Caption>plate 016</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29I/3
+agccVKEpIx8i/SpAKxSNBNooYpGhZyFUdSTgCn4ryH4g+I7jUNffRIJWis7bHnFT99sZ59h6UTko
+q5UYuTsekf8ACQ6NvK/2hbkjrhqyPEPi+PSYN9rElyJEJikV8ruH8LY6dq8nht7m+UxabaTXDL94
+RKWC/XjFZ9vDqH9oT2FxHJEzxMArgjB7frWKqyaba0NXSV7Jnt/hzxZp+v2tuPMjiv5I972xPIPQ
+49RW+Ur5qvTdWuoWUsb+VHICYipw8bLjIOOhFew+A/GUmt+ZpWo7RqFumQ4/5ar6/Xpmtk+5k11R
+10iNngDHvVeWMVfYVWlFNoSLcY+QfSpBTEHyj6VIKaJY2V1iieRiAqqWJPYCvnG7vPtV/qN+/wA3
+nSsRz1Gf8K9U+IHicQxPoVi/+kzJ+/cf8s0P9TXm2naWdT1ew0q1yd8gaQ9cIDyT/nvXPVmnJQRv
+SjZOTPZPA2lLpXhSzj8sLNKvmynHJZuag8b6Kb3TFvbWANdWriT5V+Zk/iH5c/hXUxoI41RRwoAF
+KRW8oKUeVmKm1LmR86eIIjPbXUSKCB/pUb55DcBh+ZBrE0XW59M1+z1CJjvjdcgcbl7g/UV6j460
+W2tNW8yN1tUuQSWJwvQ5Ge2TzXmE+jG2MUKqJ5872lif5FGcjBPX1rnhJRioSeqN5LmfMtmfTmdy
+Bh0IzVeYcCsvwp4gt9f0dJI3DTQgRzAf3sdR7Gtaaui91cx2ZZj+4PpUgqOP7i/SpBQiTyPX/BPi
+C88V39zaxRyQXT7g7tgKK7Twh4Nh8OCS5lcTX8ww8gHCj0FdTS1MacU+Ybm2rBTWkRMbmVc+pxXP
++KtZlsLPyrCYC9JBCfKTj8fz/CuAsYJpruWW+ud87MN0kuCVwcsQevTjH+NE6nK7JBGN9Tq/iXbp
+caHBhgJllLJ6kBSTz+VeJtu/s2Czt1I82MSZ69Qc9Oetdh438Qz3eps91YA2Rg22kM2VLLgEt7E8
+e/Aq94R8E3WpW1jqN4Ley0n/AFv2dE2ySAHox9DjPvUTu5WSKi0lqzc+FWgnS9GuL1kkj+1su1Xb
+OQo+97ZJNd1LUkbxvEpiKlMfLt6YqOWr2Vib3ZYj4RfpVKfX9JtLtbW41G2jnY4EbSAHNVfEeptp
+Hhu7vIziVI8R/wC8eBXhFrby61pF5fSx7TDKFklPO9jk9fXihMln0krBgCCCD0IrP1vWrXQ9Pa5u
+XGT8saDq7dgK8x8G/EAaR4Ru4tQdri4tZRFaxFvmfIyB9BjrWHqOvT6lO19qk3mTtxHEv3Yh6KP6
+0SbWiBeZZOsSNq7X92xZ5ixwexz0qO7ubqKzkDzSpPM+4SEnCLnoP8BWJNcrcMgdj8zAKo6iqmpa
+zIwuIRcCWdgEViuREgHOCTx/Wle2gbnQeGfDknjPxTLLfySTWFmx8+ZnOJWzwoz0x047Ct/4k+IW
+ubJdC0S4xFCAJ5EbrjogPf3/AArzax12W3tFsRPOtsnOxHKoSepIH3j9a73wZc+EWvYptQ1HNzGc
+xRTxeVCjeo5IJ9zT1QXPRvBtncWHhHTre7J89YRvz1BPOK15aeksUsYaJ0dD0KnIqOWlJjRzHxFi
+ebwNdbGKlSjEj0zXGfC6K01fRNc8PXG3MhWRSOvTGR9CAfxr1i5s4NQ0+SzuE3QypsYe2K8Tv9K1
+b4d+I4r23t3ktUPy3Ccq6Z5DDsacVdWEyvZ6ANM8UXtjcojXEZ+Uk5GPas/VY2k1AwIixTKSVboC
+AM811njf7MNd0bxGhZPt1urkemAP6ECuW1i4FzLJdqhHmoY4gR1zwT9AM07AZM14I7R5Leb96fkj
+IPLHOCR9c/lWbBa7ixdW6/N7mux8H6KniTX7m6iP/HjEziMrwW6L/U/hWWYG03ULxLtSoQ7hkdTS
+S6jfYz2t1htxKwAQHGAKv2VzZxtsni2mRDtOKyEW8vpXit1ZldtxXsB6mtEQ3djNaPe29qVQjHnP
+8uOOSB/+qmxJG1pHjG+sr+OTT5Lh5HYK0CgyCToOnpj05r3WCV57OGWSJondAzRt1UkdDXhmla1f
+6jr8cVvLc+U74Is7RFKjPYqo/nXu5G1FAzwMc9allJE8Z+UfSnPGkqFJFDKeCCMg1Ghwo+lPDiqQ
+jific2n2+gWrT2qzTJMPs6ltuP734Y/pXnd7qE17aNELW3TZtYR2wIBP8IOScnvmvYNU8Kadrd6l
+zqRluNgwkRfCL+FULn4faFJC6qJoQ3dHxg0NXGjybQrmfw3ei70y9+zNImyZ5FDoSST8wPHb9aqa
+1rb6jqKXV/fC8YgblWIKvfHArqZ/hVenXILZb8SaWct527BT2K55P0r0bSfB/h3R40ENlbvKuP3s
+qhmz689Pwosx6Hj+gaV4g8QyGHSbQWtoX3G5lXaBkYOPWvTdA+Gmi6QFnvEOo3p5aW4+YA+y9BXa
+AKoAUAD0FITTshXI1jSJAkaKijoFGBUUh6U9nHrUMhpMEKjHyx9KlVjRRSQx245pSxoopiEIDDkA
+0vQcAUUUAG44phY4oopARsxqtMxAGKKKTKR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0011/full/!100,100/0/default.jpg</Url><Caption>29377_0011</Caption><Caption>Sciurus Cinereus, Linn. Gmel. Cat Squirrel. (v. 1, no. 4, plate 17)</Caption><Caption>Exhibit</Caption><Caption>plate 017</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOJc
+fdH5VIEXOMDNOjHAp9ZWLGeUvoPypDEn91fyqQ9Kj8wbmUnkc0mguOEa+g/Kl8tfQflTQ3vTg4PF
+CQrieWv90flS7V/uj8qcKh+0w+f5JbEnoRjNVotwJcL6CkKL6CglQOTRkcc9adh3GMkYGWCge9Js
+QrlQMdsU4uN23NO6ilYCq0a5+6PyoqZhzRU3HYbZtusoG9Y1P6U2a9ihQszVHZv5OjwMedsC/wDo
+IrkrnW4ftksdyj7I1BRWGA55PX06UqknFaCWpt6d4kt9QupYlyEA+Rjxk9/1p91qEbSI8coUhtoP
+qD/9cD8682stat2uZo4w6lnZ0O04AxnGfwNV9S154F8yI4MbKVHqQQef89q5VUnzOEhtK10ei3Wv
+GJAkJHmBSzEjiNe7Gp9K1C33A/bVuGkyV+fJx9K8qudVuJdM8ra0l5eyAO/bb9OmBVhriWOWE2iC
+O7tjvDP/AMtFzz9eM1UHNyuyG0exPfxRpvY4XufSs3VHWYJNDKN6jKsGrip5YLsytJJLE8jAEpIQ
+CO3H0qlutow0omlEQbaRFKyZ9M5JJ9c8VvNqSswizs7fWy0iQXLbZUOHB7+nP0qa48QwpL5QkUFs
+bAWHPPOPWvK9Q8TtHeMtskk6KSQ5btgjBPfBPWiz8VW0kqm5QxSDIBk6cnsaS5knbVl8r3Z6dd6u
+iXdlceaF3O0ZG7qSMj/0EV0trMZoQ5715Jql5EkNnMUZo2IcoDnbxyfwzXqGiTCaxQjOMVUHcGjQ
+PWilPWimBWshu0m3BH/LFf8A0EV5h4omigZwy72D5XnAHrn9K9UthiwiA/55r/KvC/H9yY9c+yjA
+BO5h7Z/z+VEkmtRLfQpNdalfyTLplpIxlO5jGCB0/UdfzrBuJdShlljmZ1kHDxumMVu2N3KqEW7s
+HPccAVY1a7jv/JJKSXMSbZXA68cCuP2jXQ6fZxK9hNJLZpdz26+WByVbkAZ5xjNWlvXl2S7w6xvh
+GJ5ZSOfb/wDVWNavNbhmt5A0YHzRk4pYxDIXu/srorDAMOR5b8cHAPGPaqVRXMXR7HTTM8xEpIUP
+NjGf4R/k1h6vK0t5KsL/ALnzQxXPGcAfkMVPZ3p3MsrZjKMsMhXG45xyOxrOmiiuJBGHzmXj3wSP
+8+1aKVrJbDhDR33CKYXWo+RGqmOMBd5zlvUj86vahoCWo2yvJ5mBuUkYFMt9Pjtr3bBIDlSBkjIJ
+P+fyre1ET6jp6tPDG1wnD7XG76gZqJS1vE6IqytI5fRLt7bUGsJApEq+WhbnAOOn5V774c2/2cgT
+BQAYP4V873dvdQ3sD+U29SNrY5IzxXu/w/ne68O+dJ1MhUfQAD+ldSd0mc01ZnUHrRQetFFibjLf
+/UIP9kfyrxj4kaUZvEgm8klRHh2U9OT2/GvZoT8g+lY3iTwzDr0BwwjuAMKx6fjSkm1oCdnc8Tj8
+iOzZLadYZgcDzVOAPUYHWpp59Ns7JEhjeab+NozuA9ySBmuvl+Gt/E6CGWNx/FkVQm8BatA7SiLz
+GHRVTI/WuKUZLpc2529jjBbWyzNcNcSB3HK7Dgj04qRbj7DE72qO29uQVfB/DIH512cPhPXiMvbR
+qCMBipJAx6dBTY/B987kXqnyUBO2KM5J9MmsoyqX1iK7ZxM1ze6gQhlYqgyIokCgfgB1qe2WeAoj
+ib5F2rEBt5Pcjv8AU13lp4V2f6Vb2CRSbdq53NgZ64xjNWLLwgbiOd1FyGlHzGVcZ+gxWzc2rDiu
+XW55/HYzGIpI0iZyxYNhPxx1rIvHgjYCO2Yuudzkcda9EuvBur+ZHaw2srQjgyE9qrXfw51T73k7
+h2jT/Gqp86eqD5nHWvm3c8SiWV2yAPmwAK+hfDemJpOhW9uvXbuY+561yvhT4frp7pdX+0uDkRYz
+j613xwqgDoK6YJ9TObuMJ5opjNzRWhAy3fMKfQVPnPc1nW0v7iP/AHR/KrAmpXAtg47k0u6qvnUe
+dSsBa3U0gkkhyPbAqv53tR51ICYLIesuPoB/hUiZVcFix9SBVXz6PP8AaqQFvIpCwqt59IZ/Y0wL
+BP8AtGmFuOtQGf61G031ougJGfmiqrS80VN0Fmf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0015/full/!100,100/0/default.jpg</Url><Caption>29377_0015</Caption><Caption>Lepus Palustris, Bachman. Marsh Hare. (v. 1, no. 4, plate 18)</Caption><Caption>Exhibit</Caption><Caption>plate 018</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29YxU
+iqCM4/MUqipAKkoYEFL5YpVdGkaMMN64JHpnpTzgdTigCMoo5OAKXYKJolngaPOAw6jt71Db3Mk6
+sPKw8bbHyccj09qQyQoKjMYqtqd/d2NlLPFpz3LIRiONxkiuFvvifJHOY4NPVNqsGWYncH7A9MDP
+1qZVIx3Cx3cgTfs7+lVpoRkcVS07xNaXq6bA7qby7iDMsZBCNtyQeeO9ak3BFNNPYC+tDzRxMiud
+u84BPTPpTZYzJBIgYqWUgMOorzm71rXdLc2016lyjHasN3bEM3sCMGhuw0rmj408dW/h+/htrO2m
+uNUxwoUhCD2J7/hXM22heNvHLSXGoaodOts8Rcjb7bAR+probPxzFaRgazprLMjALIuGwO2ScYre
+tdb03WLhDZztaXzrmMuoxMB2GDhx9DkUKSew7NHn82heOvAlxHdadeTaxYg/vIUDNke6Ekj6ip7v
+4x20F6ktrotyZSuy4ilkEY3enQnIPtXd6u3iAw+RGIVhcfvbiAHei99oPfHSvGLzwBrT69MlpayX
+GnyMWS6HzLtznJxzntjrSlLsVBJ7np/hf4naV4jvk0+WCSxvZP8AVxysGVz6BvX8BTvFfhzRY4Lq
++mWWKW5BG6NSwD9c47dK8M1O3vdF1T5TsurKUEMh7g9RX0routWWt6dDPbXMUrmNGkRWBaMkZww7
+GpsqisxTjy7Hn/hnQdThWx1azWOVTlwrHHyliCvscZr0OYcirMcEVvEIoUCICSFUccnJ/U1DKOaI
+QUFoQXFqm9nbyXirNGsu5GZjIAc8j/Gri1mXtin2qK5nlmki3FXRnwqg9OBjjOPWrYIydb0DSJI2
+EdzBbsRzFIdyH8Oo/D8q8+m0P7EJjZXBiuVk3xBJd0YYdGB/r19a9kf7BptsZnEMES9WwAK5vUfE
+nha7JW6gFzsbCnyQc/Qn1rOfKt3YalYg8OeNpJWisNeRILphhLheIpT6exrL/wCFheH01podPmnt
+RI5BnkjBt5Gz1xnI+oFcf4+msdK1JrPTyzylP9W4yYgy8pn2OD7dKqeErPQ9cs77Q71fL1S6QGzu
+Gb5Qw5Cj0OfzpczehfKkrmx4m8EXM/iiTULudbSzvDuMyDzED4yM9wDitXwl4HvtL11LqHU4fNt3
+AmiCFfMiP55BHQ+1W/hv4jeeKXwprI/0u3DJGJP40HBU+4/lV663+H9UADHFkvmw56yWpOHj+q8E
+UJLcHJ2sdy1VpOtNSWS8jWRB5cDYZST8zDr07U5+tamZZWuc8T6hqtvZGG0sxM9wTGqKrMdvcnAO
+O9dEtcZ4j8VXEFw9rButlVWWRpFAJ9CpzXPiKsacLyBK5k3nh3xPr2haavnCJ7fMTxTODlem447j
+HQ1latFY/D2wV7pYtQ16cn7OrcpGoxhyMdqyk8WXugXqXEdxNKWcM0PmEKefmDfXArntf12813Vb
+vUZ7bEk2NgzkRoBjAJ/P8awp1YyjzW18y407u7KxuLvUNRe5ldpry4YtI3G5u+AOwp1toGqwRR3s
+1tNBG7EQSFdu9xycHr9PpXsXw28H6ZpmkQaoWiu9QnXLTYyI/wDZX0x0Nbfie/0eTTJ7O8ZXA/uk
+fu2HQ5PAIrfksrtjc7uyRyXhe3sPEGt2t1qIa28RaeQ3mRnb9pTGMsO5xwa6Xx5p4utFWdSyyQuF
+3LwdrfKR9DxXmVzJcQXUN9Y3tq95AQyyxPgjHYjnOehr0jS/Edt4y8HXbxALdpCVmgzykgGR+BI4
+pxlzJrqQ1Zm7o8yXGhWM0ZyrwIR+QqZ/vVgeBbwXPhzyc82s0kWPbO5f0YflW+/3q0TuhE6nivJN
+X0q7utXmjlKJJKzyCBI23YOcdufrXrSdqcsEQmMwjXzSApfHOPTNZ1aKqpJ9AWh5dFouiJoFrb3s
+O2/jz5kpjPPOcc4PoKrtp3hCfXjNJbsljGihbbecyP3ON2QOn416zczQwW0ktwyrCq5ct0Arw+7s
+CvjKb+yp4/JZ/MSWMlVjzkrk9un6VlUSp2SVylJo7XSbDWftN7Ho1mNN0udlKCYsNuAASAeefTj6
+10Fn4P06MeZfoL+4OCXmHyj/AHV6CsTwR4uu9Qnex1aeNpekLhcFz3HHFd5W9PlkroltnH+KvBll
+faeZ9PtI4byD518sbRIO6nH6V5jp17ceF9ZXV7VGezfMV5AvUr9PUda99rzjxjoR0+4lv7eMG0uD
+mVcfcY9fwP8AOpqRafNEqL6Mj+GWoQ3NzqscBPlusUwU9j8yH/0EV3z/AHq8P8Kag/hHxlG87Ead
+eDyiQucbjkfkcV7g55qo7A1qTIax/FaarNo7W+kwCWWX5Wy+0qPUHIrWQ8U8E/3v0rRx5lYg8t1D
+QfHN9a2+nyiN44UCho5AARjuSecfSu38P+E7XR9DexkJlluB/pEucFj6D2Hat4Ghi38JA+ozUxpR
+i7gc/oPhWHSZZ5JkhkJk3RHbkqO3J5z0rpKhJmHQqfw/+vQDMepQf8B/+vVqKirICWoZ4o7iF4ZV
+DRupVlPcU8bgPmIJ9himk0DORsvBNtb3hkuGE0UcvmQqRyMdM10znmntn+9+lQOeaSilsO9yRWNP
+BNFFNCHAml3GiimIXcaNxoooAQsajLGiikMjdjUDsc0UVLGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0034/full/!100,100/0/default.jpg</Url><Caption>29377_0034</Caption><Caption>Sciurus Mollipilosus, Aud. &amp; Bach. Soft-haired Squirrel. (v. 1, no. 4, plate 19)</Caption><Caption>Exhibit</Caption><Caption>plate 019</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tIsj
+mpBDUiCn4qRkHk0eQPSp8c5z+FLRcCAQU4RCpaWgCMRil8un0tAEfl0hjFS0jDcMZI9xQMhMQppj
+4qdVKrjJPuaa1AFVowTRUp60UrBclQVJimpT8UANxS4o6VV1G2mvLCWCC6e1lYfLMgBKn8aQFrFG
+K5LRfEF5Z3Wo6dr8sW+xTzftSjAeP1I9eR+dYt98S5Z7pH0W0Wa0ib9607+WZfZR2+pqeZdR8rue
+kYoxWfpGqpqumw3ixPF5g5R+qn0/+vV8OK0RIuKKTcPWimMXFMIp9NNICIgZooPWilcCVOlSVFH0
+p9ACNTDTZ5RFy3TBrgpPEd40peS4CoxysfIwPwrOc7FJXON8e3dzPqN8qOVW5uzbvg/wRKpwfYlg
+f+A10nw20yzutKN1GVkaOYI25Rg9M+uetZOrjSru5lu7uyn3MQWlWXH44zijR102SPybGG6EZYAI
+sxXP5Vz+0TZq9tD2BUVVwoAHoKcK4EeJrHw9L9n8524y0YDP29fwrA8UfEa71BWstHjltYio8yZx
+hz6geg9+tdClchRZ62s8LuUWVGdeqhhkUkd3byTNEk8TSL1QOCR9RXz5a6fqaeKbaJZHtnK7jIZN
+m5f973r1PU7GwsLDSLzToY4Z/tkCqydWDMAwJ75BNWmDjY7gUhpF6UGmQMOM0Uh60UxCoeKkBqFO
+lSCkByvjXVL7T4bcWygRSPhnAyVOa4039gEMFxckbiclRjH6V6jqVhDqdlJbTcBxjI6iuKm+F1tN
+NGwviFQ5PyfMfqc1z1Itva5cWcdfy2lrL5FvdtcMVztcDge5FU7bXrwTxpp1pG8q9Oqr/MV3dx8K
+4JpRs1FooifnCRAM341IvwvtIMC2v3jCg4BTPPr1rFRqXu0VddyOy0ubWdOE2rw2n2odFiy2B9c/
+1rjr21W01ppY7YSmHjypPmI5/wBnj/8AVXo1t4PurSNo4dYKq3U+VyPpzT28Gs0kpGpyKkgO5FjU
+Akjkn1NaqMuwcyOeiextVTVm02eZXO+MHadoxnIGSScc5qKbxRaan9muViuVfT5PP8mVOZmAIHI4
+4zmt6bwD51pb2r6tP5UI2gBcHGMHnPpT7P4e6TYu7Ce5beAHUyEBvqO9aJSDmR09hdC7tI51HyuM
+jmrBNRwRR28CQwqFjQYAHalY1qjNjS3NFMJ5opiBH4FSh6oxyEqDUu+lcdizuFKGAqtvo30gLO8U
+jLGxyQM+tV99LvpWESeVF6frT1CJ90AfSq++l8yqsBZ3U0sKg8ymmX60wLBcdqYz1AZvrUbTD3oG
+PaTmiqjzjd3oqbjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0040/full/!100,100/0/default.jpg</Url><Caption>29377_0040</Caption><Caption>Tamias Townsendii, Bachman. Townsend's Ground Squirrel. (v. 1, no. 4, plate 20)</Caption><Caption>Exhibit</Caption><Caption>plate 020</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25F4p
+4U96VRVXUb63s4GE0uzI4PpWb0RQ64vILZCZGH0qi/iLTIpPLluUSTP3Sefyrh9S1cGZg8p4OEOc
+j9PwrEtIvKZrppVZwcl+CM9fWuSpX5dilFs9ha9t0GWlUd+vSpI7iKUZQhuM8V4vpc0txHLKJJ5I
+gxVnYn5q2rDXn027KIz5YE4bkE44/SksSr6oOVnoyatYyWP20S/uc46EnPpjrmp7S7jvE3RpKq9v
+MjK5/OvMG1u7nW5gtrqKJZpSDsOGjPGWwOx6V03hXTda027lS8vJZICMqHO9T9DnI+lXTrc1tAOv
+DIzMoILL1HpTttcfB/bx8XeZcMiWSFsuVC7k9PU84rp7TUbS+aRbadZTGcNt6A1tCfNuOUbFgrUe
+1s/Nj8KkwS2dxx6UrCrEVymTRUpFFFkIcOATXjnjTxWV1OaEoGCg4Ct057+nevZBwpNfPmt2y6x4
+5u4p+LaOTdKnTdknCmpqWtqOKuZ51fUdSixpmnShegkQ4A+jHApJrwxwi1v7Wa0nfA3MBtc9sEcf
+lW3PqkaXQghgG2MbQAOFHsKztVVJoSJFZ4pfvL2HuPQ1yKUW7WNnTaVxmn3tzbBLXesq78FDyTns
+K1Dp6Mr3N8fICEbHV/u9gDwf85rlNLFxDKFc+Z5MmPTcOo5+hrqrjUXm863LHyc7gTyG9qzqU/e0
+IQyTUYbcoLJPNlJwJCOMZ6fj9K7rwp4rmnuRaTPHIMDeBJkofx615mBKXIWNSGwOFx+Oafod1c6b
+qv2iCSKNeBIZWGfoM85+lb01yaoGkz3VtPOqSM99EEVGPlgDqMcHrTtM0G00l82u9RjBBOc/X9Py
+qkNebS9D/tbV3BgkK+WsCFiAemay9S8fQSRrBpETy3T93XAjHqf8K6LQfvNak+9stjsftEIuRb+a
+nnFd4j3Ddt9celTV5r4Qtby78Vf2xNcSu7pLHMC3yjBAVcD0HP416TV3uroTVnYQ0UUUCFz+7P0r
+5z17WBpXi3UnuY1V5cEFBkZGR/WvoteRg14V8RvD4l159qqgHz/UVE0noyoNrVGX4VP9o211vBaS
+U7l55A5xU2ooIrIq38PDetZ2g3H9l6iuTgcL+Haui1mAXtvK8WGV1JDDsa5XFKfkbOTcTlbOGWSV
+5B9xict6VoRpc3hCwKscf8LsuSff0FQ+G9NZ9pklcqW3bc8AZ64rs7SzZmCJblB2I/wxWj5Y6sxV
+3sc3/Y0zKS0spbHJ3kVlyeHZTvZZpQw5+9nn8a9Ek0vyQxEbEkDk9/wqjPH5T48k7dxHA71KxME7
+GioyZjQ+NPEFrpKaFcw2tzbkBFlkTnb/AHT2z2Bp39oW2nIjW7MZ97M6tnMhP6YxipLiyO3zTHvR
+hgZFZNxLHcDyYiouchPLPUMSMEe1XVm7Jx2NKME21Lc9M8A3LCzvL67YQx3E26OM9iAAx/MfpXdR
+TxTH5HVvoa8jgvrKOGO3V7spD8h2sACQfx6kZrrfB0CyX892kTpHtwu9gScnmrjLoYyWtzs6KKK1
+MxqdK4Pxj4dkubp7uNRsK8qAe1d0h4qO9jeS2bywC2OAaiauhxdmfN+paVPFM3lBvlOc+n41v+GI
+7ptOuzdzJBCq7UaRgAz5HGT7Z/Susu9LvL+C4gaBUvSCS23gDsa5258NXUlkttdNb4TO0Bt3ze2c
+AVxzqK1pG1uqM2OYaffeQY2G47kwOUz29xXQx6lHZWby3E6qvB+VuRWa9hf/ANmFIbRZmhGDIsYY
+qB/P/PpWDNc2gtWlaGaeWMj92DuUEnjgcGlCpKTv0CUIJabnoGm6sb6MXV1KkFoOVaVsFh6/jUE/
+j7QlvBaw2zy5bbvCYGema4yDRtU1MCe+L2tvjIWQnOKlHh6OGaN4HLwgHzBg7ifbjp/KtPaUk/Ml
+KTNXWL26tmkNqitAxJU4+8OxrnV1O3VkiW0WOWXJmuX5YN2C+gH51pw+HNSvLwQ2zxwxNyUDF+nf
+n+lP1TwZdW9nLIz7mAz1zwO/8v1ohKK66M1k00tLMfHeRDLx28csxABIy2R65XvXe+ArmOWV0jlY
+Yj3MmzAb3z+PrXl9hbWxeCW1muvP42oYCxB68FfrXtfhW0a30lXlj2zP1JTaSPx5qoR94zlsbxNF
+Rk80V0mNhqNwKl8we/5VUVjgVIGNFwHywRXMZVxwevauUv8A4fWl7dm4XUbuI9gGzjjHGa6sOaNx
+rOVOMt0NSaOWs/Akdiv7rVrzfxhvlB/HA5qVPB1nHdLKbrODlx5SAt9SAK6Tcc0FjUKhBbIOZmNd
++GtOu12NKyr6A1dj0bTxbfZlUMoUKemcVcBxyBzQXNVGhTWyHzsxoPC0Fozi2u5oo3PzIoX+eM0+
+38MWkMzSPcXM24Y2ySZArV3nFNMp9Kr2NPsHPIhtdOs7GIRxRZx/ERkmrBcBeBgfSojKfSo2lPpV
+pJbE3bJC/NFVGlOaKLjsf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0045/full/!100,100/0/default.jpg</Url><Caption>29377_0045</Caption><Caption>Canis (Vulpes) Virginianus, Gmel. Grey Fox. (v. 1, no. 5, plate 21)</Caption><Caption>Exhibit</Caption><Caption>plate 021</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BVp4
+X1/lSqKia7gWQxtKqkccmsrI0JDwM1h6Z4kh1fWryxs4y8NoMS3Gfl3noo9e/wCVSeJtXi0vQL24
+Vg0iRfKoPOTwP1NeFadca1YTTz2V9NbCUhmELkbj7jvUSaQJXPo8Cl2ivF9F+ImuWTB7l11G3BId
+GG11HqCP616hoXijS/EEIazuB5oHzQvw6/h3+ooi4sJRaNnbSbRWbd+IdNsJjHdz+T8wXcynGfr2
+rTRldQykMpGQR3rRJEhtpNlSUlOw7kTISDjGfcUzYcfNgn2GKnNNIzSaHcqlOaKlKjNFRYYskghg
+eRuiqSfwrwzUrrWNW1iQ28jFGYsTnAUZ9a9znhFxbSQk4DqVP4ivNLvwRJbpOyzFZBkrIJNuBU1L
+ppgilLq1lH4f1DTb+6CTNCro0hzuI6D8fSsnQoheIrsFQY6k4zUZ0oWc7tekXEUmA2SGK+jCkuZV
+0mVolSGQDkAl+R+DVg3zaI00SuLPp0FrqiSwn5J5WR8dDwDn8zVi78OtFiaJnilXkPGcEVu+G7zT
+NbdfMhWORFIRQPueuPUVoeIrWW306SRBvTj5l6UpRktQjJHI2V/eXIng1OdriNoyokkOW4x1PfHH
+PtW3Ya1qdpDgXtzFHbou1WAdD224IHXtg1zqqZIHu4VdI0JGW6Gp9E16C7m+wm1uZLrcvk+Ww2qQ
+ep7/AM60g2NpHsOi6hLqNiJZovLkBwcdDxnIrQJwM1Bap5FlGJMBggL46Z71z+p3t0dQMiXPl2iq
+NoU8se+RXS5KK1MLXeh0xNNV1dSVII9RXC6z4n1Xdbi1jjjtpNytJJxvYdgc8VseDby4u9OnE6jE
+cpVW3Zz61POm7IdjoDRSOcGimBJtDoVPQjBrgNX0m4jupDbXpiAGD5jZVueMiu/XpXA+LS0jSRh3
+JU5wnasq1rXY4nM3ek3JnRQN0TnJl6DP0rPvrfT7W5CX1+IwigBXYcj+dO1rVJ7WFbS3kKzsuWP9
+wf41jW3h77Zc5AMkjfMxfqT65PWuTke7djRI3rafRGCC01KMTZyMNs59s1vWeq3X2lbO6lSS2lBB
+Zxgg44BNcfP4aDI7bAuwlSAM8j0pum22s6epglZvssoKoHO4oex4IwO1KCafuy+8HE3daXZYG1uN
+1tGv8IQkH8fSsO1iFraE6ZIySSHm4A5K56D0ro0Exhjd7hYnKkbOQCe9U7qGOzt5JZGCEsDgEYJ+
+gqvaOLt1He61JrXx34h02IRTiG6t0G3ey4YiodS8cvLbEQwGPLdc8D2HFUlh+2IJI2yCMtxmo7qz
+gW0CtlyyhgmMY78//Wrb2t7cxCiXlubvVtFie7TckfKKDwFruvh7exy2V1aJtIicMCpyMHt+lcNb
+eH1ubKGWGd5ItuGiEu0A/Su78C6WmnRXZjbKyMOo5rSMvesDjZHVSH5qKSX7/wCFFakkqnivP/Eq
+3kd9I9pp811K3Plx8Kfqx6fhXfIeKxNb0Sa9kM9vO6uQAUzx9R71nVTcbpXBbnk7aXevc77i0kFz
+JJxEeCT/AID1rqrCG00qxe41e5gNyB8lvAwyv1x3qvqpuNJInNtLDIPl3kA7j9O9Z6WVpIpM2niC
+aQZMiglXPXPqD+VckqqS2NXdoNHujPd3jvFLGr/NGrZINXSsQTyrqaNEfuvas6CyltZZIbe3k3ZG
+F37PxrUvbe6gsgbsHyiAfnyQa5XWUm2kCuiq06Lqz2buQUGYnHpxyPr/AI1Tt1VJbqS5YPbHiJZm
+GfY4JJpXugHEKQ28ix8KS54+hByPzpbfwnNJE1xcryAZNseSfWulTi46oTuJLFOLXfBIsNuuNyKg
+y/PrTP7Gur5FnDTLGBtVBIeT1yce35VoRRtZ2pE0W5cb1DKcAfl+lWrXVEit44EWUl2JzGhPzH69
+KunONrFLYxtOjZ786bdZLqu9HxgnHVTivU/DcjPpSllAxwDjk4rz1NLuW1uGaCQRSA8lmDMQe2K9
+Rs4vItEQ4yAM4GK2pNSk3HYiYsp+f8KKjmfD/hRW5BMrU/J7EVQW8X0ani9T0alcLFwojj94qtjp
+kVDJY2kxBkt42IORlQai+3IOzUovUPZql8r3CzJxaW3mb/Ij3/3tozSzQpKNrRRunowzUH2xPRqX
+7Yno1JcotSqNJsJG5022yPVBWjDEkUYURouOAFFQfbE9G/Kj7Yvo1UuVbINSZreBnLtEhY8EkUNB
+AylTEhBGCMdRUH2xfRqQ3a56NVaBqJFp1lbuGhtYI2HQiMZ/OrBbA61WN4vo1Ma7Ujo1F0Ow25kx
+IPpRWfd3S+cOG6UUrjsf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0036/full/!100,100/0/default.jpg</Url><Caption>29377_0036</Caption><Caption>Lepus Sylvaticus, Bachman. Grey Rabbit. (v. 1, no. 5, plate 22)</Caption><Caption>Exhibit</Caption><Caption>plate 022</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pVzT
+9nIFORalwAMnpWexZFso2ViXvi/TrPUhZEM78ZYdBnP+FWH8Q2yR78cVlKpFbj5WaoSl2Vj2/iGK
+5gMqDABI5rF1PxVdJdRRW8ioCcnjOaj20Q5WdlspQlc0mvTJDueQE4znFY134xvYriNYmUhmHUVS
+rJj5Gd9so2VjQ647RqXC7iMkUr+IoYWQSLncQOO1WqsQ5GarfKQNrH6CkZakiljnjDxsCDSsOK0T
+IaKhXmipSvNFICVBWP4m1H+z9PB3bd7YNbCVxHj9jLJb2/JXg4HrmoqO0So7nnuoXhbVXlLHsR+t
+SHXJvKaNiwzxzVbUIgl0SH56YC54qAMZGUeXkIfvYrjk0aWNrTdaliieEn5STUQ1DztRznOATx9a
+yJbpYnMUhPPfp+FSWtwvnghghx94H7tQnrcLG82sO8OwRyHeOPlwKhfa8sbk8pgmodS0q+uWjuLS
+BnhhQb3i+UNxzgA5z14rktR12e2P2aE7p8Ydgc4x/WuiFNydkDklueiDVZQ24NnjgVXutTlKRO/H
+zgZHpmvKl1zUYmEjXcm7sCcg/hXVadrX9o2MfmcMrYOT1rSWHlDXcIzTPXvC2upI4t2bqeM12Jrx
+PTNQjtb+B2coAwO4qQDXtMMizW0cinKsoINVT2sTUXUaetFKw5orUzFgO6JCepArh/G9wiX6ofvC
+PIPpXbwHMSH2FefeP4iL4OASzIMAfrWNZ+6aU1qectNi6Kvks0gC57D/APUKbJcNBe3Nq6B1lACd
+MrnH+eapyKy/JM5VlcYP90jj+Rq5b6BqM0TapMyrbIu4T87eDxWDity7hq+h6hp9xbi5O6O44Rt+
+7HA4J/z0qv8A2XfyzMbIExxoWkL4UHAyasR6rLNq2nwahfCazhcAOqbQAeCen6mup8SajpMaGLTk
+aMSJgs7E7ySB0yeOpzUJ6iI9MsdY1/wjH9icwwRZidN2zzMZ5yOccj8u9cDqGn/YNUWJoYiQhWRE
+cnBB6mu88JiLVLybSby7eIGNnkjjlHlzv2xx8vHpVi7n0Dw9bfZk062aadDvkmySjdOuOfwrphV5
+dCHC559PoSXE9tOsUkdqRtYAc5Hp61sWumi0gGzCLktxzgjsPX3rQjYskpYkwKxcSAEAr0HUZC8/
+/WqG72yMsouEZX/hUMDj0wQMCs6leU/dWxrCmlqRzMhWR4ZcLGcFWPbtivddAm8/w9YyesK/yrwm
+GE3OFQAjdtWJVyT717roMJttBtISCCkYHNaUX0Jql49aKQnmitzEjtmJhjP+yP5VyHj613LDcqD8
+qlW9MZH+NdVZPm2hPqin9Ki1ey+36fJEAC2OM1jVjzRsaQdmeF6ja2xJaZZI94++p43D1FUmizCl
+qbu4aEscoG+Xjviu/vdGYloZoscYGFyTWZceEry4tfLjRkXoFHcV57c1ojf3TlWks41RSEJUY+7m
+kEVihA2yknADcEc+2RXWQ+CLoIC4wEH3cZOKsr4EaW8iDxOrKQcjoO+PrWajMLxOdszp9tfMIZp0
+jOBIVUKVz71LqFtbWdyw8ozy7uJZH8wuPX1/X1rqz4FKhgVZl3EgHnA9quDwlI0SbbcMAMDcAuB+
+NXGM9gvHc4lrqSdkG6SNVG5mK/KPb/Oakt9KaabzZpYJMnAyT+veu5Xw3cIuxIUj9SRuP+FSjwj5
+4G8OG7sG2/yrSFOS6Dc0Z3h/R4G8mSMKXyeEGQPxr0VRsiVfQYrN0rRLbTEyifP6nk1os1d1KHLq
+znqSuNJ5oqJm5orUzKumNnTrU/8ATFP/AEEVeDZFZOlMf7Ks/wDrin/oIq+rGlcZMAoOaeGFVyTi
+k3GlZAWdw60hkfPyhce5qDcaUMamyAkWaRiQUUY96kV+OQM+1V9xoDGq0AslxSFxUG40hY0XGTEj
+3/OmM9RFjUbOaaYmhWbmiqzSMGopiP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0035/full/!100,100/0/default.jpg</Url><Caption>29377_0035</Caption><Caption>Mus Rattus et var. Linn. Black Rat. (v. 1 no. 5, plate 23)</Caption><Caption>Exhibit</Caption><Caption>plate 023</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Up2
+zjgc09RTwKkZHso21LijbS0AjCU7bTwKdiloMi20u2pMUYpiItlJtFTYpCKYyBlYfdUH6nFNKfLy
+ADVgimMKAKpTmipSvNFKwXJlFPApq08CmAYpcUtFQwIpporeMvK4RfUmnI6yIHRgynkEVFcrHINj
+qpJHG4Zwa5i71BPD+rWipOWgmbEkSjI57jFQ5WY0jrqWs2bV4ktZm2SrJGPmTYSyZGQSB296i0XU
+5bnSftF3G0flL87sPvYHzHH4VXOublCztc1uM4zz6UhFclZ61Zrrb398sts1yohgZiTE6Akqwbpz
+6dq2tH1gaoZ8hEKPhUBO7b6n/wCtVcyvYLGkRTTTzTWqhEJ60Up60UxEq08VGvSpAaljFoqKe4jt
+oWlmbaijJNY+oaylrbLd3TSW1sCCsYH72X8Ow/X6VEpJbhYyfH+rtptnAgkaJZCWMij07VwF3qIk
+tIpmd3Bb91tPf1/+vVvxl4mn1q5gMdu8dqgISOTB3HuSKwpbuOeZ4DERChHluVC9B/L6etefPlnN
+yTNVdKx3HhrXpZ43fUYJZH8jy0dcESjIIBz3Bz9a3DqCjD2t3IYunlA7izsOc/Q15ZJemNYFtoU3
+Bhtcg846Y710doLrT7ElojLc3J+WLn5VPUn0rWM5saijc8RZ1TxBaWdujzNborokKhVDA5OWPHTo
+Metd/bwrDCqKiqcchfX8hXA6dqxKmwmkMZlBGzGAWPQg1p2mu3F7cnSYLyK2nRcK0yku49uxIH8q
+6ITi9baslxdjq5p4oAplkVAxwCxxk0rdK57UtLljdL2e/VLe2QfeXO3HfnPNXtGmvLq1e6u/lEzZ
+hjIwVjxxn3PU/WtFJt6olpWLx60UE80VdybDkNZ+valNpemNcwIjuGAw5wOTVtGqHUbGLVNOms5v
+uSrtJHaple2gLc8/vvFj6lpgt79UjxLljGxYHB6E1j6frukmdIfLuY3HH7wZQn6g8VsXHw+1SBXW
+1ntpY3IJUjBJH6VlSfDzXHueIVAPV1lAxz6c1wTU5aSRqnbYh1fUFnuhDBBsgX+J+GJ78VjtYXDR
+XFzuCiNCQvdvwrpLbwD4ityXVrdiDwHc8itODw1qIcxS6eVyD84YMp9vWs4UmpXaHcyWTTY4bEMo
+iSZUZSOWYkDH0raheJ7aI2twQisN8h5Le1Q3Pg3UJ4Vh8ooigAbGwQB2zTZvDuq21n9ntLNwo6lQ
+Mkj+dbS5kCsUtXksryUQCTyAcgvjHPUEGrV5cxjSUZgkl1tVVum59OTj+dQHSdSaZBJpV08o+6WX
+5D9aI9J124DQ3Wmzpk8NwV/Q1VN90M1tEmublba3127862gO6NUUkSNngu2eQM8Cu+Dq8YZDlT0r
+z1fCGrEQpFIsKKctk8YruLK3ezsYrd5TKUXG89TXRBybd0ZysTE80UwtzRWhII3FSBuKqIxxTwxp
+klkMfWnb6rbjS7jUtDLG+kZ2/hx+NQbjS7jS0Af5r56D8jT1dv4sfhUOTSgmqAn3U0tUeTTSTTAe
+WPr+lMZ+KYzGomY0AKX5oqBuT1P50UrhY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0023/full/!100,100/0/default.jpg</Url><Caption>29377_0023</Caption><Caption>Tamias Quadrivitatus, Say. Four-striped Ground Squirrel. (v. 1, no. 5, plate 24)</Caption><Caption>Exhibit</Caption><Caption>plate 024</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21ExU
+oWhRUgFRYobtpdlPApcUAR7KQpUuKMUwsQFKYyVYIphFAFR0qExjNXGFQkc0WGW0FPA5601KkFIQ
+tYup+LdE0lil1fRCQdUU5NbeKo3Om6Xue8uLO1LICzSvGCQB3zQPQ5pPHrTRm5g0DUpLJRk3ATjH
+qB3FdFo+s2euWIu7KTcnQg8FT6EV5bJqGseONQuZIriW20xFbyYUfYCo6FvUmqmm3ep+G53trW6B
+nmZUZN28s34Z/wAaz59TVwVj2ee5gt13TTJGPVmApiSR3KCSGXKeq9683Hhm91e8WfU21GygK5bI
+81nOex/hH1FdxosFhp9sLe0uJ5QTyZWLHI49OKtMzaRosOKhI5qw3SoT1piLC1IKiSpRSEBbapb0
+rkNdn1PVrebT4wlpDODGSxyxTOCeOmf611skiRRtJIwVFGST2rz3xb4ijlf7NbgljwIoky8memeM
+j6VMnoVHc5+aKfT4BpOnb3kuMR4QAMxyRj2HH613vhTwfBoUK3Fzsm1BhlnxxHnqF/x70zwtoIs2
+ivdRSBNQMWyKFMYhTqcerHPJ966yiMbDlK4hqkWEd8AuCko556MP/rfyqa8nNvavIq75MYRP7zdh
+XF3kkWkXOntMEW8Mvm3CQknYCWxx6YLClKfKKKudq3SoD1qdulVz1rQknSpGdUjLsQFUZJPaokNc
+548eaLw400UrKqON6D+MH19qmTsrgjJ8ReMFnEttZEiNc/Njlz9PSuW8J6jBb+KGvtVRmj25V9uR
+G3QEj8aydOttZ8QXSQ6VEkjAkSueFH51uSfDvxTbwthrS4zztjfBXn3xWPvN3NLqx1uprbPcf2pD
+qcSTI2U8t9xLe69uMAj0xWdb/Eu7tGQatpZEZ6yQnBx64PX86424u77TtR+y31xfWciN8plBww9e
+e1dOL2PxBpstlfogvIIzJFPGMCVQP50+bUR6Nb3kOq6Yl1Yyo6SpuicjIB7VmaT4Zi06W4muJ2vZ
+Z0VGeYAnHcfQnJrzvw0t82naiTdzR2Wmq8kSRsQC7evrjH616joV49/oVldSnMksKsx9TimmpPUW
+xdfpVc9asP0quetaXJJUqj4h01tX8P3lgmA8ybVJ7HIwaupU69KcloCMrw14ctPDWlJZ2wy3WSQ9
+Xb1rZpAaWpSAy9c0Gx16ya3u4gWA+SQcMh9jXmI0i58OSNa6kJAF3NazxkDzP9nPQH2969iqlqum
+2+r6dLZ3K5SRcA91PYj3FTOHMOLscNpt7HeeCNUsEtVtrtYnYxqc71Peur8LxNB4X02NxhhAufyr
+lNE8M65Y6iJJo4nWBjGrl8b0ycnHoR2r0AbUUKuAAMADtSgn1Gxr9KrnrVhqgYc1oIkSpRg9RUSV
+IDVWESAAdKUgEYNMBpwNFguNMKn1FOCKpBA5FGaQmiwDjUZA9BSk00miwDWPFQM3NSs1Vnb5jRYd
+yZSakBoooELk0uTRRQAuTikzRRQAhJqNiaKKAInJquzHNFFAz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0039/full/!100,100/0/default.jpg</Url><Caption>29377_0039</Caption><Caption>Sciurus Lanigunosus, Bach. Downy Squirrel. (v. 1, no. 5, plate 25)</Caption><Caption>Exhibit</Caption><Caption>plate 025</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25V4p
+4U59qVRS1jY0uAWl20vSkLUuUVwxRUM08dvE0s0ixxqMlmOAK4fV/i74X0t2iiuHvZV6rbrkf99H
+imok8x33WjFeOyfHm2VyItDnYdi0oH9K0dK+N2i3k6xahaXFjuON5+dR9cc/pV8jHc9RxUFzcQ2k
+LSzyLHGoyWY4AplrqVpe2Qu7W4jmgYZDxsCDXhPxY8cHV7kaNp83+jxtmVlPDH0o5Slqeu2vjPw/
+qF4LS01W1eY8BSev0re2gjtXxvG3kkFCQ4/iHUV9QfDnV59Z8GWdxcsXmUeWzHqccZpONimrHRmM
+ZoqUjmis7CJabTqoavq9jodg97qE6wwr3PUn0A7mtUSy9XM+JfHWieGIXN5dK04HywRnLsfpXCeI
+/jPH9nuLfRrCYMV2pcykDaT32/414zdyT3c7z3MjSSudzSMcliaHYOVnR+L/AB9rHi64KyO1rp4P
+yW0bcH3Y9zXLkxoMYoWJpEwp59KiaNs8g1Sa6EtWNC2IfBUKeO9WZYWaHLoh9MGs63ilV8qCFPUm
+tWO4jiUhFBb1am52KjBsl8P+KdW8O/aIrWWQ2s6lZISeOR94ehFY8cbsr3EgLEHn6mtKO/RY5Q8a
+5ZeDjoabDOI4Dt++xz0BH5UXb6GiSiaHh7wXqOtwfaIUyhZlz3DAZwfrX0T4N0T+wfD8diRgqxP1
+ya8j8H/ESWyQabPa2yM5/dzIm3Jx0I6fjXsHhe+l1GwkuZiCWfjDZGKibs7MT1VzZIopSeaKkkd2
+rzL4v2M95pFpeRo721szebsGSM4AOP616b/DXK69Irwz2biRhMMERnBA+vahySV2CvfQ+btTVrck
+bmIxtQsoBIFUN5cEHGe9ew61pOkaVpclxqFhEY0zlpDvmdvQGvJLie3u7yV7a2W2hJ+WMMWwPcmp
+5lNOxez1GxExEv8Awj0q1DG9ycpbkk9DirekaQ+pXISNT5KkFmr0Ow0aK0KjYcHqQKynVUNOo7Ns
+88fS784Z4CIxyQB2qjdfuFH1wa9pitIwu5xgE7QDjmuE8eJpVurW/kkXuAw2cbR/tetFGtzS5Wgk
+mlc4qzkjkulWUgIT1rqmsY4xsABBXAPpXH2tpJd3cdvCpLSHaPavWrTRo9MsYku3USlQqhh8xrev
+NQtqKn7xxFro0ou0yw+Ujb719A+AIHg8OKr45ckfSuBg0gzSMxVQowQRnIFepeHbZbTR4o1Xb3Pv
+URqOpLUqcVFaGixAPNFNf71FWZjzkocHmuZ1qH7PbvM53yZyADzXSBuK53XPljO9Mgngd6yrK8So
+bnzdrd7qGqajLNePJJIz7QDkAY7AV1Phv4efbbSO8vmkjRxkJwAfau4axt5tRhnmtYI3yfndOo+v
+4D8q34JbZyY0mjby+CqnpWNSvLl5Y6FKmr3ZgwaXbaLYkRW65GESMYyzVStDeS29zFcpGqkFPN6c
+5/p65rX1DUYY5imJJCOQRGSPzrnb3xDMbeaKKzVyeA0vQfgK89ztKz6ltG9YW0UAEpuhPuGfMJzn
+6e30rB8R+EoNZ1A3y30MYYKH3jd0rPGq3scIWKBEwPvbCcn+QrKvjqN5CBJM8iFjujUYGT24rqhU
+aejsFotanRabpeh6EftsEn2mduA4XIH0FOk1KK7vHURiWTZwzj7pP8u1VbazgtIFkuZHhkC7VQxk
+5+lMt5rW0meY3lrMjkZ2klgPpjr/AFpu925O7L5bLQng1G9ijzK21HwGXHIOePwr2TRVC6NagdDG
+DXlFjo1v4luoYLK5ZYkYFwQScD2J/wA5r2GJBDAkSjCooUY9q6KGt5GNS+zEkbDUVHI3zUV0GY9W
+yKR4klxvVWHuM1Akhx0qQSH0qQsKbG1kAElvE2DkZQHFSLbwJ92GMfRRTPNIHT9aBKcdKnQNSXYh
+GCi4+lRtaW+CRbwlvdBR5vtSeafSloAz7JDIR5lrAQPVBTxYWajAtYB34QUvmnPSgy+1UrC1I002
+wRmZbOAFuuEHNKdPsT/y52//AH7FOMvtSGU+n61SsPUckSQjEaRoP9lcUrNURl9v1pplz2/WmFhs
+rHf+FFRsdxziikM//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0038/full/!100,100/0/default.jpg</Url><Caption>29377_0038</Caption><Caption>Gulo Luscus, Lin. Wolverine. (v. 1, no. 6, plate 26)</Caption><Caption>Exhibit</Caption><Caption>plate 026</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3BUGO
+lSqgpEHFSgVmWN2Co5pIbdN80iRr6scVS1/W7bQNJlvrhhhRhVz94+lfPmveJNe8WXE8kS3M0UeW
+KQqSsa/hTUbjPo+C4trpd0E0co9UYGptgr5h8GeIr7S9ftPJnkCPKqOm44YE96+oF+ZAfUU2rCZG
+YxTDGKnIppFICnLtQ4Ib8FJqFoxnpV5hVd1+akMtJ0FSUxKkFMR5B8QI9S8XeLYvD2mqxigx5rfw
+qT1JrodTt9N+G3w/uEtkUzOhTcR80jtxk11Au9J0++YI0Sz3BLSMOSSOOa8i+N+ryS6xZ6ShISNP
+MYepPSnFp6DafU898PNFHrdncXLhIvPV3Y9lBya9kvvjXplvIY7LTJ7hF48x3CA/QYNeKwQGQoD0
+HANXruxihjVQ2ZW+6oqZTVy1G56a/wAcCxzFoZ24wSZ8nPb+Gp9L+ME0scX27SQcthpIZMfjtI/r
+Xmf/AAiOveRbNFp8pWUgqxGFYk4HJ4rvPDnhvTpb9bW40HVXvYIw0ivMgiD56ZHb6n8KTbewrJbn
+rtndxahYxXcO7y5V3LuGDQ45qvbJqBePz0ghhQY8qNix9ueKsv1pkk6dK53xa1/aQx31jdSRlPld
+Bkg+5rfaWOCIySuqIOrMcAVBcm2uYhKJI5EXqdwK/j2P/wBeplqrXKpy5ZKVrnkFnqFxLq093I48
+wEYPbd14rnfHlhqV3qUGo3iufNUBXYdcV79DZaY0AmeztkBOcGJRj9K5/wAXal4cSwittQthcAtt
+jjU7SOOx7VjG1KV3Lc6KlX21oxieBuHgtU28ZAq/4VezXxTaXOoqz26SbnUKX3YGQMfXFbHie10q
+7m06LQ7Z4pZmaN43kLY6YPT3P5V3eh+GYNLs7axt7P8AtCeKUS3EmzaC+OhJ7Djj25q009TKV46M
+6q+1myu/DVvfx2skizOot4njwwfOBx2wa0tH09tN02OGRkaU5aRlXALHk1QWFbaZL/W7y3hCE+TE
+zhUQ4Jzk4ycZreBDKCpBB6EVr5mI1qrv96p2qFutJsEYPjOWWHw3I0TlCXUMQccVzPhZpm3xzAtb
+sc5PRGxwT7V393ZR6jYSWshwrjqOx9a8l1XT5tN1G7RiTtAz83BOM1wYqF3d7M7sM1KDh1PSbiIw
+6WkUbiUsMDac8ckj+Vcl4j0RLzR47uaRYnRvlkZjwO/H4VwVxr+pw4s9Mvjbpu2jDYaRh6HtzVzw
+/wCJ5pNWt7HX5ZLqwlYwsJjzC54BPrj3rJYRSqxqXtZWS/4P5mTqezbS+8W6hspNLuJFiUw2xDG6
+fIYAnA2j6/Wo7z4saudNXT9LhhskA2+eq5cj154Bqz8RpFfWYdCtMJZWMSggfxseeT7Z4/GuMfT4
+ZZ1iiLFU+aRwPuiuxSUNGRN+0eiCbU7y+j/028uJ2Y5JkkLY/OvTvhRrGuyXbWU0dxcaSVOyZ+RE
+wHQMexHb6Vh+Gvh3NrGiT6lp9+gm3GNI3Qc4wevY16j4L0S48PaJKt+VWeSQyyYYEdAM+natISZl
+JGzq2ow6Tps17P8AcjUnA6sewohnW5gjnT7sihh9CK828f8AiyO5uYdOsy0sIkw7I2FY/X0H+NdT
+4FvUvfCNmUXb5W6Jvmzkg9an2l20h8tkdPGcLn+Vcn4n0yxu9Gv5rc4ugDO/mAhwByeDgjpXWRdK
+zvEqwtodyJEVnMbKhPY4NXKKa1FGTi7o8b+HekRa54ttxcgNFbQGfaecnIHP50fE3RjpHiiaaNCs
+F4BMhA4DdGH58/jVn4U3b2mu38qwNKI7UBwnVRvGT716x4i0zRdc0pP7SCvCcNFIp+bJ/umkkrA9
+z5+1jVVvdSN4z7vOhjL887goDD8wayreUtDKEYhnx8o7/WvQPEugeH9NRbeG3/eSHcXkmIKKO/pW
+FZeHpb/9zo8ctwh+ZikecH0z0rNpM0V0dD8PdUl0Bry5nuYRBcBR5RycEdCAPbIrQ8ReK7PU1kim
+1K5aMjPkwERr+OeT+NUbH4Z6/wCX5ku2Jm42mXJA/Diuq0/4XWEEDPeyme6x8jDhVPbjvTtJ6C90
+4HwzoOoeJ73yEjEVkp/eTHkhT1Hpkiva9P0620nT4bGziWOCFdqqBj8frTdGaP7AIkgSB4SY5ERN
+oDD09quMeaqMEkS3cWI8Vyni+6lm1Gx01Ffy5CpcopYkFuQAP9kH866mI8VLtVnV2RSw6EjkVs43
+RKZ51baTF4Iv7/U0OFviBHBkBlTOWBPOKydS1cfZJ5LWSZVZ2S2TOdmc9/SvWZrO1uHV57eKRl6F
+0BI/Ol+x2oAxbQ/L0+QcVDg2UpJHiekeHL7xVe28t1FJLaQOFmZcBn9snvXsuk2Fvptktra2n2eF
+Oi5GT+VWlHlghI1UHn5eKXdIf4QPqapQsJyuPpppSaYxqrEjSAM4AGetQseacS3qPyqNjzSYxImN
+TgmiihbCY4Madk0UUxhk0hY0UUCG7jTGY0UUhkbMcVExOaKKljR//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0030/full/!100,100/0/default.jpg</Url><Caption>29377_0030</Caption><Caption>Sciurus Longipilis, Aud &amp; Bach. Long-haired Squirrel (v. 1, no. 6, plate 27)</Caption><Caption>Exhibit</Caption><Caption>plate 027</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FEBF
+SBPpRGPlFSAVNihuwUuwU/FR3E8NpbyTzyLHFGpZ3Y4AA70AI/lxjLsqj1JxS7ARkdK8h8T6taa1
+4w06503UftlnJtikhDEeW24DkHGM56169bWyWtrHBFnZGoVcnPAqVqymrGVres2ehRQS3mRHLII9
+wH3c96uTvHFavcFl8tU3lu2Oua8j+LniDzLmKyQkRRSAHHrzWzrvjCOX4YW7onlXF8FtUjU843BW
+I/4D/OhDsd7bul3ax3EZDRSoHRh3UjINNeIZqxbRLDZQxICqpGqgHsAKa680NCLSdBUoqNOlPdFk
+jZGztYEHBxVEmZquv2elJ826ebOBBCNzn8K848V+JLrxLB9mghmtbdFJkj3gs3PcD044969PttO0
+/S1Z4YY4uPmkPU/Umucl8W+D7O7cefG0nRjHEzj8wMVL21ZUXrojgNF8Ga5qFoJhYosE7Fl3ytGQ
+R0Y4wT7V1kviXxR4YNtDq+lrd2xXaZbcktkenJzx64NdHp/jXw9qNwttb36LI3CrIpTP0yKq+OtW
+jsdLW3DATynKEnGMHrn/AD0paJXQ7tuzR4N45vFvdZWQSPtnXznBPc8DjqOnQ1DpuuT3EllcXZDW
++mKTawt0L9jjvyc++MVnvbT+ItYvruWXZDGNzyEH14Ue5pl0kdrHkEAJ9xRnDEd/w/nRsrF9T6p0
+i7N/otndlkYzQrIShyORmpnHNeffCIa+3hlHvJE+wGRvIWTJcJ0wpzwM5616E45qjNjL+a6t9Nnm
+s7cXFwiEpEWxuPpmvMZfiB4rFxLDLbWttgD/AJZHK/mxFerncIm2qGbHCk4Bry7XvD/ifXvENwsO
+nJbQh9qztIAhUcAjHJ9elZz5mvdHFpPU4zVtb1TWbiR7+6lljUZVXbC59gOK77wtb+G/EGmxz23h
+2eSdFHmk5WPd3wxbBp+nfCK0Xa+r6ncXbH70cfyJ9O5P6V3E2kRx6A+l6a5sVEXlxPEOY/Q0Rg1u
+OU09iI6DoNvAJn0yxjWIbtxiX5cd815P8Rddim895CC1ygitY0JyEzy34jFPg1rUrjTzouoTOkNj
+IxmBYlpeSRuJ/hB/PBrhby6/tLWX1K8dVjHESN/CgyBx+H86lyUgScQs7ORNMgtwDvlmL7AeWOMZ
+PsO34+tZSWU+oa/HpkMe5jIIwoOe+KvwXMkFlPdyOPMcFU5ww9Me3/1vSu3+CugLeahd6zcQgrbk
+LEzDOXPf8B/MU022weh7FpGmw6RpFrYQLhIYwv1Pc1O/WpmqB+tadCCeM8VKKhj6VLSuIdRmueuP
+E9tYeJm0y+kWCJ4VeGRuAzZORn8qv6zq8GlaHcai8imJF4YcgknA6e5o5kFjxv4h3htdev7ewgcz
+3ickdMZ+Y9fwrgmuUvFihnRYTaqplCnPmqP65P613BuYL/xlNeagARFb4SHPBL7jt789KzPGGmWV
+nbrJBHHE8sg3Kv8Ad5wK5oy/E1ZxdzLPdTohDYJyBX1B4M0T+wPC1nZMoWXbvlx/ePJ/w/CvDfCC
+Wd3r2lXOpSxLFFNtaQkAYX7oP445r6Lhu7a4LCCeKQrwwRwcfXFbRaM2PaoH61J50bStEHBkUBmX
+uAen8jTHHNU2CHo22Mnk4GeK8vk8fS3DXWm6gJDbvIYxPbny5Y+ccqe3v/OvUIjxWBr3gvTtbdrl
+C1pfY4ni7/7w6GpkpdBxa6nmt9p8M0stnYX891buwkAL7v4ck47Y6Vhrrt7pC3WjzTG4sW2zBH+Y
+AqQfyrc1Lw9rnhWZ7s2sgCgj7bYruUj/AG07CuCvIZJJSwulkEgC/KOue34Viou+prcv6Levd640
+oK/vm2nPOAB2/AUnjS7M13G6tnGQRnIXnis2wjltp4XT5GYt823BHFRa1cid4xksu3rVcvvaCexc
+0KJTpd40n3tpK+44zXtGj/D+yvfD2mXNx9p0/Uvs6+a9pJ5ZPH8Q9cYzXnfhvw/HqekCezElxDay
+YlAGN5GG/XPT6175Y3P2ywguPLaIyIGKMOVPcVcY3buQ2UND0C18P2kkNvJNM8jb5Jp33u59zV9+
+tSmoXPNW0JD4ulTg1WiPFTBj6frVkkhwRzXg/iazt73W9Q+wqscEl3lQq4AYAAn6E5r3cHjmqz6f
+ZMuGs4GHoYxUTi5WKjKx8wanIZMRRJhVY8qOpGeax7iKVvLGCwAxn09q+pJPDmhOmxtHtgBnGIwO
+v0qW38PaNE++LSbZMjBPlj+VChYpzucT8GtJls/D93czIVW4lwoYdQO/05Nel8AYAwKRESKMRxoq
+IvAVRgCkYntV2IbBjUDnmpCeOagc/NRYLixscVMGOKKKSBihjTtxoopiE3GjcaKKBjSxppY0UUgI
+2Y1CzHNFFDGj/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0031/full/!100,100/0/default.jpg</Url><Caption>29377_0031</Caption><Caption>Pteromys Volucella, Gmel. Common Flying Squirrel. (v. 1, no. 6, plate 28)</Caption><Caption>Exhibit</Caption><Caption>plate 028</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29UzT
+wgJPt7U5BxUmKiwyPZ7UuwU+kzQA3YKdsFApwFLRCG7fal2+1DOsa5dgo9SaFdXXKsGHqDVXANo9
+KTaKfSUARvtUZOfwGabgMMj+VTUhFAFVhzRT2HNFKwyVOlOBB6UwcofpXneq+Jb3RtZdrcho84dG
+5B/wNAHo+M0YrG0jxDDq1mJ4VPHDKeqmteOaOVSyOrAcHB6Vm2A7IXqa5LxL4zfQLloktEmUY+Yu
+QORnHSqGs+M7iW5ubPSo0UxKMyuuSfoOn51kQ3aalp07+IntrZWZdkgQDzDgjlRk/iMVKlfYGclr
+eq6l4n1GWW/meOBVYrArHYgzgYHfvzU+i6xeeCr6znE8rWcyB7m2JyCp7gdiK0pdFt/9MuorhJYF
+jAxEuQRkDA98VJqllpniW1zaLNbPbQEfvQBu9F61abFY9etrqG7tYrqCRXhlQOjg8EEZBqbNeHaT
+4s1vw5pFtpqQ2lxaoCscjq2eucHkY/KtrTviJqwkG7S4GU8FVdh/PNVsNK56vSGsXQfEtrriFAjQ
+XSjLQv1x6g9xW32qk7i2IG+9RSt1ooGPX7h+leZ6+sU0lw1wqowbGfXmvSy22FjjOATivKdQuDqD
+StEhVif9Uw5yT0B71L2Giv4I1S20261C1nbETfMCegxn/Guon1Gz0qI3b3lvbwTLkl2CbgR6d68t
+uLNvMlaU3ALdo/lXOenqagl0SferXLMQcKpYHgZ965Z1I3L5Ga194n0yNmSxkvZAT963QJnn1PJq
+JfFtvcu6SWyecB+7+1R98eo4NbNj4NneMeTalwR8rYwKwfFegHT4sSqPNXqQeBWMaqvtoNwLia9f
+R2zxvDC7MMhkXaFPpjNWUtb+40xZDdQxBwSUEfQfXNc5pmpRXFgIZmH2mP5Of4vQ1G0MrY8yRyoP
+C7uK6k2QjXNrc3EUltvjk2qQGQdx0roPCrtdx7pEQMi7GGBkNXJ22tT6ajeUAg75UGhdXtLuYyOD
+HIfvPE20n8qvdWZVnuei+WtvfwzWzBZ0OQqnDH19667QNVl1PzjINqqcKDjP415jolxpml7rtJZA
+zD5mkPauz8FFbu9u9Qjb93KoAXPSqhvZEzOwbrRQ3WirJHJyuD3rzHxJ4dtbG4ljhjmeSVjKgLkj
+P4mvTIzxWZr1ibm0Msab5IwSqisqifJoNbnnFveLpkCC4u7gzswVVwrZb8elP1OC/vo9peJVHPPp
++FZOzUJ9UCz2MqyRElQYyOAa7CDTruezEl1AkfmD7jck57GuGpzNLQ0RzcHizxFp9rDYWtlYOM7E
+IkLYOe/Iqp4ni1fUtGgkubcLOw2ShGDAt7YJq5ceALl5zNYTTQgHjb2/Mj+dK3hjxHZ24Z9WQAHO
+yRMgfqRVXukmT1OF07RDDcSDUYJPLPzEoeV+o64+lda/gjdaI8N1MV25zuzx+NWrTR7q9EjXGpJd
+woxWRLVVXnuCQc1buNZkgjaOK2DBcDYJfu4x2FX7XXcLGSfhu1xbFnuJ9w7HHFZg+HMtuHcPIVGQ
+S2OnqK9C0rUJbqzZzvLs2NiknB/Gn3Vu5Qu86RqpwVZs9vQVXtJdGVY82uPB1ylssi+a8Wcjcenv
+Xpnw3tltrCREC9ecNk1hQ6fqdxcYgtrp0zlXaIiM57jJwa7vwxpbaZp370MsznLhhj9K1g5OWpM7
+Gyx5opjH5qK3ICNuKk3joappIQKlElAFgBDztGfpS7UP8IqDzDR5ppOwEwjjGcIBnrVa6tLO6jeK
+ePcp4IyR/Kn+aaQy56jNTZAU7LRdG09HS1tI4w5y2Acn8aafDehSymT+zoS/dsEE1eDAdFH5U7zK
+OWPYNQis7WEKI4EUL0wOlPMMJXaYkI9Copnm00zc1asBNuC8AcD0FNLcVEZqjaWi4Dmb5qKrtL81
+FK4WP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0033/full/!100,100/0/default.jpg</Url><Caption>29377_0033</Caption><Caption>Neotoma Drummondii, Rich. Rocky Mountain Neotoma. (v. 1, no. 6, plate 29)</Caption><Caption>Exhibit</Caption><Caption>plate 029</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JEGK
+eFFKo4p+Kiwxmyl2in4oxSsIZtpdtOpaaQmxm2l20tLVWC4zbRt9qfikNFguRttXliBSYBGR0qQg
+GkIoaGV2XminsOaKixRInSn0wHahOM4FZ1rrtnMp8yVY23FdrHuKq6W4jUorAn1aZtTtFtP30EnD
+7OcD1PpV3VdYh0uJXkVnJ7LUOcbNvoFmaRNJmsfRfENvrW8RDYyn7h61r1UZJ6olodRmkoqxDs0h
+pM0ZpjFpDQKWkwIm60UN1oqChlwWFlMUxuCHGfpXiE+uQec4LoQsxbHmdeTnrXueN0RB7ivH9Y8F
+TTazLIIAINxPUA/hWVays2VEv6frVs0CmG/jhdlIZZJwe/Y59vSluBczIA1z9oHbEtc3e2kelQsA
+6TMo5DgFR+PWskahNNGCsUEa5xkLgj6c1xSnJ+hbSW53+mT3ekO00FuyBvvAyjH41r2vjG4X/Wwi
+UA/MYyDgfhXksc82pXxs5LmVrcEBE3cMcdcVe0mWK0aBHjKlpcukfBPbg9u1P2s4O1xciauewR+M
+dOlhbyyWuMEiHox/wrl7/wAf63Z3qtJpsKQZ4iJIZhn+8eP0rl9RmuLSaO+ltLqJy+6OZWVj9GHb
+gVpQy2nitgLpRHMqjy8SBQSO23PNb+1nJXixRSTtI7fR/Huj6tC5LPbzx/6yCRfmHuMdRWlJ4m0u
+NQTcZB6YUn+leHx3MmgeKYbpxiNC6Pu4BGDwce+K6yDxotxICi26r6NKUH/oNbwq3imyZQs7I9Bh
+8VaVLjE+M9Mg1q213Ddx74W3L64rzc6xPMgeG0tRnq6ShlP44rtPDdxNcWDGeONHzx5Z4I/IVamm
+7CcWjWbrRQetFACr92uS8U3ogP2eHJlYcnpxXVoeKyb/AEOK8uDMeWPY1FRNx0Ki7M4KPSH1OLOz
+7oySQFUfn1rMk0BFuRC0UiJnO8/xH0+leknRXiikRVDq4wVNZt3p+oTXbSPDKxSPCdME+ma4Z0ml
+fqacyOPbR9GgSWO0ZJb2KMyFvOKspB5AGOcDrXKXMME3zwOzSbiecZzn8816JdeE55rhJ/JLSqd2
+V4Gawb7wrdm93SabdpGDlWgOMfXHNYp1ZyTcbIz1OfbUdSXSTa30ErRD/lq3OOc1a07TLmNLe5t5
+VSSQ4XoDnpxnrXTv4e1GK3WWOJxlSCr5JPpnmsiDQvEy3W+200IBkozxD5T6j0rRXvaxXMupFc6G
+TCv2y5f7S5+VXbOTVP8Asie2Db1XYQO2MmtltC19meRNKkWd+HJIKseufY5rZ0/Rtbug0mo2ojKn
+A+U7sf1H8q0hztaoFKN9ThbcXpupIIkbcBkkdOP0r2LwZPJPpTmS0W2bf0Xo3vWPbeFbgXEs6xBG
+YADcea6rR7SWxsBHOVMhJJ29BXVSUuop26F5jzRTGPNFakgjcVJnPeqiOcCpQ5ouFiwDx1zS5qDe
+aUOaTYrE+aYd2eGGPTFR7zRvOKXMJocPMPVlH4ZqReByQT64qDeaXeaaYWJsikJqHeaC5qrhYec/
+3jSFqiLmmlzRcYM3NFQsxzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0019/full/!100,100/0/default.jpg</Url><Caption>29377_0019</Caption><Caption>Arvicola Hispidus, Say et Ord. Cotton Rat. (v. 1, no. 6, plate 30)</Caption><Caption>Exhibit</Caption><Caption>plate 030</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUGK
+ULj3pwHFLilYBuKoXOuaXY3S2t3ewwTP9xZW27voTwa0gK8+8faNpOpHz7txmDCk7yChY9ucUnoC
+1O9R0kQOjKynoVOQafXzXpWqa/oMl0dL1KaO2R2X52BRgM84OQDwPzq1L8R/GF9bNZ298Auf+PiO
+EBz7Z/wpaCdz6K4oxXzDZeP/ABZpNwXe9nuEzk+dk5/E16T4d+MdhcRBNXVrdwOWIyCfrVpCueq4
+oxXnFp42l1C6lvIJw0BIEcIPTPAH9a1v+E4gskZ77gdEUfeb/JIH51N1sUdgykj5SB+GaTbxzyfp
+VWw1a01CGN4pkJfooPU96ukU7AQFeelFPI5oqbDHjpRRnapPpSK6uoZWBBq7iH14v8RIfEHh2aVk
+uEutMv5T5bTLveBs5xk/pXs4I9R+dZniHQ4PEWiz6fPwHwyN/dYcg1IbHz5GzQWDhyrNMoYhuASw
+5/rWWXNnB5EbPEc7mKcM3oB7Vv30txY63NpF6IbN7NSjSIoJI6jBPrnNYDarNaXO5BHcjJx5oz+t
+SwBNOu9QImvLny4VGAZn7egHepJrSydDBbQ7UHV3OWb+gqsHurmV7m6JIY4/+sBWjBASU2tj0Of5
+1SAzBFe6XJ59hNJHjnGeKuJ4hl1FkW4wsyDG4nv61PN5m8hecD5h6+9Y95ZNzMg27earR7jtY63Q
+tcn0jWba7LtgEhUzwBjlj9a+hreXz7aOX++oNfKcNy10FmDfPGnzA/WvpHwVqZ1bwtaXDDDAFG+o
+4pLTQGbh60Up60UgF4CEnsKyJ762UMPtCKQema0rlglnKx7Ka8j1S4mS6fygTycErVdLiZ276rbh
+8falOKgPiexjQlroYBxwef8APNecfadQMjosnXqCQ36Vm6tcX1naGachVJwoUKNx/Co5ruyYrFTx
+/qo1vxVKwhRYYFVQy8tKMA7j+dYDS+b5aRWrcNjgZJPpW3DoOoXcQnmCwbzuBlPzHPr/AIVoW2ln
+T5C0yEyxLuBBO1h6iolUiOzKt1otwlhHKEZCBko3+FUY5iLiMFSHyFwB940utX+o5EyXB2FQNntW
+bpOrIuvWc14DtSQbs/lVRu1cDVd3mumVImGDzgg/nUUqKiZJbJzWhd3kIuJFt4wq8ksOpFY7XolV
+g+4E5IGKtDK2n4j1KSEgbZEI57Gvof4cQxw+FUWPP+sbd7GvnbTAsmsqx5ABz9a+k/A8Bt/DFuhb
+cetD3DodA3Wig9aKQDJ0821kjHVlIryrV9PnN26SsSEPQntXq6nivPfHGlaikgvLcB4QHLtnHlri
+oqK8Rp6mHHFDbfKzRp8xG88D6VJP4WhmvVvZ5pJxEAUXIAU+wx/nFcs07xiKO/dW2t5wZZAcqeo+
+uAK39L1iC8u2js7hCgXITPft7+tcjnydCt9zUE9tBtBiAkxkh8swH1rn9X1FpmdFBVSOhwMfhXTw
+2Uht43Yb7iQDzAq5xVTUtElZfLiVdwOWYDAP1rGpJrYGrnm94lzuyYfMHopqgmmpe5LwyrNnCoi5
+BGeTmu+bw/HGhE8x87kttPA+uasaVo5iidUQBwSTIe4rop1WlsTynnP2PUIv9dEQw7A5zVJ2ZSXO
+eAQAe9drqT31zdSWGj2BMij5rtzwoPoO3480sXgh7azSIpJcXTguzRjjt+fWulVbL3g5exxFpNJb
+ncnDsck19NeB5JJvCtrNIMGQbgPavLNM+HNxcXNr5tvII3Y+dn5dg9vWvadOsYNL06Gytl2xRLtU
+ValzaktWLDHmimM3NFIYqtxSSKkqFJIw6nqCMg1XSQ1KJDVBYypfB3h2eRpJNJtt7DBO3GPp6fhV
+X/hX3hkSiRNP2MBj5JGX+RrofMNKJDUOMew7so2Xh7TdPUi3iYA/3nZv5mp3tLQIVaH5fpU/mGje
+ajlj2E7mfFo+kqzMllHubG47Ov1q4lhaqMrCqkj05qQNgcCl3mqSj2FqRJp1mgIW3jGTk4Ucmnra
+28bFlhQMRgnHNLvNIXNWrDH7sdEpGaoy5phc07gDP81FQsxzRU3HY//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0024/full/!100,100/0/default.jpg</Url><Caption>29377_0024</Caption><Caption>Dycoteles Torquatus, F. Cuvier. Collared Peccary. (v. 1, no. 6, plate 31)</Caption><Caption>Exhibit</Caption><Caption>plate 031</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJxT
+wvFOAp2Kmwxm2lxS1zM/jWwXxjbeGrdHuLqTPmuhG2HClsH1PHTtSsI6Wlqgmt6VJqX9nJqNq17y
+fs4mUvxyflzmr+MmmkS2LRikJx6U0zRr1cVVgH4oxUX2mInG8D605J45CQrAkdqLDFZCRgMV9xTd
+pAwST7mpaaaQyuy80U9h81FSUSjpVG4vGjYgECrjHbEzegrkNS1hrcyMUBY52gmqbsrsSV2bEuqy
+xqTlG+lfPEGsT2+oapqsUrx3EjOkcoPzBnJyR77d344rtL+/1C5ePdNdku2ZIwu2MA9Bn19q42GS
+0sPE0F1OP9FiuQXxyBwecfWoU7uxTjY7f4beGrjTJ5dcvYjFcTLtgjcfMqnqx9Ca9Ek1ERKXuLlY
+Yx1Z22gV4/qvxGv7mVotGLRR9PNkALH6DoK5uZtQ1J/NvruaYk/xsTTvYmx7Tc+PfDtmSjamsjD+
+5l/5VRPxN8Ph/wDWzMuOojNeTpYRL97rmpltk2/dGKfONRPV4/iJ4duGA+1vH/vxsK27HWLO/Aks
+ruKbH9x8kfhXiVvYxSRtLIMKPuj1qk0s1rOJbWSSB1PyspwRVKVx2Pov+0ZlI+cmtW1n+0Q7jjNe
+Y+CfFTa5aNa3zAX0GNzcAOvY16NpZ/dEAgj1FNktFpvvUUrdaKgBJzttHPtXmuqxs7Ss8bM6ggHn
+pXd6xera2DIHTzn4RGYAn6VykVrJqIYC+iDsMPGX3bMHqMVhWctkrlw01PPNQvNVik+xq3lRydCv
+VqyrzRHRMSjaOvPrXbeJvD8umm3v4pDdeX8r4XB65zisLUNTtr+HBID9MYwc07NJWHe5y1ssUb7R
+t8wHBGOtbkdsHUbkOT07YpbPw/HHayXbpIjDOC4xke1FozRTGN5DIhAKtngin8ROw9reNAGYEjuT
+SWVi2q/ahbA+TbJvnfHT0Aqe6yYH2xFjjover/w5v47TVLuxvY/LhvV27mHG4VfJoFzkbm6G8JET
+sXoKqefuGHArqPFfhyTSNVciMiFiWUgcGuXVVBkJG4LziqjsBa0u+k0vV7S6UZBOxx6qete3eDtS
+Se7uLZW5AzivAhDe3Fwjx27MQflVQTXtvgCx1CGU3N5bQxyuvJQHOPfmiSd00D2O/brRQ3Wigk57
+xN4dtdYijuJAwmhGAysRx1xXCNZPpjBLcsGfjO8jFeryr5lu6juK8r1W9kgvjFdwMNjE/MMAe9cO
+MjKy5bmsH0K0Gk6jfPIq3s7M3JaVsIo9hVKeSDQrsqzpczIMlmA6+3pStNDLcBBPJJjuHIGPSifw
+/BeRmTc6EnP+fWuSNZpczuW46GJfa1qF8jGVz5QIyiHtVWDSRfSbmOdowDuIUCuhsPCxa4WQy4iP
+8AOST71pw2SfZ1aSJIWYnaAMcds1M8XPZE8mpxMdq1lKTHHskQ/xHI/Gi4uLuIKYljCnnryT610l
+7aRKpMq74wOsZxk1l2clnHfrc6gf9Hi4jgQZ3Htn/PauijiZyaSBwN7RNW1zU7IWWr6NJf2eMJPG
+cOg9s4BrnPE3hubRJWv7cn7I2MrJw657EetbGo+IPEGoOv8AZVq1rApJEjD7y9uo9KxLiw1bUpkO
+oyyTgc7wSwU+mM8V2+1jHdiUWY2mXN/Fct9nupoo85yGIzXunw83vp8sss80zkj5pTnHtXndlYW2
+nyoLmNmL8Ku05Y+wr2LQbU2mlxq0CwuRkqKzpVXUqabBNWiaTHmio2PNFdRkKjcVT1DSdP1VAt5A
+smDwehqaNjtFShjSdmtRmNB4L0OB96WvPoTkVW1rwPaarEqQ3Utnt7xKD/Ouk3Gl3GsnSpvdD5n3
+OTt/AEEUMaPqNwTGcqYxs/Prmn/8IVAIpYpdTnff0JVciuo3GkJz1rP6vRe8Q5pdzibv4a2N3IHf
+VbkEfdxjAOKXSvhlaaff/aptQnn9I9oVf612i4A6CnbjVxoUltEXMzDvPBumXsSRyNcKq54SUjd9
+ar/8K/8AD21Ve0LhQMZc/wBK6PcaQsav2VPsHNLuV7bTrGyULBBGm0YHGTVosMVGWNRljWistEG4
+rNzRUJJzRSuFj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0029/full/!100,100/0/default.jpg</Url><Caption>29377_0029</Caption><Caption>Lepus Glacialis, Leach. Polar Hare. (v. 1, no. 7, plate 32)</Caption><Caption>Exhibit</Caption><Caption>plate 032</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NUHp
+S7AMk9KV3WKJpHOFUZJrg/FPisGB4LZysbDAlQ9/Q1lKSihne4FYviPW49GsGcEecR8gx1rk/Cfi
+i6k00xygtHDwJJH5brwc1zPifxHPrFw8CuVhhHzEDHNRKWgrnr2n6taX6xeXIC8kQkA6ZzWhxXgd
+nrNxY69ptyGfy4VCEs3BHvXrV/4otbWCMRyJJM+OA3Az3z6U4TTVxHRcUcV5hN491KyvXZlhmhHB
+QN3+uK6KXxosVt5/2fK7QTyepFVGrFq4zrsUmBXL6d4vivdOaR1CXCj7mev0/Krel60L+zlw485W
+IKjqM1d1a4jcZcjAJB9RTduB1J+tVLG9M+6OXAkXn6iroIYcEGjRq6GQsvNFPI5opDKesS+Tprtu
+YDp8teQa8/m3Zi+VU3bQw6ZP/wBY17Fq23+yp98ZkXbyorw7VZXl1GM+U8cMbkAkj5j69fpWNRpS
+1KSL9pNdWdu1vNIuVOVVf7vtXNyXERW53E+YXJO761qtbi3M00jFti5fDcqPpVI6Kt2PMiWdgck7
+ASCPXOOalSUkTKNh+om2msI7m0nR54cGSJlzvH94f1pll42tJJNuqKsZQArhTg8/0xxVtLCKynjn
++zzom0bg6f7XP04rj9Z0owXsgtke5gDZDqh49icYP4UQUbcrFubV34t0+a4dogwUnhthwfwq+fF2
+mahKkckpUIMAsSAfw6CuA8wyyLGicKORU00kDKcxgEccVrGjBDPYtGisHtTctEGkD/K4ckEEdq1I
+porLd5QWPeRnHHP+f514tout3+guJYHL2zn5oWPB/wAD716TbXltrOlLdWzNlgTluMHuKJxa9BWO
+oXW5Y7lfmXcDXV6PeLcs4RiQAMntXlk00gAJHzEDJUcE10vgzWkiuVt5iWeVtoI5JJ/yfyoptrQD
+0JutFK3WirGZviGOWXRJ0hfYzLjNePWkKSag9tPJKJV+bbjAI74r2vUUZ9OmCKrNt4DHAryLULrR
+NPvVubi5ke6QEGKFgFBPBG41hVhzMuLSRFcwxpcSSOGkS4XhlHXA5x6dKo6fvuBKmlalHFAByZJQ
+jKe49efYVuJ4n0TUNNa3jspoLgR4VzHvB4/vD8q8v1Z57S63pB5fmZ2Erx9RWSg4y0ZTldHq2oIb
+a1eU6pm2ihO9XJ3H5fXuc/SuTstVhxJE7Jb/AGhdqzKQ+0nuTgZ7VwgVnX95ISc/xtUwg3xsY5Cm
+OoBoqJT6ijFo7NfBGnrBJP8A2tuyclwgHP8AWuU1TSk81YreQySscKDGU3c44zU2narcxqIrljJH
+yA3dTW/cW1tFbWmtNe+aHeMLBsKBCCOMkex5rWlzxu27g0jh5RLBF5boVYEggjGK2vDHieXRQ1vL
+GZbORskDqp9R/hXWa69jqti32bT2+2lvukdv7wx1/D1rkn0O5s7do5YJc7d7qygEe45yK0hWjOPv
+KwnBo7mK+s7qFpbaXchxtwoAHrx1rT8NWrnWYGQvs3bgGIUMDyeSOf8A61eTQNd2GJoWJQ/e/wDr
+jtXoPgTUItU1iBIx+/3gskkm3aM549fyqnC2qM2j3Q9aKD1oqhg6CSFkODuGOa8t13wjbyXTyyoE
+lyTuVAQOfpXqaHis3VrLz4WkUEsAePWsq0W46FReup5NrGoab4XsY5p99xM/yqo43H/CvP8AX9ZX
+VryGWO0MEUcZAXORk85rrfGVlb6tILWXUFSaJiVBH3TXJhdU0y3aMJb31oPlcIQxA+nWuanyqN38
+Rb302KEKTTbo4UaQ45wOF+prQh8NamoL5UqRuKqTkj24qz/Z+m3NtbXGnXTWjSHMhZjlfwHvXS2u
+p2rW0VlHfpPNEuDI3Vj65rOdVx+FDtc4CB5vPMKRMZCSAK0rfT76zmBurV3jC7kUv8oY98VsXGhJ
+JqH26PWLeORT+84zj/E1S1HxNGYWWCVn3LtL5wD74rRVHL4UDXcqR381lcNbo6yW56oxOB9O4rpr
+PzJsCe3aXIAVycMAOgPrXCwJLqcnl2ttNNM/yjaMlifX0r2TSPB9w2i2L3iul3HGPMSMgZPv6nGK
+2dPm9Sedo4jUbG5inMkEOwj7y7eGHv612vgHQba51iDVorMW8kYLPgeueP8AOOtbtp4Ke5mMl2fk
+42hgGx7V2tnZw2MAiiGAO+K1jBrczbuTMeaKYx5oqwFRuKduHv8AlVdGOKkDGkBUu9B0jUW33enW
+8rHqzRjNZk/w/wDDE/3tJt1/3Vx/Kug3HFAc1LSA5NPhj4XjJ26emD2JJH86V/hv4YCbf7OtlGc/
+6odfr1rq95o3mpUY9gdzkE+HPhhWJ+x2+T2K8fqauQ/D/wAOQlSul2uV6fuV/wAK6JflHHel3mqU
+Y9halG00HTbIEW9rFGD12oBV9YY0GFUAUm80hc1asgHlwvGD+AppbIphc1GXNO4xWbmioWY5oqbg
+f//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0043/full/!100,100/0/default.jpg</Url><Caption>29377_0043</Caption><Caption>Putorius Vison, Linn. Mink. (v. 1, no. 7, plate 33)</Caption><Caption>Exhibit</Caption><Caption>plate 033</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NU+U
+YqUKKbFzGp9QKXzovOMPmJ5oGdm4Zx9KzViyPz4PtYtfMXzim/Z3xnGan2ivO7W9+0ePWlneUSrJ
+5caL0+9jB9sCung8UQ3niQaTbQs4XeJJs8ZUdB+PesKOIjO99NbIbVjd2ikAU9MGvL/jTrepaVZa
+ZBZ3EtvBcM4leJipOMYGfxNeZ6P4413w9dxXEF9Nc27NhoZXLA//AF66GI+lbq4trKEzXM0cMY/i
+dgBUNte2d6m+1uYpl9UcGvDfFXiu98b6vHbW6smnwY/dju2OSa7Xwbo9xE6RIuIVx5jg43Y6/hWf
+PrZIvlstT0CSNjjZt/EVBJHwM4z7VdK4GKryjpVtEolkSSTT2SE4kaPCknGDiuU0/wAM3NrqaXeo
+XCoq85WTlsdAD1rsYhiJPoKztf0yXVLFIoW2ur5GTgcgg/zrnr4eNS02m3HZX0BStocbBrOn22o3
+WqvaE3TMfL+bjaeAf97396k0WOPw5o1x4huBvkdB5MZbkhiByfqa0NZ8OaXpOlSarfPJJDY25dol
+48xh6n9K+eNe8S6p4hna6v7l2VmxHErYjjUdAFrKjQqKXNU6bf5g2nse36vC3xF8H6pEzRG4tQJL
+cIvAcAnGffGK8K0cySTiEjLKxwCOhpmn6rrOi5msL24ty4wTG5wfqOhrV8KadLdXQ3K37xsZxz7m
+upJxhZu447nYeHdJit4jJO8ccQG6aRjtAHXr+X4V7TpGlR2ECNFO7h1BPIKnjjHFeD/Ex7rS7Kx0
+yJj9mlLNOR/FICPlP04P5V7Z4Gknk8D6O9wSZDapknr04pUktxzdzdIqCUVYNQyVsyETxfcX6U+o
+4j+7X6CiaeK2heaaRY40GWZjgAUJ6CZzPxKdU+Hmslu8G0fUkYr5YKskIjk42/MPWvZvif47j1TT
+7vRbOF1gUqZJHGC5yCAB1A7815PBHOXR47GVpXIXIjLBvoMVm5pvQdrDtOV70BZHHlg4IXqK9l8K
++HbnTdD+3sAJHPyzDHyjjkjvxWf4C8E2+oWzapqsEUU8cm2NI2BJx13gj5frXpek6bbrazW8epG5
+DAgsCpC57AemMVhN8ysnv5jvYwpfDsHiKdY9ZsWkjnxIXUY8uVc5/A+tdTbappsOnM0cgjtbZvIB
+I4yvGB61xl/430fSddmhmu3ylr5CBhzkE9/esXS78aubG0huFiQOzSCRvlyQORj2Hf161i6s6EVF
+K+/6frcNz099YsVit3aYKbg4iQ/ebnHSrMleZ6fcSPfTatdjzbSyO2GQHCOc4VVPp6n613+n6gNT
+sxciMopYhQe4HetaGJdW6krP+rv7wtY0ov8AVL9BXFeONfW1jkYYa208GSbPR5yP3Ufvz8x+grR8
+ZXk2m+FzqMBbfayxSYBxuG4KQfb5q8r+JV7LDo+j6Z5nmT3ge/umHQu54/AfN+laylpYEtTm9Phk
+1zz7m53SS3BZn4ycdzj1/qa9I0HQ9Q07SILhYRdG3KqQ7gKFGPzrF8H2Mdpp0csv7tcKN397Pb+V
+dT4thfTvAmp6hol20wfaMq4IROnGPY1gk5OyKk7FSbxz4aSRbpb6WxO8/aLQQgiX1yB+PNOsfiJ4
+IN8hgkntCXyWZNoPp+HX86+eWLNcNlj15z3q9EkZBVs59RW/1envJXZndnrXxP8ABqaxE3iXQZEu
+I9u6aOM5P1Fcf8OLhrrWJdMkdt0sEghz/f2nArC07XNZ0IuNPvJY0YfMoOVI+lbvws0281Hx3aXM
+MbeXC5llkxwKqpTU4uMhHokGm3M+mxoAVt5rlwqtwpfI25H0zXpsKGK1iRkWNgoBVegNTSWsMlv5
+BjHljoAOh60SVyYfC+wu732LvcwfGtu1z4D1OJRlvIDAf7pDf0rwXXrt9W1u15YiCKKAZ9FXmvdf
+HFxHB4KvFeUo0iqi4PLfMOB+Ga8T0K3S61ZZ5FyiZJJ6ZHJraX6FwXU6XWLlrTwlbWMIP2ibCqo6
+k/5zWFeXWuxaJNYxv9njuMC5C8qR+XHvXRR7bqZb8qjfwwqeAoHVqyorTxHrjy3GjQTyRK2C6KNo
+PoMmppx1T7Dkkecahp09vdxAKjGf7hiYMGOccY9+1RT219p8x+028kefUcV6JfRXSpFBreizpNE3
+yytGVOfYipdOhsJoja3OZoi3ymZuR6gZro9pbdEch5wLhwonVmVgeCtegeEPinc6Eltbz6ZbNArf
+v5YkCySKcYPYZHP1zTtZ+HqvE8mkzImeRG7cH8e1VPD3w+imvYLfV2uo38xQ8IXZhCcFlfkMBkEj
+jiqUovYlxZ7p4a8ZaP4ridtNuMyxjMkEg2un1Hp7itmSsrw74Y0vwzYi306BQcYaZgN7jOeWA5rU
+kqZAjnfFPhh/EmnRIlwY5IxlVP3ScVxKeDLrTIkszCVEi7XkXn68+/8AKvWYifLXB7dxUw98H8Kn
+2aZSk1oeQXGlXEEHlWsJDSAQxJjkA9TXqeiaXDouj21hCoCxJgkdz3P51bMUbOrlFLL0OORUlXCH
+KKUriSRxyoUkRXU9QwyK5fVPh9oGpM0gt2tpm53wNt5+nSunbd2NC7v4mB/CqaRKbR5dd+GvEHho
+PJZst9aZydo+cfUf4VY0ix1PV4RPDEYotxOHyn4Y6flXpRNMJqHTVy+ZmVpOn3Onw7Jbjeh/g6hf
+oavSGnt16moXNO1kIIGPlJ9BVgMaKKFsAu40FzRRTEJ5jUm9qKKBiFzmmmRqKKQETSN7VXeZvaii
+kB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0021/full/!100,100/0/default.jpg</Url><Caption>29377_0021</Caption><Caption>Sciurus Niger, Linn. Black Squirrel. (v. 1, no. 7, plate 34)</Caption><Caption>Exhibit</Caption><Caption>plate 034</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3SNcI
+v0p4X1xQg+QfSvP/ABl41NtJNp9i5Vkyskq9j6Vi2oq7NErux6AGTO3cufTNcZ4z1jXdFl32ckC2
+zpujZo8/MOqt/MdO9ed6Pa+JNVmOpRi9+xxjLT7yAcdxzz+FdbPqsviXQJtNmk3IRxLgFsg8GkpX
+XYdrHXeE/EcfibTDceT5M0ZAkTOcEgHI9v8ACt/aK8q8NXzeH/F9tA/FrqEYhPYBl+6f6fjXqV0h
+ktJkD7CyMA3pkdauOq1FLRmNc+KNIt7a8nNyGFq/lsB1ZsZwvr6fhWpFJHcQRzRMGjkUMrDuD0rw
+1tJuba4a1uiY2ibEm49wa9D8Cy6rMjpJdQSabCoSNQcuD2HsK56dfnnyWCx1e1iTuRQPY5qNkANW
+2FQuOa6WgRZA+T8K+etRjzfSm4LbpLlhPnsS5zX0Oo4rzH4geFVSdtShX9zM2ZB/df1+hrOorocX
+Zno8FnbppaWcKKtv5Xlqq9NuMV4/pkUuga3daXcHmFyAD/Ep6H8q7X4b69LqekyafctuuLHCBu7J
+2z/Ksf4i2Y/4SjSriIYkkiZJCO4B4/maqTvG6Et7MwvE8yrqeltGCCHD5/ugkn+lbHifxNqmqWHk
+28JtbPajvKXH7wEA7c9uTWL4lkVZLVJGUEKEZsdAcgfzNdzaz6DL4ctJ9S+zgPAI50bgkgYPA68i
+s2207Ow5HEi6lv7pLrWMSCcbQQgXCjIGD378mvS/DGlaVYaXHJpkJVJVBaRs7n+tec6kkdxqEn2G
+B0sxGscSt1KjuR68mur8FahrVxJ9juHhktIFwWMe119BxgfpXNh6kfatN3bB7HaMKhYc1OahbrXo
+MksDpXI/ELVPsuhmyjhaWe6O1Qq5IrrhQ0Ubsrsisy9CRyKiSbVkCdnc4X4c+HLrRrS71PUVMM10
+BiJjjYg7n0NY19qtv4g1uW7KsBCyxwnPGO+PxzzXeeK7K+1Lw9cWensFmmwpJbGF71xdl4Rm0K3S
+7vIRcCHJWOLqTz949hz71jU5k1GK0LjZpt7nLeIdPvdc1G7+wRO8cUatIV/2TnNZ8GpWr3NtBfS+
+VFcMi+Z1MYGQ2fxrrrDRPEeqSM0fnRQSHDOWMUZH/oT/AMq5LWNPj0/WJrR1hu4YZi7suQGz1XPs
+T2rOcU3eWw91bqdXomieJbuYm2PlwqVImuFwCAf4eOen616jb2cNszPHEqO4G/b0/wA8mvMdK8ba
+tpunR20Nsl7DbLt3SE7yvYZHoOOnaui0n4maPqE6W92kthM52jzuUz6bv8cVtTpwgtDN3OyNQsOa
+lyCMg5BqJutatiROtVNY1KPSNHur+QZWCMvj1PYfnVpelZ3iLSzrXh6+05SA88JVCegbt+uKV9AP
+I7nVNc128jWS8u5bi4JMVranaFHXtjj3NT/bvF3hlsyLeLD1KXQ8yMj/AHucfnWDb39/4e1mJ7kt
+aajaZTa68EdPxBrrf+FtXsIXz7S0kDDhlYrg+/WsYvu3c0fkdX4R8cReJI9htmimXhlHIz7U/wAU
+6Fbppc95aWULSL+8lVkLblxzgZHNczB8WoEbD6ZFvPJ8p8/0r0PR9Wttd0uO9t/9XIOVPY9wa0vG
+asRZxPGZNcWwg2KyW7ynaSFYx8/3s9DUV34ekS3ubm8eMRlcht2QcjquK63xdoNxZO7W9sk9uxJj
+jbocjlTXCXl1Enh0WiSiHbK4MbuP3anB/LJNRGT2YNdT1j4c6rLqvg+3M8hkkt2MBc9WC9D+WK6d
++tYHgbRRofhW1gLBnkHmsQcjLf8A1sVvP1rRsSJ1ps1xDbqrTSrGGYICxxkk4A/Oq96Lp9PnWzdU
+uSh8tmGQG7V4Jrs+p+c0uppfl42YOZlcqSDjcG6AemKidTk6FxhzdT2bxNq+g2Vh5mow296zD91B
+sWRnPtnoPevKLrS7vW5JLldOsdKtT92OKJQce5xmrdrf6dHpUSwNGLllAMh+Y59s1hPqV9qKy2z3
+MjKXwqoPmYe+KzdW5Sp2NTS/CWnvHJ5swkfkA571p+DNauPCLX1lLGLmz37kYSgbPzrEuNLmhtRL
+Z+bZ7BgvJIAWP0FNs7e2iVpL7Uo5ZXXcd8YfZ+fGfwoVWy2BwXc6TxD4t/4SC/sTZM8MMIZ23AlW
+PTqOD3rl9VTT71THbhx8pHHKp3zn09BU8bafeyuBe3Esir8mXIAA7VTiNvAZ0jzk4UFyM+p/rWU5
+OTuNJJWPRPhLrUl94dm02d90unSCMEnPyHJX+RFd43WvIPhC/l+JtWiVso8AY47kN/8AXNevOea6
+ou8TNqzK2q2d1f2PkWl69m7MMyoMtt7gVx/izRdXl05YLzW7iazPyvHHEFMgHTdhfz5ArvlNKVDq
+VZVZTwQeQapxugTseAanpw0mHy4IYjGxyJWIZ/8A6w9hUVlqV4JEtNHs3cKTkIm5pPrXstx4J0a8
+1N724idy2P3W7CD8BW3aWVrYQCG0t4oUHRUXArONF9S3U0PGYvBfi7Ww80kItlc8i4k28fTmnT/D
+DW7ePG+OdvSJ8D8yK9oaR1P3B+dKGkOCVAH1rRUoojmZ4vp3ws1l5t0hgtQOQxcsc1z0dnLp2rz2
+d2m6aNmWQg5Geea+iyaxJvDOkS3st41lG08v32bPP4UpU77ApdzyD4dXwsvH6RoGWG6iaMZ7nr/S
+vcGPNZtv4c0i0ukuodPgSePOx1HIz1q+55pqNlYG7skVjUgY0UUxC7jRuNFFMBdxpNxoooAQsaYW
+NFFAEbMagZjmiikxo//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0051/full/!100,100/0/default.jpg</Url><Caption>29377_0051</Caption><Caption>Sciurus Migratorius, Bach. Migratory Squirrel. (v. 1, no. 7, plate 35)</Caption><Caption>Exhibit</Caption><Caption>plate 035</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NVGB
+TwBnHeoLuR7ewmlQfMkZYfgK53SNdn157GKF9vkkyXrrwBhiFT8cZ+lZ36F2OrCijbTwKQsqnBIF
+VYBu2jZTwQ3Q5rhdb8QX1lr01hNKYYpVxG0bcof4W/PrWdSapq7BanalBTGVQMngVz3hLWZ7oS6b
+e4NxbDh9xYuMnJ/DgV0xGadOSnFSQbFUhW6EH6VXmTGKvMoHQVWmHAqhltkDxFCOGGK8ht76XTdJ
+1y1t32Sm5j3Z/uupVh+YP4mvYV6V5Hr1ktt421CynGINTjZEPo7fOh/76BFJ6NMEd74P12PWPDcE
+nmbriAeTOD1Drxn8ev41yWtePUjv5FgzJChIZwcDI9PWvNLK5v7Aaha2F5NEJHXzUQ43Lg5yetJl
+TG8DcSKCQc4FWmmwase0eG/FceoW/mb8xjrkcrj1FZ3i680jWJITA5W7U7RK6ERke/8A+qvNfC3i
+dfDeomaWF5oGA3qhGVI7gGvRbO+8J+MbgG1v2s7phzAwC5P0P9DXNiqdWUbQs0CaNDwfHJZ2cmo3
+okRjiIIV+8euf5VrDxlpJneBndJkco6MAMEH681pafp0Ngq2sTM8USAoHOSM5/wpb3RdPvpkmntk
+MqHIcDB/EjrSp0p04csHYLpvUdbXtvepvgkDj2pJhwKdFp9pbvvit40b+8F5pJhW0ea3vbh6Fxeg
+rzn4swCOzsLyHctwJNm9fT7wP4EcfWvQ5Zo7eEyyttRepxmsbWLXTPEWkNbXgeOOQfK0kbIVPryK
+blHZkngt9I4kbU9OuYw9zGUuIAQHQn7wwexIyCPWslpipI3ZLDaWNaviDRJtC1Oe2nG5Vcqkq9GH
+UE/UEVhyxsoyvPFUrA2WbS2PzbuQfzpZLJ4sSI5RlOVZTgil0uGSWT5iePQ1emXLEHoOxp3A734c
+/ER5rxNI1mTdK6hIZz/FjPB/OvXsg9CK+TLhTFKs8JKuhyCOxr1Pw1D4m1vT4NT02964zumPBHHK
+nrisK1V07Wi36DsdnrPjS3sfEVroluhkuZJkSVj91A2Dj64NdDMOBXO2nhVbjUP7T1Pb9vWVXPlH
+5dwC8++cfhXRTdqKcpNNyVgLYAIGRmq+o30GnWMlxORtUcA9z2FTqeBXO+M7XULrS4VsI/NIlBZN
+uSfSlWnKFNyirsS3PJ/F1/HqN9cXVtEkKqUlRFBxkdev4e1afijw9os/hqDXbaSytLiVFYwRHAYn
+sB2PNXL7wPew6JNqV38jR4zD1JjPDE+nY/hXn9pot/qV1cafbI0jxqTsU849QO9Y4dzcV7TRjZAb
+9bONkZMt602W4juIyUbaetQtay27tY30bqw4RpFII9qrWTtaznK/IwwQ3SuzQRJM7C1LyA9cCvUv
+gjeu8Go2pyY0cMvsT1ryvUp5Z/3Y4j25x6V7B8JtKOjeHxeXJCvfPugHd+OB+lK4HpYBeZ2z8gOA
+PUj/ADj8KbKKljTy4wp6jr9ahmqHsNFlelcD4o8SeJNH1R4rcWgt8ZQlSzYPrXerXJ+KPCc2t6jH
+eC8EEUSYYAFjgckgDvWVf2nJ+73BHOWGsa54jD202uQ2kkq7RH5HyuD1Ge341x+u6Xq/hfV4HvHV
+HDZhvLZ+f8+xro7i7tNPuHt9IR2kKqPtcw+Ycc4Ujj61r6xp8154EtWnR5yshZ2c7j6DJ61xU8Vz
+XjLVrW6KtY4n/hJmv9sWvWK6hBnHnJ/rAOOQR06Vm6rpunPtFjdiWMsSFZSkiY7MDx37eldPongW
+DWrO4ayumtrlNrBW+ZHGfTqMEevesTWPCOpaVqKm6ZYQ/CSoCVLfj0JrspyvHmWwWRzmsRJEoSN1
+dtg3EdTXrHwt1ZNU0HS7IsDNYtNuHcAAAf8Aof6V5G+n3lvqX2eUmWViNuTncfSui8LazJ4P10ah
+HCzWc37q8gx80fPJA9jWyaasKx9DGq8vao9O1Oz1exjvLG4SaCQZDIc/gfenzU2JFhTxTbkFrSZV
+6lGA6+ntSoeKdk9gKq11YDxuztS948cufNdlVE55YkDJr1vT9OS00qOycK6hcP6EnrUNrollaajP
+fJHmeZs5bnb649M1pZriweD9hdy1b/IcpXMnRNCi0Z7oxsCJXynHKr6fmatatpsGr6ZPZXCgpKuM
+4+6exHuDVkuw/gz9DShmPVcD612xhGK5VsSeHaj4Y1C/sDiyl+1252s6qeSD2robLQYPFcOnNqdn
+Ja3hhkjmniGxnddoywI5PX869RNMYnsBURp8vUpyucn4W8DweFbqaaC/uJVkXb5TYC9euB34rpJj
+UuT3qvMelWImQmpATRRQA7JoyaKKYBk0m40UUAIWNNZjRRSAjZjVaVjgUUUDP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0028/full/!100,100/0/default.jpg</Url><Caption>29377_0028</Caption><Caption>Hystrix Dorsata, Linn. Canada Porcupine. (v. 1, no. 8, plate 36)</Caption><Caption>Exhibit</Caption><Caption>plate 036</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NV4p
+wAPanKOKq3WpWdmdtxcIjf3SefyqHZK7GWdopcVUtNStb3P2eQyAdSEOPzxVbVdWWxXy4ihmwWOT
+kIB3IqZSjGPM3oI1MUuBWZoWrprOnC4UAMrFHAPQj/IrTzTi1JJoTYYFLtFFLWlhXExRtpaWiw7k
+LkL/AAsfoM0YyM4x9alppFKwyArzRTyOaKkZIvSvP9Z8JXOpeNhOyN9mkXeZM8DAAx9a72RpEhZo
+kDuOilsZ/GsDVtb1LS7Zrk2COikAru557VFXlatK4guYbbw4YZ7VQDIwSRWY/MPUeh4Fc9rsM0ur
+tPDcpJFJjerEDbx04+n60muXT6lZs8azGUgOIywGw9cEnise81RILGCTVXjgAJ3Zblm64wOTXHUa
+qNwjsB0lprNp4btXhcBJZ5MxoRjgIoJP1OatWGpa3rCtJZTWy7HAdZeMD6BTn868xvvEuhX1wJJD
+dy7RtG2P5R784rovBviO1h1SKDTriGS3mdUaF02SDOOR3OD9RVRUotJv3fITPVoBMIV88oZMfMUB
+xUuaTIoBBGRyK9FCHUtNzSigBaaaWkpDIz1ooPWipKHr92uR8S6oIr62hk2iNSzsPcdP1IrqpXZL
+aRl+8FJFeFSanqfiPV9Tim5uIVLQwjgvzggfhziom7KwWua+reJo7W2uriIgIg+VN3U9v1ry9p7j
+U7p7m5ZpZGOfXHParGrzXvl/Z7i3liIfLbgRmotNdoyWVenXGP8ACsHZRui4xs9TWt9Ntp41hWXZ
+MVJUFcCT1H1rOu7CeGUzRZQwkBZEJGMdDnt2rrdFtRqJRJFCgMAjqoyp/Km6rpr2kk8BfcyK3zY5
+yCAT+QrmVRpmjSZd8OeJda13SJ9Mu5muW27d4fbJj3Pc1r+G/Fsvhm4fT79ZXtCxxuBLQn6eleaz
+21xp1z9pspWjdXIyp7YyK0jrVw0BlZUnmdsY/iBwDnn1B/SulSbfMiOVLRnvGk+LdG1ZhHDfQCc/
+8si+GP0B5rdzXz6JV1V7dHt1jdIf3wWMK6MOQ+7GQe2K7Kx1bWYrGKOTUJJAqqY3z8xHofUj1reF
+RvRkSilsenmkrm7LxOklou9S0gwCx7+pretrlLqLzI/u5xWpI8nmig9aKkYhG6Fl9RivGfEfhx7f
+WHmjkMblsq+cEV7Mh4rnfEeneavmhMjBJwOawr83JeI1uebwXjnTbmw1qR72CVfulsyRn1UmuKaw
+g88iwnkdZDt8uSMhx+WR+tdnfo1u7kwZY8ENwQKow2cYLyOC7THhS2Pw4rz/AKzKK940il1LegNZ
+6UwN5qkCTnlLfeM59W9Pxrpb3w/d3NtDdRSQzSSMZGKsCCD1ANedz6PbwXe4QRIAQCVfOPzNaVld
+3ujRs1peyQRYyY8jaffBpLEUuvUUk0yG5sZoo50lj2+X0LeoPf8ACsLRNVlsNQAtoEld/kAdc9+D
+W3eaw+ttCWkQFV2uirlMjvnrTI4rX97HE8cTSLs3xjDD16iuiNaCeg0uZbmvN4wJuBD5CFmI3z4H
+zH6f5NXxqRnQuVkkI5J4rkLLSEW7EYeR5FPUnjr2rW8yO3nMblfLzt+bsTxmtY4hJ2exlODN/S9Q
+S4lI2vjOOvWvT9IK/wBnqF6CvJdJu4BcJFEQQWAJr1zTUMVhGrDHHSuiFTnbsSk0WWPNFMZuaKoo
+EbinEhhtZcg+1V0c4qQOaLgQy6Tp9xkyWkZJ7leaxbzwBol7uLrMpP8Adk6V0W80oc1lKlTk7tDu
+zjI/hR4ejbcWuy27OfOIp1x8MfD0oAb7VkdT5hJP412W80bzUewpfyiuzz4fCPw+r7orq+Re6oRn
+8wKsj4T6D5wkWe8UY6eZ3/Ku3Bx0FLvNWqNPsF2cwfAOlrGEilnTAx1ByKz5Phfps7Hz7+6kUnIH
+Ax+VdsXNNLmhYekndId2c1pngPQtKlSSK3ld0OQZHzXTZCqABgCmGQ0wua1UYx2QgZvmoqFmOaKL
+gf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0044/full/!100,100/0/default.jpg</Url><Caption>29377_0044</Caption><Caption>Lepus Aquaticus, Bach. Swamp Hare. (v. 1, no. 8, plate 37)</Caption><Caption>Exhibit</Caption><Caption>plate 037</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3NFwg
+4zT2KIhZyFUdSe1EQ/dr9KWREeJ0kAKMCGB6YrNLQspvqunxtta5TPtz/KmXur2dpp092JFkES7t
+qnk+n8xXnfm/YdUuLR3G2Nyoye2eP0xU+oxNdWnlRuoyRznAxmvPeMnGfLKOhfLdaHZ6d4n0nUgq
+pOI5D/BJxz9ehrWDxNI0YdS6gErnkA14q1u1gGFyD5ZPyuOQfoa0Le9nt9EvdSeV1e5AjjdnP3Rw
+B+VdMK3MrsSiz06bVtMguRbS31usxOAhcZp63VpLL5STxs/90MM143pU1usCTTvtkmkKlyM9Bn/P
+0rWutftoCCMyMv8AHFn5ffn/ABrmqY2UZ8qjcEtNz05vLJxkZqJ4wD0rH8M+J7bWYBC0v+kL0DDB
+YVuuPmrshOM480QJbq6Sx0+S6dXZYk3FUGSa8sude1HxHdzvNNJDZR9IEOB36+vTrXqV5eR2Fi9x
+J0UcD1PpXmlxfi7F/ceVEhBYlY0C8beD79+axr1EvcT1FYo77V7eGSEh45lBRwMEYOD+tTyafdW7
+PLFc70yDhz3xyKxNMO3w3Yl22oszbmJ4VCTz+tb8Wt6cdKuLgb/KgTcWI4JOMAZ5JrkqRmm1DUpF
+HVbqe/e10f5TLMwdyP4UH+NUPFN2rzW2kQnEcCZYL61c8LwSv9p1y7A+0XB2QKew6AVi+JL6C31d
+rXT4hNfBNkshHAY+3c81tBKmlBblNN6IhjkjjHliQu0XzJCBks2MfljNWrTTpIrGS7v5G+0SAna3
+3Ykxycdj1rA0nTtZj1J5TEyup3M8y/KTjj61syatPqVnJMImj2jZKnVeD1PtSlPllaNjeNBKDb3N
+XwcZE1K1dAeZVwenGcV7K4+avI9J1bS9JvtMurhZGWeRUQRAYU8DJz0AyOK9dbBORVYJaSl3Zytn
+H+PtXW0EFpuwTGZcevOP6GvL5dRuI1nZpdnnxlXHon+f616r4w0FdT1G2uJnEVtHCRLMw+7g8D68
+14pq17bf25NArF7ZJGUZH3wDhRUUqUp4qUmtEJtJFs659rWGzVgljH8u0jHmHqSx9ParX2iXXr+1
+02ASGDcDIQcgkf0A6CqV1Z2lvEt0qnymQnYeQW7D9a6fwXCkOmXOpXMe4gELkcYHYfnW7k02jblS
+in3N+e4gsPMG0LBZxHk9Acf4VyvhLSkKNqs5zPcMz5fsCc5rP8RazqFzZraPZi3juJVV3Mm5n5z6
+DAq7f6mNPjiFpl8KsWxT8px71x1Izu11f5I3w7jG85M0tXuZJIjFapuXgO44AH41VtIdmnX9rN8r
+m0Ylf+BZBqxYwSzaVJfTSRnehRArhuc89PpTbiJhfwTySQx26QlGLHBcnPAHcc1hFyvypGWJlzz0
+d0c4I7qTSLSWGBmS1fzC3cngnj0GK9/0u6W90q0uUziSJTyMEcc15dE7FAsCBIycZIxkew7V6J4Z
+tLmy8PWkV44a4ILuQc/eYkDPfAIH4V24WfvSRz2sZ3jvWEs4rKxkwsdyxLuei46frXi3iLw7dwX7
+zxQs8TnfuUZwa9o+Iulx3ugpcbQZYnAGe4P/ANfFed6fqIt4GtrSNv3Y2mVzxu74FYV8VKhXbirv
+T7h2TWpy9xM32Cz08o6zb9zZHIHb867vWZIdJ8O2VugaISj58fgeR9axJtFuB4zsILl3kPlrIS5y
+fcfnU/ji7SbU1jZsRWwCnHOWPb610Sqczv3Hf3SvZRWVxcm5n867t41ysSLj5sDkn86sN4is9rQW
++nwxx9MMu7P5/wCFc5YeI4tOuGW3YHd1Ut39eldHZeIBdbIjP5MzSdGHDr6BuxzUT54rRaE6onjk
+NvoIk81bOEyHaiJk89STg7a5eS7u77WdkUrptYld55XHOWJ+ma7izvrCcvaS24t2f26/XsaxL7Q1
+gviXiDM+Dwf9YAe39RXPGs73ZLbYaLfz69eQ6YJEhVty+YTjzGzkD2B9K9m0yCW202CGYESIuGGc
+15po9jpt5f28aKtpMkwkXC4w3GQR6HFessMEVvhIQUnOKsUnocv448QWmkWaW11D5nnAOm7IQEH+
+IjnHIrzC41CKO2U4jQn7rRNkAkfyr1fxH4Ss9emF3e3c8aQxbQiYwBkknke/6V5tremaZcWzlrop
+5LGBZXG3Ddjxx+FRi6adRSl/wRxL2k3h1rX7y7Yb47eLyUIHXA5OfrmuI8T3Kz+ZFDITI07M3PIA
+GMV1/hu0bSvDU0jSMN4JLAjn3rlvKgvCpmEgdQwLxgckngnNb01FPUraxhaTpSxRSyzK37zCqewr
+Uaya0tWa5H7tsbVI5P0rTj0m2l0z7ImpMlwG3R+bHsX6Zyaqau2qwQxx3kTEfcEw5U/QiuiM4r3W
+EouXvIji1V4kQuTOqDKOP9Yo9/7w/WuxtNRtfFGhy2lvMPtKLuj7MrDn/wCtWHotlZ3dnZ28MZmu
+QroQrgSAk5GOQT0q5pXha+j1EX62t1bywEbmaPYJB349f51hVoU9WjOxs/D53vtZ+y6komCxlk3j
+lWBFersAMAdBVGw0jTIpY9Qt7SJLh4+ZEGM5Azx0q7J96tKFL2cLMEPkjWe3eJvuupU/jXiHiqzu
+JdRlsIIpJLSB9rSopCmXjOT7civcVPAqOK0t4rc26QKsRJJXHUnkmtJ0Yzak90NOx5DrBMejwWKA
+g4AYA+lTTadCsaLCEWIjKEegHf3r1GLRNNiZ2+yRuzHJLru/nTrnSrG6kjeW0VjGML2ArnqYSU9U
+x82p5bNo8Uumb9pDY4I6qa5xrLzrXaW3I5HyMeM17pJplg/D2a4IwR2PGKht9C0i2UCHS4Rj1QH+
+dKGEqR05gcux5hpOmT2O2OTTII2jfcpePBDDvuHNdUPEmp6SwXUbWRIWxtYjfGR67h0ruRjH3cD0
+pjABcbePSumNJr7QubuV7G5jurKOeIKEcbgFORSufmqTOBgLgVBIfmrS2gEisakVjiiihALuNG40
+UUwFznqBQWNFFADSx9aaWNFFAEbMagZjmiikxn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0041/full/!100,100/0/default.jpg</Url><Caption>29377_0041</Caption><Caption>Sciurus Ferruginiventris, Aud. &amp; Bach. Red-bellied squirrel. (v. 1, no. 8, plate 38)</Caption><Caption>Exhibit</Caption><Caption>plate 038</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FYUH
+RVH0FP8ALHpT1HFOxUFEflj0pdg9BT9vI5pcUCI9vtS7fapMUYoAZj2pcU6iqAbikxT8U0oSchyP
+agBu2kK1LimkUhlVl+aipGHzUVIyVafTE6VJVCEopaKVxBSZozSZpXAdRSZrOh13TLi+FnFdxtcH
+ICc8kckZ6VVwNKkpaKYwppp1IaAIG60UrdaKkZInSn1HH0qSmIhuLmK1j3yuFUnGTVF9e05PvXKi
+ptVYJahm24B5LHArir3W0N79ksiplUbpJGUlV9BjuTXLVrcjsVGNzsl1ezkUMjswPQhDTX1q0jYh
+zIpHXMZFcNJ4mWLT2klTMqu0exONzA+uOB3rAm1/WdRLJC2yNgdwjXt/vf5/Cso4mT6D5D02Pxdo
+80rRx3DOV6lUJH0rh/FNwltqUGo6dAYlhcShuVBI5Ix781l2mr2GgE20bM8gXc8nUZOMio/Eeutq
+GnRtFEwjwS2R0PTH+fWl7dzklYtRtc9Rt/Fmlz2cdz5pVHUMCwx17c1eh1e0nAKPnPTpXiOka7ZR
+29hBfMI40jYYcdSTgfpXX6RrOlwLGLZ1WIMc5bha6HiOV2aI5D04HIBFIaZbyLLbxupyrKCDTia6
+EQRN1opG+9RSAfGflqQGoYz8tSA0wM3xDbG60iULs3J8w3dOK8mnuPKeT/SsZPzGPAya9rbBUgjI
+PbFcdrHgCy1ORngne2LHcV2ZFefi6E6lnA0i0tGeX/a7eWRy8dwwPJK+vHJHpVDUdRu1kKmXainC
+Rcgr74r0WT4X3eGWPU4sE9TGaoS/B67kBJ1aMuSPm2HgAYxWNOjUStJFc0TzwSX11exM5ZwWwyDB
+JGc1audbvo5zDJgqP9rIxXeR/CbUEl3jUbVSAMMisDkd+uM07/hTski/vdXUNnO5Yjn9TW3spt2t
+oLmR5lNJNdDPlIzFQcrzjNXfDttNqOoR2hDNEVwpQYx7H1r0e2+DlrHOsk+qzSj+IBAM12mjeGdN
+0JNtrCSf7zAE1qqUth86NSxgW0sYLdRgRoFA+gqUmjNNJrrWhiyNvvUU1j81FIBUbipAaqxucVKH
+NCYNE+aN1QbzQHNGgE5bIxmkwcffOah8w0eYaVkA8CTdzIcfSn7T/wA9G/SofMNHmGmBYzSE1B5h
+pDIaYExamFqhaQ0xpDQA5m+aiq7Oc0VNyj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0017/full/!100,100/0/default.jpg</Url><Caption>29377_0017</Caption><Caption>Spermophilus Tridecemlineatus, Mitch. Leopard Spermophile. (v. 1, no. 8, plate 39)</Caption><Caption>Exhibit</Caption><Caption>plate 039</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RUGO
+lO2dMAU5RxT8VnYsZsHpRsHoKcWVcZIGemTS5pWEN2Cl2j0FLmlzQkA3YPQUbR6CnUVVhXG7Aewp
+DGv90flT6SnYdyJo1xxGpNJ5a45QD2qakIpWQ7lcxrn7o/KipD1oqbDHr0rmNe8Xrpd2bOKAyTAZ
+J7CuoUcVxPiextJryR3B83nBXrUVZ8kbhFXZjan4pmvYI5Zbd4zngq2BitzRfH2mXMMVvdFoJwNp
+yPk46c/SvOtRhE0zRxsY0QZZj6etc+zHznjTcTnOWrnhUu9GU0fRL6tbx4L7wD0IGagHiKw37S7r
+zjJWuB8K3Mur6cfMkzJA3lk7Ooxxz0rcGntyS/zDpuGR+lWqsuxNkdcNRtioZZQwPI281H/a9tu2
+gOT/ALtcVdQPbQq7SxxqWwRHEct+tV7KRZLlW86TAP3GUjP45qvbNbj5UegDUoT1DD8KZ/asHmFA
+Dx7j/GuR/tu3Eps0OZ9u7GScfgaw7djdT3M93cTJGr7QScAe2BU/WRqB6YNSiJwEb65FWYpRMu4A
+j615jbX8Ud+IM3ADD5HyTuP513WgTia3kH73KkAlxitadXnFKFjUPWihutFaCJF6V53rO99ZmG59
+wJ/iNehr0rz7xBYzXOpyFXMADZDA/NWGJSdOzHDc4aL93qFzDPMv3S33sD1AOR1rn5rCRS92p3R9
+VQk/Nn/9VdTqum6VZv511eTTSMclBjJrKk1yK3O21tYEQDA8z5mrhTtrHUtu+5Xt5tTg2m38+2kI
+2tHExG7PsK6rTb3xNbWaI80Cjr/pLBmA/A59eK5e31bUL+dgtwyrjJIIUKK2bSG23lnuJJlUBnkz
+8i/VqidSstI/5itHqdg+uRR2CveiMsFzJg4T6jPaska3pksZa0jLu+QADlT6jOTWJLqNjPcrO0Tz
+28JALyPsj+g4yf0rA+0RXWryx6a8ltFKdwAPBI9D1raMKlSFqj/AqyWqOwguYoNY+06lE0MrIAuV
+PGfwxzSarqdktrJD5kK7+gLD8/rVW5vZLjw82nXBa4O4MJQgDLjsDXL3disGJH+9jI3Hmr9hBta7
+dClc6FdZ8+NWhmRYYvlUdSMDGPWvQvh5M1zZ3U0hyzMo654ArwiwuhbXx5JiJ+YE17n8OXVrG5Ck
+Y3A4ropwhTlZIznc7RutFB60VuQOQ8V5l421O4i1CW3gQjsWPf6V6Uh4rlfFmkhkN9FCGcfeOM1l
+XV4XBbnkUthcy3IMxxuGdx7CqxsPMkaNBhAeXPVq1ry6YzByhDLkBcdR/wDrpFhF1y7ZCjIVRwP8
+a4IuUtdi7Fa0htLaaOPaxUOGdhgjjtz1p3iXxH/aM3lQpAyq3CwptUY6ZP8AEa0JdNIiAdlEZH3R
+3Hv61yU1rHFelIZ98Wfl2jc30rSGl7AUbl7q4KmVyyjhQOFX6CpLQNb3CTSOwEZyFXqf8+9XDZTg
+klEhQckEgt/+upYLdVO1IeSepyK3UrLUaRPfa9fXRUxWyQr2BJNZc8lyXLXFwxf0U/4VeuZIIQN8
+u09yMZPsKqhRdqBawYxxuPGaq6Q7lGNHkkaTB45Oa9x+Fro+nXG1WBQKpLDrxXmmm+Fr64iWR4pM
+MduAOhHFe3eFNJ/sfRI4GXEjfMw96cHzSuiZPQ2WPNFMY80VqQLG3yinttZSrLuB6iqscmBUglp3
+FYzrrwtol8czafHnBGVyp5+lVh4G8PgcWjA+vmtn+dbvmUebUOMew9TPm8M6TcWwgktQyDp8xzWa
+PAPh+F/MS1ZD0BDHiuj8yjzKVoi1Obj8FeH0JJjkc9PmcnFTf8IL4eaPY1mSP+ujA/zrc3KD0pfN
+9qajHsF2c8Ph94bU5Fj+bk/zq7beE9DtBiOwj65ycmtTzaQy01CC6D1Gx29vANsUKqB6LUpbiojL
+7UxpavQLCs3zUVXaTLUVNx2P/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0052/full/!100,100/0/default.jpg</Url><Caption>29377_0052</Caption><Caption>Mus Leucopus, Raff. White-footed Mouse. (v. 1, no. 8, plate 40)</Caption><Caption>Exhibit</Caption><Caption>plate 040</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAEwDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tF6V
+IAD0oQU53WNCzHAHU1ikWGylCVzmueK49LjbyovMcep4rY0bVIdY0qC+hI2yryB2I4I/OqSAt7KQ
+pUuKY7rGpZ2CgdSTRYCMpUZSqE/ijQ4JfKl1WzR+m0zKD/Oq+sahbz6S32W7QtIQEaNwTnPWk1YE
+aEsSsMMoI9xVJtPtWYlraEn1MYrN0bxDFqeoyWRkEjqpbp0x1FbxHNJa6j2LyUlzCZ7aSIHBZcA0
+5BUtUhHl2s28k8EtvJxKuVHvWP4O8Z2/g/7fYaxI4g/1sIAy27uMe/8ASui+JWqReGLc3oRZJbsF
+IkPTeByfpivAbiee+uHnncvJIcknvRG49z2W4+OlsJD9n0iVo+xeUAn8MGuF8WfEjWfEbmOKR7S0
+Ix5UZ5b6muV8ohearmR45kaE4dTkHrVKw7GlFoWqzWBvzYzfZc481uASfT1qJLvUNLc+TPPC46xk
+kV2uk+KLvUrOGLVZkZLJT5QCAAt6kDqRUuu6M2p6Ut09s/2+6VprYLxsiTqSPfr9BUOd5WKS0udf
+8MrzTn0WBrENcahcOTdM3WID19B6eteikV8+/CTWZNM8bJYlsW+oIVZf9sAkfyP519CEc02Qy2lS
+Co0p9JEnzr8ZdWkvvHBsSx8myiVVX3Ybif1H5VyNragxh24zXS/FS2KfEq+JHEiRuP8AvgD+lZDY
+jtVAx0qZztoawWhl3UiISA/J6jFUkmCklBg9Nxpblw74Uc5q1ZWyNJskUYOMn0q1ZLUmTNXw/HE+
+6W5JFvGd7DP38Y+X8a9w8E6RcXVhPrmqc3N+myJMYEUPQADtnr9MV5N4R0RNc8S2ulRfNAGMlwwz
+/qwe/uen419IKixxqiKFRRgKBgAVN7u5Lelj5Q04tpPj6yB4a21DYfwfFfUvUA+1fM3jiBtP+JN4
+qrtP2xZF/Eg19KwktbxMepQH9KcguXkNPzjJNRpWZ4g1u10jTZmlfMzIRHGv3mNZ8ySuxHhfim+j
+8S+ONQvI/wDURsIYz6heM/ic1k6osNnbLuBOeMCpGns9NufJKsGJ3buh565/GsPVrz7XLiNiQex7
+Vh705+R0KyiU1mhDNKFOV7VPE7IkkueT0qk0JjTY3DHLEVOCwi2g9uRXX0OdvU9K+DWoJaa1dLKq
+5uVVA2CW68AYHTPrXvBPFeQ/BrQ3jt5dSkVgz4CBgQNvPIPfmvXj0qLgedeOvh8PEetadqlsUSSK
+RVuAf40Bzn6iu6ChVCjoBip26VC3Wk2CMzxJ4msvC+kveXTBpDkRQg/NI3oP6mvDdc8W3GqWvmPK
+RM53YT39T+npXtviHwhpXimOIahG/mRf6uWNsMoPUemKbpfgHw3pajytMilkH/LSceY368VDhzWu
+UmkfN0Nhq2uXyJbWlxPKwCjahOfxrV1vwjqHhiWKG+ixLKgYOOV5HIB9u9fUEUEMKhYokQDoFUCv
+J/G1u2t+KpGZm+z2yiGMD+Ju+PxP6VUmoq4XbPG7yymS+8lQzbgOce2ada2T32r2thCwd55EjUgd
+yQP61u+IESC8dISRGp+UfTjP41u/CHRE1Lxe17KMx2KeYAe7ngf1NaRlzRuTY9w0TSIdD0m3sYDl
+YkC5PetA06msamwETdKhbrUzdDUDHmk0NFhalBqBTj3qQN7VaENupmigYxjdIeFFcbqmlBImkdMC
+NC2f9o9T+VdtxnpUU21gVeEOp9QDmplTUtxpnzXrENxdXpjjhYszbUVV5NeyfDfwuNB0RZ54Sl3O
+MvkYIHoRXTCzsVn85bGMSA5DhBmr4bI5BFUlZWBsUmmE0pqNj7UxDZDxVdjzUrnIqsx5qWNFlCcV
+KGNFFNALuNG40UUwAMaMmiigBpPFMJNFFICGQnFVHY7qKKljP//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0026/full/!100,100/0/default.jpg</Url><Caption>29377_0026</Caption><Caption>Mustela canadensis, Linn. Pennant's Marten, or Fisher. (v. 1, no. 9, plate 41)</Caption><Caption>Exhibit</Caption><Caption>plate 041</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29F6U
+9VOOQM0IOKlArBI1GbKXZT8UcDknFVYVxmyjZVO+1zTdOXddXcUfsWri9S+LOk2zNHaq1xJyFCUW
+A70qB1xTCAfSvKbDxfqev6xh51gtYhl1U9T6fhXX6fra3WpR2duxdv4j2FQ2k7FW6nRSLgcKW+mK
+gZBnpV0jioGHNNoRbSpBTFqQCqQmNkkSGMyOcKBkk1474p+IN/qmptpmghsD5WfOAeeufStr4p+K
+Tp9quk2kh+1zj5sfwp3JrwyDUTFIwFyYVJ+ZlPzNRvsNLudw+hwyOJ/EOubieTGjf1NTuunPaPbe
+HNNG5lIkvZ+ij1BP9K5W21vQbMCR4Zryf1k6VJdeKdT14rp2nwGKJztWOIct7UcsnuO6KdrcXdtq
+LW1pMZDu27k6Ma9+8DeH5NM0wT3fN1LyxPUe1c74C+Gv9mKl9qig3LDITrs/+vXqCIsaBVHAodmy
+bjGqButWGFQP1pMaLS1g+M/E8HhXw9PfyEGXG2FD/E56CpfEHiTT/DVnHcahP5SyPsQ7Sefwr56+
+I/jGbxLrnkK4NhbORCVbIf8A2vxpx1JbOe1rX7zVbuW4uX3yTHc7dz7fT2rIzGwPY0k3JPFQLkmt
+1ZbENstKIlGS+T6V13w+8VSeH/EcJisluopSEdAmWAPdfeuHweSeldd4E8VWnhe8mu59NF2WAUNu
+AKD2yKUttNQT1PqyGeKdN0Tgj27VJmvFB8X7eXUw1hoswhZcb/OCyFsemCCPbvXp3hTxHF4p0KPU
+oYZYQWKFZBjkdSPUVzrm6o0unsbbdKrt1qYmoW60mxnAfGa2M/hCJwCTHODgD2rwGSFmRUdAHXg9
+QTX1R4rhW50KSJxlGIzxmvGW0iC6mYQuheJipGN2Rjr1rP23K7AoXPOZ7cIQJcqxGRmoltkPHznn
+qorvJtEM7LGITIwABb/Oa1NG8PWzJteDaoPVl4b3FV9ZVheyZ5ZdReUqrtYfUc0yCBipPAU46nFe
+mat4MF7v+ylA56MW4z2zXPxeDr5pjDcKkYWPcXDqyqPcjOK0VaLjcl03exoeDvDNvqsMvm6hZecM
+bISSXXBznHevbvDiWPh7R4tMtzI0cQJ3t3JOTx+NfP8A/wAIxJtE1rJOhjbK3CqwXj0zg11dj4su
+bC2jtL69W5VsATcBl+vrWM6jb90uMLbnuMeoW0uAsoyexqUndyORXmUN3JGoYy7kxuLA13ujXa3m
+kwToSVYHBI9Dikp3G0VvF1ylvpAZ2CruySTXkGoeL7O1mdSvmNgkKi5+nJ/wrs/jDePbaPaquDvL
+YB6E8V4WieY4MshGfvNjp/jQqanLUOay0OgufGF/cybokSEYxtXJJHv0B/Kqy63q7ybzfXYBPRJi
+AB7DPFV1utLGhzQfZpl1ISfu51bKsvoR2P0rLQyQ/vkY5B/Ot1SiloiXJs3F8R6qk5jjvZlKno77
+s/nUsfifVVIVpY5G7F4wdv04pukSaHqF2sOqWsySuT+/WcIiLjvWhrelafpujWlxY3cd1ieRHYH5
+lB5UMOoIwetDhHsCb7kDRanrEO+a5LKOu/kD6D+gp0GjaVA2641hZHUfNAEAAP06mqSapO8awxlu
+eh3bQPxqSLXF00PFLJGd3UQxBn6dCzVk4y2NERWPia/0W48kr5ts8mY4nzlF9j/SvePAes22s+Go
+pIFZTGxSRT2brXzRe3/n3hl2Oq9FDEE/yr6D+EyEeCI5mbc00zscjHoKbjYTG/FzT5brQrS5iQsI
+JiGx2BHX9K8eXSLi4yQgAHr6elfT9xaQX1uYLhN8bdVPeqCeFdGUgiwiAHbPH5VLU73iJcvU+cot
+BVo2ILpKOxXC/nWnY+EobizmVoJXuHI8l45AUX6g819BR+HdIiwUsYgRyOKsJpOnRuXS0iVj3C80
+/wB90aH7nY+frbwFdEBkbbLFxlwVGf51E3gPUFgnkNzuRiC4UHDEfUfWvoaKwtbYN5VlCoOScAc0
+4W0DHd9jhyR1Kilav/N+AXh2PmMeH/34CpJsHG4nHP0ps+gSJMWDbM/dDDrX1D9ktQMC3iGeuEFV
+ptK0+ZlMlpExXplelS4Vukh80Ox8tHSTcXyW6xCZzwyqpyPyr6O8MWP9m+F9NtDEI2jhUMoGOcc1
+rJZW0BzFbQoT3VQKSRsGrjGUV7zE2nsToxqQE0UVaJHAmlzRRTQC5NISaKKBDSTTCTRRQMidjiqk
+rHIooqWUj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0025/full/!100,100/0/default.jpg</Url><Caption>29377_0025</Caption><Caption>Mephitis Americana, Desm. Common American Skunk. (v. 1, no. 9, plate 42)</Caption><Caption>Exhibit</Caption><Caption>plate 042</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3MKMj
+39qkCCgCngVmkWN2Cl2Cn4o6CnYLkZAUZPApkjRRgF3VQem44riPFviOS4vY9I06ZFZiQzk43H0H
+rXn1h9q1zWJZ9XvXGm6ZzMxkLAnso96Fa9h2drnvO1SMjBFNKCvKbjxzrd38ulW0drZoAEaXlmH9
+KZafELXdMlDanbx3Ntn5mj4ZaV1ew7M9TYLnbkZ9KhdBmk0vUrbV9PivbVg0Ui5B9PapnHzUNCRc
+FOLKilmICgZJPYUgFRXtrBeWUsFyAYXUhsnGBT6Enn+t+Lnv9VEGh3V0pT5WwAEY+o71LeeJ7+10
+R4NQuYkuTxvVcnHv0Gaz7izsNC+0y6feC6cDYGA+5+PriuE1K9k1IPJy4yRjPH41hC7d2y0kSap4
+ld22RTrPKhDI7W6gqfY1Rh1SS7gg06CJvK3+Y0ajLTSnuf6CsxLOe6mEMCF5WOAEHWvdtMbS/CXh
+S2jnktIb6OEb22hm3HrnHJrb3YoG2c7pHgS5ubT7br109tCBkQRtt2j3NQ+LPCA8PWy31jJJLaZC
+zRSNuwDxuBqGLxnqbXMU0d8Z0eZkWGaMLHKuPXsauXGqT3PhvW7KWQbYoGeOIjmMcHHXkdcVEJKW
+lgu9yT4baiLWPUrJ2YwxOskYAzjd2/OvRXHNeN+Ao72fTNTu40ZmmnhhUKueA3zH8jXsrDGB6Vox
+FsVwfjvXZ4rhdMticlMtg9Sa7sVzfiHQrFjcatOjSTbAqqT8q9s49ayqxlOPLER5vcRta6YkMkyi
+SUs55znGNx/X9K5vVjFaeWkZaCKVN7jGQTxnrzjmr3iSO4RI7uGRka3O6PPbmqmjWy+MNRt5tRMV
+hp8Q8t5EUkOwGcYpKFmtdC76FeHUrjT7QOgT7NKwAmQ9Mds9q2bWWPWbSNDFueR8Aljlsf0616Jp
+3w00BLRzaXU721wvIVwyN7jINYcvgy40S+vJ7S2MemWsDLEzvuY5x0/M1Ne6g7E3OYuYLj7HJIYt
+2mRuFMka4MTdiPxFdb4O8HWtxpF1fG+kuGvImhZGH3AfxroPBmmW1z4TKzxb4boYZWHUf/rz+VP0
+bwrP4d1xpNPuwdKlU77aQ8q2OCD9f51NHnik+jE2W/Cnh6Lw5oyWUbmQglmcjlia13+9U5AA4qB+
+tdLYIsisfVbu3vtGu445AcsYVbGQXH8//rVk+MPEr6Yh0+1Cm4eEyOS2GVCcfLxyev5Vydh4plm0
+2G1t7YCS2D79x+9k/e9jjt71yTxKjPl6LcpQbVzO8RWLx6RJCx86QADhepPpVDw2kcfhC6094oo9
+QtpDKUbliDwdyn2/MVupdQa3ERG5E7x72UHPlkHHX1zXMXDJHeRSXEIS+jQxPNGxBlXbtDccH3+l
+aOXMrJgtGdN4b8V/8IrKlte/amsXZmJUAhCf9nqK9Ltdc0TXbdorbULa4WRSrRhxuwexHUV4ppVt
+farPO0UQnjVdgjJGc/0qje6bEjsUzBcJ1UnaymqjJJWYSV9T2PxFrDaBa2+n6ZEgk8slQeiIvfFe
+Xx+PvE89yzw3ClASArR8Gs208UXlrewrqcr3IiUorOdx2nsT3rp7aytdR8Ca1bGNVk0+U3VvKowc
+MN3X8xTd/skq3U6/wT40/wCEhWS1uoxFexDLKOjD1FdZJ96vE/B80kfjDS51ypnUo49cg5/kK9sa
+lGfNG42rOxwvjbQ9V1DVft1jZrKbeILwPmdTnI98E5xXBalY3qzLGx+y4QMAV2dAQR+POT7ivflq
+vdaZYX0kcl1ZwTOn3WkQEiueeFu+ZPUqM7aHmun6JHB4es5LeJkuJUMksYPzyJk9f5/Ss660e2vm
+WXUbyJX6rCpAUDsK7/WNL1CXV57yzBTyrQiJl6s2CMD8/wCVchJZSTaBZ3kKhLiN3il3LkMR0zno
+a5KicJObbjbS9r6K33X3YJ9DjJdGvdIuft+jXLwyqcho2yCP6/SpL7Ul8Qact7dIE1OAmOYIMK4O
+SrfoeK6aGSGS1djG0bZxIAPun1+lZk+jfZ5J7hChgnTbIM/MjA5DY9M8fjXoQnzQUr/MLanGtD9r
+uLSNBudmCn3r1h9KbQ/hxqcsylZrmALtPZQMD+teZKgsZWWaZbeV3IR3OMD2Neh2ur3Ws6G2gXMk
+N8GjCxXdvIH+gcfpmtBNGJ4IiN34v09UyY7aIyZ9ARx/M17O3WuL8AeEpdAS4mumLTvhVJ7KO1dm
+/wB6hRsrIV7snU08VEOnBqRc9zVoQ+omtbeRJEaFCsnLjb94+pqTNBJx8uM+9NpPcRyWpeDgsklz
+p75JHMD9GHpmuSbQ7u4mbzLWSPYP3bYOQO6mvVmaYHhVNKDJkbtuO+KiNGEFaOiK5meEa34KupoW
+cRzyY+6ME4JPJqHR7nUvCMMM1noLmTzF86baxLoDyCD069a9/JpjfWrt0C5WsruO9sYbqNWVZUDA
+MMEZ7EUrnmpCT3OahduaTBEqk1ICaKKEIXcaNxoopgG40FjRRQA0saYzGiigZGzGoGJzRRSYz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0042/full/!100,100/0/default.jpg</Url><Caption>29377_0042</Caption><Caption>Sciurus Leporinus, Aud. &amp; Bach. Hare Squirrel. (v. 1, no. 9, plate 43)</Caption><Caption>Exhibit</Caption><Caption>plate 043</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JYUx
+9xfypwijzgIufpUiinYrKyLuMES/3R+VL5Sf3R+VPxS0uVBcj8tf7o/Kl8tf7o/Kn0tNJCuM8tf7
+o/KkAQkgY4rPvNUubWeRV06WSFAMyhgAc+g6mrFpe2d3u+zTIz/xAcHP0NSpxcuVbgWdg9BSbB6C
+nIGCDeQT7UuK0sFyF9qjkH8FJoKjHSpSKaRQ0MrMvNFPYc0VFhky9KfTV6Uu4A4yMnpVksdRVUXX
+kxSSXjRworYDFsDFQajrlhplqZ5pgwK7lVOSw9qjnja7CzvZGjSM6xoWYgKBkk9q44ePI4rOPULu
+2SKyeTYSkm507ZIxWrca5p15aQAXC+Vext5RbI3jHX249cVLqRtdMHFrc0Yb631FJY7eRiAv3wMf
+lWcNM1KOZvIv8BhuBdc4Pvjr+NY0UmnQmN0voodv7tcEkDHuKu6/dJd24hS7BRgS2wgbsHH6VzQq
++1V5brsylHU3rFL9IwL2SGRh1aMEZq3XCeD/ABc0l7eaPq10nnQHMEknymRPQnuRx+ftXYzaja20
+DzTzKsanBbqP0rsg4qO/3ktNMtUw1nPqwt7srcbRbMuUlHr6VoK6yIGRgynoQaakpbAROcNRUU5x
+J+FFIotr0rG1jVoLO7gimWRYzy0uPlHbH16Gthfu14r4mu7mDXbhLkzMpkO2TOQOfSsq9RxjZK9w
+irs6zxf4os2svsCr5wlw7BgfmX25BB/wri59cF1c21isIgt4xtVA5YsM5HXnrmsy4bfcIZJ1wo+T
+a2eR68ZFUGdzcsxkMj/3iQNo9Se1cDnKekjVWjqjRvNXgTQm0GaE/bjKzbs8DPQH3qOKzu/Nkgvt
+/wAkINqGfYNo54HfirUFq+uakLvUrkSXE3QQpjfjuTj+ldJFoVjMqrdvORCMxKXJAx6cilKtGL5R
+6y1OP1FbmwtV8q4cwnkxPyB7g9qm0zxb5IBv4Lm5EK7YRGwG3PUE9x7Y61e1/TriBPJlKhHBKM3H
+HXufwrD0mKRWeMWryo3HyqWI+taQfLFuxaUZSLQudP1+9dpDILggrFC+Oc+4qjbXU1pqbafd3s4t
+mIUkOcAjoDzTdQ0XU7K/jkS0lTdh4wBz16+1b9rY291feTqFgbdgcsJAfmP5/rW6krX6fkKStoSp
+Zw3nztqM0yAc75iw/nXpfgG2a00B4i7snnMV3nOAQOBXB2enabaWghjlQ/N0Z+f0r0nwtAINJOGL
+BnzgnOOBSoSvUtcia900bj/WfhRT5Rl/worrMidfu1xPibRDcXbTqcOe5rs1PFZ2sofsxkDlQOuB
+k1jiYt09Bx3PHtW0cwtGiysZpifmI4UDH681h3NjBp80SFfMdzy2K9BuhbiRkht5ZZGbJlMZOPYe
+lUft009wYrbRfNkT5WlEGDx74rzY1uVWtdmriZFsrWUYhjR/trj5lOQUUnjnHp71ptLFpVo100yv
+cY43fMAffmp7htc1CNof7ImXZ0d0OdvtxVSw8Ma6L3zpLKUIPmyy4/SsJxc5c1noGyJI9Vs7qffe
+RK8qsBlyQApxjt/nFaVlevJfy/Y7V4bdW2o7/KXx1IHWs+88L68WaW206RpmbO5iCP1NWdI0PXUn
+cXeUYEDzDA7nPoD0/WrjRbV+V/MUX3Za1Cxu5T5jSSMW6DcF/M9ah0yyu4oGS5uYtgOQrHdj6Zq7
+qvhrWpYMKfNTafkSPaxz+NZUPg7WraFiltJI744L4C12KDitmPmRYn1DRre52ySLub5cha9D0fyD
+p6PB9xua8407wZrk16hvLeBY1bOXAPHtXqEEK28CxKchRit8PGSeqsiJyTQr/eoprHmiukgcjcU4
+/MMHBHvVZJOKkElO4WJQqj+FQfYU5VVc7VAz6Cot9G+pbQrE2aQl8cbSaj30eYaVwsODyE/dAFPU
+tk5xjtiofMNHmGqTCxPmkzUPmGkMlO4WJDn1H5U0tUZkpjSGi47Cs3zUVXZ+aKVx2P/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0032/full/!100,100/0/default.jpg</Url><Caption>29377_0032</Caption><Caption>Pseudostoma Bursarius, Shaw. Canada Pouched Rat. (v. 1, no. 9, plate 44)</Caption><Caption>Exhibit</Caption><Caption>plate 044</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3JU46
+U4Rj0pyin4qRkewelLsHpTyucUtAEewelLsHpT6UYouBH5a/3R+VHlr/AHR+VSUcUXAZ5an+EflT
+TCn9xfyqUmm4BbOT9KLDIzCn9wflTTEv90flU+KaRTEVTEufuj8qKmI5oqCrEi9KdimpyBUlWSNN
+JXKa3rE+ma9HtlAh48xCw5H0Nalr4j0u7Tcl3GD/AHWYZrJzV7Dsa2aWsbUdaW3g3Wy+Yx6Eg7cf
+Wp7XV4JbRJJHVZCuWUHkUKavYLGlmjNZU2v2VugeVmVT325qEeIoJV3W0byKGxuxgY9ar2kV1FZm
+5miuaXxQ0LFZ4A2TgeUc4HvVy012CVsSOdzYwAhpqpF7MfKzaFIaVeRSNVARHrRSM4U4NFSMfB/q
+Uz12j+VS1HH90fSn0yTi/Fbypf5RY5FwAUccj3H5Gs6xuNPkizNAgdQPmXjd+H4Gm/EaM29/aXiO
+qk9uckgj061wf2/zLgtKZE83qB6jp9Pr7V5WI0mzZOyO91LXLaxshcw2zy25wCyncAT0464rD0vx
+XbXcwtVU+eWwoZMFvpxXMf2zfWk8kqvwcqE4YYPqOlXrfTV1TTrIxLHFdRS7mlLYUjOfwqIuLBan
+bajqV1bWnl29m8zFcne2EGf51yMuq+INGEd1dtbG2kcAw7MYB7jvXVMtjBGVu7qIlx91Tk+3NZr+
+INDt3SNljd1zhtucGrjNF2XUinhvLt2lM8QjbkFJMjH4VXFndNfKUuTGx2gYcjjvV/UNbtJbCSWK
+VCQM8djXIR3lzc3kRSTK+YMtnpzzgdaqL1uDiuh9DwjbCgPXaKU0kfES854FDV6iOcydRuPKuFX1
+XP6miqWuORepx/yzH8zRUhc6BDxT81Ch4qQGmBy/i/wq2uRi4gZjcIuFQtgVwEvgHxIWYx2Y+8CM
+yKP617RmlBrmnh4SlzMtT0seKH4a+JJSBshjB7+YBj8BUkXw88TW8bJHEh3EcCYAfXrXtGaaXYfw
+H8DU/VobC52eVR/DTVQoM0wklI5Pm8D2qgfhRq887mRoEUEbTv6/lXsYmJ/gNOVieoxVRw0Iu6Dn
+Z45dfCnWkUrazWzbhhsuR/StTw18Nb+0u45tTuIVjjbd5UXO4g8c+leoE03dWvsYhzsdTGNBNMY1
+qQzmPEUpTUIxn/lkP5mioPEz41KPn/liO3+01FIZ1KPxUoas2O4JA+X9amWc+n60CLu6jdVUTH0p
+fNPpSuMtbqN1VvNPpS+YaV0Fixupd1VvMPpR5p9Kq4ixupM1B5hpPMNMCctUbNUZc0xnNAHHeLpi
+urRAH/lgP/Qmoqn4yY/2xF/1wH/oTUUAf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0037/full/!100,100/0/default.jpg</Url><Caption>29377_0037</Caption><Caption>Arvicola Pennsylvanicus, Ord. Wilson's Meadow Mouse (v. 1, no. 9, plate 45)</Caption><Caption>Exhibit</Caption><Caption>plate 045</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IaB
+GT1GKmAp2Kgoi8ujZUnSmE0hCYowKqzxyrua2JEnXafun/CvPtX1DU5DqVhLLNBNExZNrngHkYIr
+OUuXcaVz0ulFeY/DDxBPNcXmkahcvJMv72JpXJJHQjn8DXpwFaxs1cTumLRtHpSgUtOw7jHXA4Td
+7cU0L8uSuPapQR60EUmhlcoCelFPK80UWES0ZopQuaYDDmkwaratrGnaHZNealcpBCOMtySfQAck
+1ylv8W/Ck8/lvcTwLnAkkgO39MkVLkKzO0xzXIeMLDFzbXiqSsv7iXH6f1rbg8VeH7qREg1iyd3+
+6omXJq9qFmuoafNBkfOvyt6HsfzqJrni0OOjueQ3elwWVo16kA86U7VYuUEYz1JB6f41V8KfE690
+i6NprU0l5ZDhZAAzp6c9x9ak8YXMttZJZTBWDzbWAB3Ie4rg7q3S36MGUelY0XJbmzSZ7dH8UvD9
+3IEhu2ib0mTbmt869Bc2MckMnMgJBHNfMEimQkgVueGvE15oFyq7jJaufnibkY9R6Guq7toRynuc
+OrtFcKGn4Pr3rqYn3xhq8w+0w3Cw3MRVw4yjYyK7fw5qD31q+RlUOA/rxUwl0YmjZxRS0UwsDNtQ
+t6VQfVDGhf5Sg79qs3g3WMwPdD/KvM7wXaWpjgeTHAUNxkHsBmolPldgSOY+JWuvrviRbNG/0ezT
+orZBYjJP8q4B+WIPHODW/rlrcWWszSTJsaUB1BI/KsWZkZ45ChCMTurOT1NFsbGn2luHjhAXzH/i
+YZwPWvWtJ1O+0XRoYfNEi4UqME7Rgcc/n+NeMWOs3Wk3tveW6qRGeEb5lI7g12j+NkvIFeW5ih3k
+Z2xMcfpis4xktSZtM0/EkI1WYyy4VpCN0h4w2OD/AErzfVLS4tJjHMrKc8Z6V30esxXll5VukMke
+fnbzDkj8R1rK1rT/ALZYs+8PLEfmYnt2JojLllqWldHIXy+Vs8sYAHaqruGUZ61ZdWWPy5jkD7pB
+zVeaPa6pjnHeumLBo7TwbqzGyks5GP7s7kyex6ivXvBzb9MZsnhsDnivn/RrhrGd3CoxZNuG7c17
+r8PpvO0RjtAG/PFC+IiS0OvzRTSaKYiO+J/s+428ny2xzjtXj76uJpyWbbjn5nDbR0J969icCSF0
+YZDKQR614dP4UvoNVu0itJPs0u5Q5bBQE5yP0rnxFPnSY4keradbXahxKY7VhkuoALHtyff0rE/s
+VoxPGsMxtpE3RmQAnd68dq3D4P1Z7NY/tAZ0OVZhnA7VcTR/Esa8SRvJtxvKZI/WsveSsaXjc4+z
+0RhbzwzSbd4HVfu4qomkItz5TTl1J6xoSfyrtxY+I0dFkaNx3UIOfxzVb7P4gtbiUi0Ry3cRAn8C
+RxRGc+pLUehLpmh2y2ySQjbIwGxYlYt7lgRxirs9mttE8MqpJbsQJAxzlsjCjHU/TpTNNv7nT7aU
+XMF15h6oVJGeuSO/45qhd6zPeXsbvbSBFwBuQhR+mB+FQ5SeljSNkW7jQrG4ImeM4UAJEAAB+X9a
+rXGmWSxMotUVGBGEGP1q7Lr9tbxMCy5+8TtznPHHrXOXet3LSs9uihR/z0GSfpWcfayZd0kZM1tJ
+aTvFysifPHnuPSvXfhPqK3ulXKg/cYZX0ryPVkvY40vpgSu8A+g/+tXpXwYsLmCy1C7lDLDMVCAj
+jvn+lelG7Sb3OeR6oWwaKjLc0VViB6tQ0UTn5olb61CrcCnh+aYDhZ23/PJfypwtbcceUv5U3fS7
+6l2EH2O16+Sn5VG1nadTa/oP8af5ho800tAIfsVlJ/y65/AUh0fTpUKtaKB9MfyqcSml82mrAZz+
+FdFkILWSEjpQPC+iqxYWEWT3rR8360hkz61dkFyhL4f0mWFoJNOgeJhgqwyCKtwww2sCwwRJFGow
+qIMACnF6id6NAFLjNFVixzRU3Gf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0049/full/!100,100/0/default.jpg</Url><Caption>29377_0049</Caption><Caption>Castor Fiber Americanus, Linn. American Beaver. (v. 1, no. 10, plate 46)</Caption><Caption>Exhibit</Caption><Caption>plate 046</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21UNO
+Vc9iPrT1FONY2NLjNtLtpaWpaC43bRtFL+NH40KIrhgUbaXFFXyhcTFG2loBp2C41xtUnaT7CmD5
+gflI571LmkNJodyqy80U9/vUVJROKaZUHBYClZgq5JwBXLaxqUzMyWksSEH7zEGrSIZ03nxj+Nfz
+oNzEBnzF/OvOpr69jc79TBbtGqgk/hjNYlx4kvYBJJca5Dp1sDhdyiSd/og+7+NS0K56ne65punw
+tNeXkUMY7u2K808Q/GHEjW+hWwIHH2icdfov+NcH4l1qy1B1Nul9LIelzdzBjj2QDArJtYRINzZy
+fzoQHRSfETxZLKZBrEiZ/hSJAB+lXrL4qeJrJwZp4ruPusqAH8xisFbBBGWVC2B+dULhk8sgx8iq
+Qz27w78UNN11lgkH2O6PHlyHIY+xrsF1GJhzg/SvlDlZAV4IOQRwRXovhbx3dm3GmXTI06jEUzA5
+b2PvVIR7M+qxoeFyBTrHV7TUZZYoGJeL7wPavL9S8T3ltYDzH2zOPu4AwM/1rpfhvFNJa3V9cYDz
+NwO+KzlO8uVGnLZXZ2rAZopW60UCKus3H2TSprg42xjcwPcd68pm1NfEM4htrqewuIl3Ryo5MbMS
+PvD04r1DxDEs+gXUbu6KygFk6jkV45NZX9jq7LoMUdyACZTOmTt4Gz3yaHKwWuT2Og6tqQm/tTVh
+D5sLPA1vOq+ay9QVAywx37VxWp6TcRXMaSRsiL3Pc12Gh61b6jr0MGp2SWiRRSw+bb7tmHByrA89
+e4qr4u0q/tprRdPDX1osYRJYQXJYKAc46HilzaiaOUETPewWygMpGTgc1rPaR28O8jIxn5f61FY2
+dzpzNPcW8rXDcfdOEHcfWm6jqKsWGzaNoH409yRk94scIU7lZunYVT2o5DlwBnDBj0PvTZ45JtPt
+5GbJJYAU1LO4dMGMhs8Z9KpDKzx+ZcssSHg1Pp4ePVYmGFMTB8j25qe2s7wttW2ZXyfm6VoM2n6D
+DmdluNQkBXy158vPrz+lF+iBIsWEV1qd0L/VJWS3Lbtzfx+wFeweAJ2ntrtjHsTcAgGMAdhxXhpF
+3dMssjM6jjvgD0HpXunw6sxbeHRIVAaVskg5zWSVpG0lodY3WikbrRVmY2aJZ7Z4nUMrLgg968p1
+3w7cJemWGSSONePv9BXrCH5azdRskZTIF3N2UDJJrOona6Ki+55TBHa21qocgDfhm7n8BzWXqVhL
+qkbi2luEVjgRQyFVb68c12l3Zam87QtaH5skDA/XHA/OubVNVSeW3to0kuk+QJGnyouepNcvO079
+TRpM5mz8Ea/aukkepW0JzwvmMcH6YxV42OrFprSfT7W+lXG6SFiuD2zxj+VdHD4WvJiputQkQsSz
+LH1J69T/AIViarb3WhZS3zLC+dySuS31PY/iKarTb1J5Ec/Lo15q0ojklgtUgO3y1OQuT3NXbfwf
+JEis2qYVjwFkK5/Ct21un1XT1EO0R5xIkMeCPYjtnmoE0q6ubtEdgm4EhWfkfgOwqZYmadkCiiO5
+8FStZeVFqDrJu3Fmlzx6VDpXgGOyuo31CUSbj8u08fjW/Fp0SW5N6+6ZeQqsTx/kVWkfV7lfJsbK
+X7PEeH6Y9zVxr1LWL5I3uaU2m2dokajAXP3T0/GvSfDsaw6NEiRiNeyr0/CvNNM0HVLm5jkuFYqS
+MtXqthC1tYxxtjcB82BjJrSi7smo9CZjzRUbN81FbmQsbggU/efSqEMh21YWQ0lIdix8p6qKYLa3
+yT5MYJ6kKOaaHNLvNJ2EKbS1brDGceq1l3vh/R7tma505XyNpIHUfhWl5hpfMPpU6BqY1l4b0Oyv
+Bd2enGOULtJUkBh6EZwa0V0XTRcNcfZUMrEHcecY9PSpTKewpwkNO0Xug1K8mh6XNMZZLKJnJBJI
+q4IYUUqsaAHqAtQmUik801ash6kwIQYVAB7UjuAKgaU1E8xxTuFiRpPmorPedt54orPmKsf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0001/full/!100,100/0/default.jpg</Url><Caption>29377_0001</Caption><Caption>Meles Labradoria, Sabine. American Badger. (v. 1, no. 10, plate 47)</Caption><Caption>Exhibit</Caption><Caption>plate 047</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25FqR
+V9RSRjgVLisUjQbtpdtR2t3BeK5gkDhGKtjsRVjFNWaugITEjdVU/UUnkRjoi/lU+KMU7AQGJT1U
+flTGTA4UH2rmdd8b2ukyugAIGVRuu9vQU7w34ivtYwbq0WA4z5a5ZgD0J/uj60h2ZvFM5ymKryRj
+0q+wqtIBQ0CLidBTL3f9guPKP7zy2249cVFeWpvNPmtw7IzrgMpwQe1eUi613Q9RYS3FztDfeJJ7
+9weormr11T91rcLXJ9K8ST6O7SqSxl3RlcZ5DnB/L+deh+HNeXW7ViYnSWIDfkDBJz0/KuA8SXVr
+Bb2qWhFu90n2iUJHkEt3zyRzngVJ4BimfWme21AKQv7yFwxEi/iKwoN06nLfQG7nq1Zut3n2WwcK
++2VwQMdcdzV+aaK3iMk0iooGSWOK4DxrrSR6bNfxg7fKAiZl5Gf1r0ZPoJI4aCQ+K/G9tYxSKlrH
+INqk8cc8ep4rvNZ8Upo0/wDYXhrTheaj0cIvyxn1bHU15Ro+oNpF7ZXqeaLkb5htH32IKqv4knPs
+DXtHgTw8dH0b7Xdof7Svj51wzckZ5A/Xn3JpeRb7ieEdM122huL3xDfGe8uSCIh92FR2GOK3pBzV
+tqruKGTcspVHW9OfUtNlghKpKwwHPGPxHNXk6VIRuUj1FTKKnFxfUk8xSH7Jp0kV1ZDUYracj7S8
+m0RgDLAHqRwcVd8N6pf3l640qzsLe0Q5kbhiq+/OSa66z0OK20b+zpHaZTuLM/OSSSf51zui+DJd
+I197mGdRbSo8c8Q4JBHyn8641SqRnG69Wv6vYdzjvFOuN4k1THmMkFqrNb7TjOWGHIzwcDAqh45u
+QdMhhjyGlcZVm5PpXceJfDWmaL4bumtIwJ5WQAtgvjIyF98V514p8p7vTofNjl+cD5o2U/ma6IJ8
+95GkpLlSR2vw98MXK6j/AGte2yrbJbpFbiTDFm7uB29K9MNZHhvVF1HTlUWctqYQECODggDgg45r
+O17xPeabPPFBp+ViXiWRuGJHH0A/pTdeEYc99GZu7Z0jVBJXBeFfEd7qHiPyry9ln3K2EjX92v5V
+3sg6UU6qqx5kCJ4+lcZ4k+IsOi6i1haWMl3NGcStnCqfTPrXZL6VXOj6a6oHsoG29CyAn86moqjj
+aDsI5/wZqWv6ktxe6imbKZiYA20OvPQY6r15rqH+dsxsBKvQNxkehrkPGUUl3FDb2OqNavbuSUgb
+aQdvGcduf1qbwFfzXWn3Vjfl3vbeXc7SHO9W5Ug/hj8KVKok/Zt3aLcGo8xR8dWeraisVzbhEtLQ
+ZlDEblORuPuMYrjNVtIbu4jDSgSIu+JzgDcD09OR/KvZbqCMRujqDBOPLlU+h+X+uK8y1rQ5fInt
+JYy1xbvhSP407fpROPLeS6ig9dR3h74lTW+qR6f4jnaDzAdjyQBNhPQORgD6gd+1eg6tpFprumNb
+TsxSQbhJG35H3FeAazb6r4s1i6vDbIz2sYSSNDtIUZ7Hqa0PAXjW88Pa1bafc3MkukXDiHbKc+Qx
+OAR6DPUU4yUlyyKlHqj0Lw/4En0LxKl2Xjlt1Vgrjg8j0rtpOtTk8VBIacIqC5UQiVDUwqANtUn0
+Gai03UYdTtRNCcEHaynqpFXEGY/irTpHtxc2iosn3WY8Yz3964dr1vBniG11NpLmWzlJjugzbgFP
+Rh9Dg16brKu2mybOxBP0ryHx/fM2gARSEElQzA+uT/SuGouXEJrqdVP3qTTPRofGGla5NJaafcB5
+YpNwVhjzwjAsEPfpUfieHz44dTsmbcqAOQONpIwT9MmuA8H+G7i70Lw/rdvdw2kltdlpvNbaJItw
+7+v3h+NeiTapa2elXdttaZWd1iMfIcNyDn2JI/Cux7e8czWuh55rWnTafq8Wo2syosmY5wowGHXJ
+rziO3+3eJLS3nnSBZLhVkndgFGW5YmvXruK1m0aSG6BbC9T1Fcp8OVsH8TXWh6naQ3NvcAmMToGI
+YZxg9Rxmopx97mL5vd5T3C2u7W5jAtrmKYAdUcN/KnOK8t8b+GrbwaLbxJ4fLWbwzKskKMdrg+34
+Yx716gzblB6ZrVogmXHPpXG3txFYajI+nXRsgCAztja3PQq3auxjNV20uwkuTcSWUUkx/jdQ35Z6
+UWuI4y81/wC2SD7RqO6IAgrAdqnHXOOTXIa1b2OqRfZ2uC68AR2imXgdORXr93oOl3yqJ7GA7e3l
+gfyrQSOOJAsaKqjoFGKj2N5Xk/QtVGlZHjWh6DcwuDZeHr2TaMJJcHb9PvdB9K6C/wBC8SG081mt
+7RMhTg7yinq2B2r0QyleqYpd5b+Dg+tacqJ5meTarpGr6HDBHcyLfxXbBEmgU5De4rG/4R/UdO1d
+Lu0sbpZ4yHR9h5Yc88V7kcY6DimMfTFOwXOD8XaRqPip/DaIhSx88TXkbcEYGcH9R+NdnIcYqUk9
+8VWmbpzQwRNGeTU4NFFCEOzRmiimAZpMmiigBCTUbMaKKTGRsTVKdzkUUVLGj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0007/full/!100,100/0/default.jpg</Url><Caption>29377_0007</Caption><Caption>Sciurus Douglassii, Gray. Douglass's Squirrel. (v. 1, no. 10, plate 48)</Caption><Caption>Exhibit</Caption><Caption>plate 048</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xY6X
+y6lC5HNOCgDAqBkPl0eXipsUEUhkQQ0uypMADJrifE3iK/LxNocyrHCxLuyblmx2HqOv17VMpqOr
+BK52WwelO2CuV8J+Kb3WJjbXtnhwu7zo1IX6EHoa67FUmpaoGmhmwUhiX+6PyqQUtOwEJhX+6Pyp
+hiA7D8qsMoYYI4NM2BRgDFPQCqYhn7o/KipyOaKWgEgpaBRQAUUnFKCKlsDnfGOpPZ6bDZ27EXV/
+KIUI6qvVz/3yD+dcndX0MN7ax7N0cZJMZ43Y+UL+tP1zUHv/AIgDDHybBPJVf9o8sf5D8K1LOGy1
+TXY7ee2KssJdu27kY59ODXPUfNJJGkVZXOl0SaGa2kCQJDNE/lzKg43Af/XrUpBgdABmlrpWisZs
+KKM0VQBSHpRQelAER60Up60Uhj+1Yt9rMdm5Vpk3dl6mtkdDXA+IriG0vQZAoXJwvdseg7/yrKpJ
+xWhUY3Zonxjb79uJCe+1TT18TibISKbHZuAK4r7Te32Da2rRRE8MR+ue/wCFVpdJuPMP2h5WXr97
+ArmlVktzTkRJJIy+LbxyQFkkD5Jz1ArVtfENpbeJjcvOqxwxCHJIG5ien6Vg3dpYWlodsgRjk8Pl
+s+3rUWl2jtZl8pHGnzZuMEnPOen65rJVNbj5T1SLxTZNt3SKm7pu4zV9NXgkAK8147JrlzOWg0q2
+EiJ1nf8A1f8AwH1qw11rllaia5igeLGT5alCB7GulVZLcjkT2PVrjXrO05nkC+g7/lUdv4k0+6bb
+DOjEdVzhvyPNcPY27nyr6Z1uJJUDKJBlVHp9ferN2+kyRlprVo5VP3ohyPoRx+daRq3Dksd7Hfwu
+2M4+pq1nIryOz1oQagCsl40ajGyR/l/EV6hpl19rsI5thTI6GtU7kSViaQ4aimy/f/CimImDALk9
+BXl/iXW9Lk1YzTWivNHlEkYdq9Lb54mUdxivKNe8PxWF2817eKQWLBAOvPSuTEzcUuxrSV2RWWuX
+91emRQiWq4GWX+Vct4s8U3j3Pk20rxo33nXj8K7bTFj+yOF8rdtO3HOB71zmseFE1KESW5KlSckr
+XLCa57yWhvKPu6bmJ4aj1DUJGnE7mOAZZnOQc9q7rStLjnupBqkO+NCGVEbKOewPr/Kua8M6Tf6R
+fSx/b5IosDe0f3G9M54rt/sF688cokkcoQYy0pVc+pUcGrlOKleJkoytZkF5rljbzmOWCMzZ2RIB
+x+Xb+VUR4lt4TJZanGXjlJyY8MIxjjpn9M03UfCdxM5d5C8pbLN5eAPxPWqj+B7qcI32nAXgLGmf
+1qHV5nqi1C2xU1G5e307fZapMbaNgIx5ZXOe2T1xTtKfXNYjMqTAIvG1hnNXr3wbObUPf6oTFEuF
+LjCoKfoxgtP3Njq0RJbAQ/xfSrdS+iGod2WoNDmmaJrwI5U9hivSdKTytOijC4CjAArm7G2uZtmZ
+1CN93J6/SuotIWtoAjSb/wAMYrpoNmVWw6VsP+FFMlPz0V0GI5JKgmsLK5lWSe1jldejMoJFV1nO
+KnWYkUNJgromWztAxYW8YYjBO0Uj2FnJjfbxnHQY4pnmkUvmmocIsfMxx0+yxxbxgegGKXEKLtEL
+AdsAVGZiKBMcdKn2cewczJMQN8phZvqKlRI/uiPaPpVfzuOlOE/tVKKC4t3p9nfQGG6gSWM9VPQ1
+nx+E/D8Lh49Ktgw5B21o+d7Ueb7VXLHsHMxEtbWAII7eNdgwu1R8o9qkL1EZaieWmkhNiyN81FUZ
+rorJjFFPQR//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0016/full/!100,100/0/default.jpg</Url><Caption>29377_0016</Caption><Caption>Spermophilus Douglassii, Richardson. Douglass's Spermophile. (v. 1, no. 10, plate 49)</Caption><Caption>Exhibit</Caption><Caption>plate 049</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?rgn1=medium;select1=all;op2=And;rgn2=istruct_caption_image_title;select2=any;c=sclaudubon;sort=medium;q1=lithograph;q2=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719889%2029377_0049</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1OPTl
+9KmWwGTnGO1aixj0pdgzWaRTKK2KelOFigHSryoKdtFUIpraKO1TrFgVMRiikBH5dL5dSCnYFDAg
+8sUeWKmxSYpDIinFMKcc8VYxTSKYFUx80VNiikMcKB1oXkVBLe2sEywzXMUcjdFZwCaFoJloA0uD
+VR9SsYZxDLeQJKTgI0gBzRqWrWGkQebfXKQqegPJb6Acmm5KwrMtEUVhWXjPQr+5W3ivNkrnCrKj
+JuPsSMVtlsmpU09Uwaa3HDinZqEyKvVgPqaeGB6U7gh2aM03NLmgodTTRmg0AR0UpooAS3cSwo46
+MoIrgPHtiZrxXjOWwMiu20kk6XaE9TCn8hXJeKgrajLFHKPN27tprGt8JpS+I85OtazpBMbJBc27
+cNHPEHzn36/jmn/2jPd3kd3qUjlQirGZG6IBgDn/ACa1Jj8mfs6yP/ErdvpWXqMD3VuYkuCkUrY8
+p+MH2Fck6il7ktDfktqjbuLPTruzNxFcK6bc4A5FT6bqfidoYxHcPNasdqM43MB6/wD668+iF3pM
+ziF8ZGGH3lYe9Q3F9eXEflrPIseOIxI20fQZ4pUqfI3yS0M53e6PaYobhsPc5LA8gdPyq0XdECoW
+UDsua8c0XxjqGn3Kx3kj3MQwNwbLqPbPWvQH1j+17EXmj3fzRLl4WQFgf9oYzj3BrqdRx3RmonQW
++rajFLsd3aM9CRkrV3+3bmJTuVJfcVwkqaxqyBmZLdQPnEI2nPueorCv3vtKeOSO4mJblX8wlSPx
+oWITexXs9D2Cz8RfaR80IU7iMbq2o5BLGHHGa8Xh8VljD5UUhKoNxZRgn2Ir1Pw1fnUNGjmZCjZw
+VPatIzvoTKNjVPWikJ5orQgq6Ydun2q+kS/yFeffEJzZaulwcYlTt14rvrFsWsA/6Zr/ACp1/ptl
+qkPlXtuky9tw5H0NZzV1YqDs7ni1nrqSS7JACmAACOlXtRtIJ7cPtSJiATz0+legW/gDQ7efzIoW
+AzkKTkD86tXXg/Trlt43I2McDj8q46lCTWiOlVV1PDLpAsZ8vaWIPI5pmn6LJeo7yTC3UD5VC7nb
+6CvXpPhrZliwnIGcgY4FPh8BxWZ3QXXz/wB5lrCnSrRW2pLnBvc89svCqqqNKsUbngCQ7mJrodP0
+s6cpnW8UuMqOeAfoOtdVJ4TeV8/aVTjG4Llm/HtVyHwvbRooeRmwMelaKnWe4c8DzaSwkeaRTqUo
+8w5dFbap/CnTWAhsDbSIXG7IMhJKj/ZB6V3cngLSmnkmXzBI4xlmzj6CrV14UtJ49qNsJXBOMj8q
+1VOrYFOB59p2mxSyJsIHTn2r1LSbNbLT0jAx3NZdl4StrWVZJLiSQgdMBRW+AEQKOg4Fa0YSTvIi
+pNPRCE80VG7fNRXQYlKzkHkRc/wD+VXA471hW0z+UnTgCrK3MhJHGKV00Bso4x2qUNWWkze1PM77
+gOKLAaLNke1QNFGf4QPpVT7RIGxmpPNY0rAS+UmcmpFCKcqMVUaZvahZWLAcUWEX91IWqDecUhc1
+VhkpIphcAVC8jZ7VG0jVQEVzdJFKFZsHGaK5XxHcSLqKANgeUP5milcdj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719889:29377_0012/full/!100,100/0/default.jpg</Url><Caption>29377_0012</Caption><Caption>Spermophilus Richardsonii, Sabine. Richardson's Spermophile. (v. 1, no. 10, plate 50)</Caption><Caption>Exhibit</Caption><Caption>plate 050</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719889:29377_0049/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0008__xz111ffbb66842f49d5f2e023e5131778d.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0008__xz111ffbb66842f49d5f2e023e5131778d.xml
@@ -1,0 +1,2885 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719890___29376_0008__xz111ffbb66842f49d5f2e023e5131778d">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="q1">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">2</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719890</Param>
+<Param name="viewid">29376_0008</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0008</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>b00d3ab63fc1d6fd6f181e4d71b76e7a</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719890</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0008</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719890%5D29376_0008</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719890%5D29376_0008</ItemUrlEncoded><TitleForTagging>Bos%20Americanus%2C%20Gmel.%20American%20Bison%2C%20or%20Buffalo%20%28male%29.%20%28v.%202%2C%20no.%2012%2C%20plate%2056%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0002" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Next>
+<Prev><Url index="0" name="S_SCLAUDUBON_X_B6719890___29376_0009" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009</Url></Prev>
+<Self><Url index="1" name="S_SCLAUDUBON_X_B6719890___29376_0008">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776096</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;q1=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719890]29376_0008</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/539,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_flm class="fieldsRef">2014-12-11 11:07:44</m_flm>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-8</istruct_isentryidv>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</m_caption>
+<istruct_x class="fieldsRef">8</istruct_x>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0008</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_caption_plate class="fieldsRef">plate 056</istruct_caption_plate>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0008</istruct_isentryid>
+<istruct_caption class="fieldsRef">29376_0008||||||||||||||||||Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)|||Exhibit||||||||||||plate 056</istruct_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<m_iid class="fieldsRef">29376_0008</m_iid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</istruct_caption_image_title>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0008</m_fn>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_caption_image_id class="fieldsRef">29376_0008</istruct_caption_image_id>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<u class="imgInfHashRef">1</u>
+<type class="imgInfHashRef">image</type>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<md5 class="imgInfHashRef">39c661cab405233d69a0d9b728e918f9</md5>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/6/audubonVQ_v2_12_p56/audubonVQ_v2_12_p56.jp2</filename>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<master class="imgInfHashRef">0</master>
+<height class="imgInfHashRef">6644</height>
+<collid class="imgInfHashRef">sclib</collid>
+<basename class="imgInfHashRef">29376_0008</basename>
+<width class="imgInfHashRef">8615</width>
+<modified class="imgInfHashRef">2014-12-11 11:07:44</modified>
+<ext class="imgInfHashRef">jp2</ext>
+<size class="imgInfHashRef">5582522</size>
+<levels class="imgInfHashRef">6</levels>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:6/0/native.jpg</Part><LevelWidth>134</LevelWidth><LevelHeight>103</LevelHeight><LevelMaxDim>134</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:5/0/native.jpg</Part><LevelWidth>269</LevelWidth><LevelHeight>207</LevelHeight><LevelMaxDim>269</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:4/0/native.jpg</Part><LevelWidth>538</LevelWidth><LevelHeight>415</LevelHeight><LevelMaxDim>538</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:3/0/native.jpg</Part><LevelWidth>1076</LevelWidth><LevelHeight>830</LevelHeight><LevelMaxDim>1076</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:2/0/native.jpg</Part><LevelWidth>2153</LevelWidth><LevelHeight>1661</LevelHeight><LevelMaxDim>2153</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:1/0/native.jpg</Part><LevelWidth>4307</LevelWidth><LevelHeight>3322</LevelHeight><LevelMaxDim>4307</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:0/0/native.jpg</Part><LevelWidth>8615</LevelWidth><LevelHeight>6644</LevelHeight><LevelMaxDim>8615</LevelMaxDim></Level><MaxWidth>8615</MaxWidth><MaxHeight>6644</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719890</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29376_0008</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1846</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank">Lithograph</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/res:0/0/native.jpg?attachment=1</URL><Filename>29376_0008_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719890:29376_0008" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719890:29376_0008" canvas-index="51" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="sort">istruct_caption_image_title</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="q1">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">2</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719890</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0008</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. II; [title page]</Label><Value>29376_0025</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. II; Contents</Label><Value>29376_0011</Value></Option><Option index="2"><Label>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Label><Value>29376_0002</Value></Option><Option index="3"><Label>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Label><Value>29376_0010</Value></Option><Option index="4"><Label>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Label><Value>29376_0006</Value></Option><Option index="5"><Label>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Label><Value>29376_0007</Value></Option><Option index="6"><Label>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Label><Value>29376_0004</Value></Option><Option index="7"><Label>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Label><Value>29376_0008</Value><Focus>true</Focus></Option><Option index="8"><Label>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Label><Value>29376_0009</Value></Option><Option index="9"><Label>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Label><Value>29376_0005</Value></Option><Option index="10"><Label>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Label><Value>29376_0003</Value></Option><Option index="11"><Label>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Label><Value>29376_0052</Value></Option><Option index="12"><Label>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Label><Value>29376_0039</Value></Option><Option index="13"><Label>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Label><Value>29376_0014</Value></Option><Option index="14"><Label>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Label><Value>29376_0051</Value></Option><Option index="15"><Label>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Label><Value>29376_0018</Value></Option><Option index="16"><Label>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Label><Value>29376_0046</Value></Option><Option index="17"><Label>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Label><Value>29376_0041</Value></Option><Option index="18"><Label>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Label><Value>29376_0012</Value></Option><Option index="19"><Label>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Label><Value>29376_0019</Value></Option><Option index="20"><Label>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Label><Value>29376_0044</Value></Option><Option index="21"><Label>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Label><Value>29376_0021</Value></Option><Option index="22"><Label>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Label><Value>29376_0035</Value></Option><Option index="23"><Label>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Label><Value>29376_0038</Value></Option><Option index="24"><Label>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Label><Value>29376_0016</Value></Option><Option index="25"><Label>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Label><Value>29376_0037</Value></Option><Option index="26"><Label>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Label><Value>29376_0033</Value></Option><Option index="27"><Label>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Label><Value>29376_0022</Value></Option><Option index="28"><Label>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Label><Value>29376_0047</Value></Option><Option index="29"><Label>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Label><Value>29376_0042</Value></Option><Option index="30"><Label>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Label><Value>29376_0032</Value></Option><Option index="31"><Label>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Label><Value>29376_0045</Value></Option><Option index="32"><Label>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Label><Value>29376_0036</Value></Option><Option index="33"><Label>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Label><Value>29376_0049</Value></Option><Option index="34"><Label>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Label><Value>29376_0043</Value></Option><Option index="35"><Label>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Label><Value>29376_0048</Value></Option><Option index="36"><Label>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Label><Value>29376_0015</Value></Option><Option index="37"><Label>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Label><Value>29376_0031</Value></Option><Option index="38"><Label>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Label><Value>29376_0028</Value></Option><Option index="39"><Label>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Label><Value>29376_0030</Value></Option><Option index="40"><Label>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Label><Value>29376_0026</Value></Option><Option index="41"><Label>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Label><Value>29376_0029</Value></Option><Option index="42"><Label>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Label><Value>29376_0013</Value></Option><Option index="43"><Label>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Label><Value>29376_0023</Value></Option><Option index="44"><Label>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Label><Value>29376_0027</Value></Option><Option index="45"><Label>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Label><Value>29376_0024</Value></Option><Option index="46"><Label>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Label><Value>29376_0040</Value></Option><Option index="47"><Label>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Label><Value>29376_0001</Value></Option><Option index="48"><Label>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Label><Value>29376_0034</Value></Option><Option index="49"><Label>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Label><Value>29376_0017</Value></Option><Option index="50"><Label>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Label><Value>29376_0050</Value></Option><Option index="51"><Label>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Label><Value>29376_0020</Value></Option><Name>relview</Name><Default>29376_0008</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2ZE+V
+fpUqpzSouFX6VIBWNihAlOCU4CngU7AM20u2nHhScEkdhSIxcZKMvs1ADdtNKD0qUikxQBAyD0qF
+4we1W2FQsKLAKn3R9KZKlzvzC424+6QOtSJ90fSpVoAqlb1WG1lYZPYcDIx+maN1/n7ijr3Htj+t
+WJbiK3AMr7QeBxR9qgGMv19jTAjBvN/IXbkccdKdKboMREARnjPpj/GnpcwysESTJYZGPSk+1W8W
+FMwJPTJznmgRCWviOI1Bx6j/AD6Un+nbv4cZHGOnHPepxe2zAkSjAGack0Uv3HDfSgZTDX+PmjXP
+4cfrVh6mNQyYpAIn3RUq1EvQVIKEArwxylS6htvTNM+xW+7d5fI75NKIkLEkHJ9zTmiRjk5/76NM
+Q1bOBHDqmGC7QcnpTF0+1AH7rGOnzHip/LXAHOB70giXH8Q/GgCH+z7XGBHgY24DHp6daVLKCJw6
+IQwGB8x/xqXYPU/nSFAe7dMdaQDieKgcVL0GKhc9KGMUU8VGKkFJANWLGfnfkY+9TxHgY3v0x1pR
+ThQIaI8fxufxo8vjHmP+dOKhhgikESjbjPy9OaYCbCAfnbn3ppU5++3WpTTaAI8EDqT9ajepmqCQ
+9KTGPFPFMWnihAPFIY1Y5OfwYilFOxTAaIl/2v8Avo/40vlL/tf99n/GomtwBlWfI9ZGxRHEXX5m
+YL2wzA/jTAk8pQc5b/vs/wCNKaFQIu0En6nNBoAY1Qyc1M1QSHFJgPFSColp4NAEmQBShh7/AJU0
+GnA0wF3D3/KjePf8qM0ZpgIXHv8AlTdwP/6qUmmE0gBjVeU1IxqCRqQAshz2p7Sso4AoooGILl/R
+actw5OMLRRTEThyfSjeaKKAAsajZjzRRQBCzHmqs7sF49aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0025/full/!100,100/0/default.jpg</Url><Caption>29376_0025</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUHp
+UixD0pQtSAVmUII1x0pwQelOApSQuAQefQU7AM8sZ6U4IB2oEinnD9AfunvR5i+jd/4T2osAFR6U
+0oPSnhgxIAPHqMUEUAQsg9KqXMQKjI71fIqvOvyj60gJVFPApq9KV1Up8wBxzzTAkGPWnD61iyso
+uTngY7Y9PrV63CdViBI6FdvH5GmIuc5o57kUveq8wQJuIXODyceh9aAJ+PUUhrEilxhU2sT0zjit
+KCZNg3Tx9Pu5Xj8jQBMagn+6PrUyuki7kZWHqpzUMwyBSYyRegp5+6aYv3RTm+6aAMu43LMxz1IH
+U+1WLUgHafMHqwbr+dV52P2hhx0/p9as2sW5RvQNnrx/9egReVNpJ3s2fU5pkufL4J7+voakVQow
+On1qKb/V9uh/kfcUAZON20Lkk+5/xq/ag527XVQM/MTzVBGbcMbSRzgkD/2ar8Hn7cYCg99oI/8A
+QqALRFV5hwKn7VBKeBSYx6dBT2PyGokPyj6U8k7DSuIzpZCs77SM46Ej0qa3lZcOXQj0GBVefP2g
+5fpg4yc/+hVPbA7BtkJyecbv/iqYF9ZkYgBhk9qbMcR/n3x2NOjXYuMknvkk/wA6imJ8vqeh9fQ+
+4oAzl3OygHI7/Mf8a0oGzHj0981nQAmQkSYxjpk/yaryzkKAVYn2H/16AJSagmPAqQPuz8rDHrUU
+rcCpYx6fdFPP3DUafdH0qX+E00BlzsFnY5GAB3H+NXLWLzF3Fk68BVFVbhsTtyeMdz/iKtWsnmIW
+dpDg8YzTAu1BPjyxnHQ9ceh9anBBUEVFLny+M9+mfQ+lAjIBRcbjlcZ4P/160YFVl3bB7Nx/SqCy
+HcMFlPTIJ/xq7Ddx7Qhcu3sDSGTtUEo4FTk5GRUEp6UmBIh+UfSpB0qCM/Iv0qYGqQDWtYnYsdwJ
+64NSLbxLjCDI70oNOzTAWmtGrj5gDj1pc0meKAIRZwA5KZ+vNKYYgQQi5HTipCaaTSAaxqGSnsah
+kakAkTHYv0qdWNFFCAXec0u80UUDF3Gm7ziiigA3mmFzmiigBjMcVVlds0UUAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0011/full/!100,100/0/default.jpg</Url><Caption>29376_0011</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2JIRj
+lQfbFTLGABgYFPVakArj5UakXl0uypcUhwAalpAM8ul8uohdKCVPUGsDxl4kttF0WUm5MUsi4V1P
+Ke/tUOcUriOiYIgLOwAHcmsI+MtAW+Sze+WOWR/Lj3KQGb0z2/HFfOuu+OdV1AeQt7czQqx2tLIT
++hrm3mubgiSW5lY9sseK2jCTs9kTzH0dq3xAk0PxBJZ3lvbS2ZwYZYZPmYe+cjI/Cuit/Fmh3Fvb
+zC+jQzglEf73HXivkp43PzGRyfXNadnq89rEsM4M9sG3FCcEfQim6U1dp3GpH0rdeONFs74Q3Mrx
+QNkC5ZDs3Dt6j69OK30ljlijkibzI5FDK6cgg98184w3VtcxRN5s00UxI8uWQsqHHbPSvZvhubk+
+E4EmJZYyyoT/AHcnAH5/yrKEpNtSWpVzp2TminsPmoq7IZaWnVHI+yMt6Vg3OszI7BU5HP4VRLdj
+oiwRSWIAHUms29vZYwuyCQgnAYgD+Z/pXOSa3dTbpE2HZyBv4+tcT4k+JmotbSWml20vmgc3DoCq
+j+8Of51jJOWiYJnV+JfFNjotqZbi9SK42nEKMd7fQfnzXhGv+Jb/AMS3Aa4kZbYHCpuLY+pNZ969
+1JcvcXlxJJPIdzO7ZLU0CQhmH3Rgnjt0zVU6MYvm3Ym3sM+zswZCPmXv7VL5QVdhXkDFLKzQy7GB
+yR19amjieYdcZFdKJ6kTYSIE4Cn7opqoHycDGOaZKWL4PTtUttuAkB6lCBWnQSJdKb7PfLBKSYHb
+jnofWvof4b3Q/wCEd+zzTpvE7rCjMAxTjt9c/lXzmBvtxICQynNekeFNYvrrVdHeAEyPIsbMcY64
+P6VjVT5k0WtD3UrzRUpHNFTYsp6rcraafJM3QD8685udbmkBcSqzA/KcYxXU+P7hrXQY2BAQygE5
+56H/AOvXlSX8c0XzMV+TK56kevQ/5/CuWvKSdkS7Fi41S+e8aZCjQE5dGA+Ze/8AnvV61t9fuHMy
+XMUto6lQMKAF/mDjtiuWvrgNCVhiYrklnBwB+J6fT+VYkepSae7SWt9Isv8AdViR+PGKdOnUtqSp
+WOg1fwrGkUaDc0xzj6nH6cH865+8tvsMEhyMFfLB9TnJ/TH51r2PjErGx1K2cy4Kh42Bz6jaTkdO
+f8iuc13UZNW1Dy4EKxDgZ4Jzz+FbU09mNtWFggfVctGVVUfG+RgqhcdST9Kt/a9LsiIUWa+kxh5Y
+jsRf93IOfrVQWDzRw2kKsyg7nK/xN6D2FdLZeHobW0d7p1RguQuf0qpzSe44oyFh0q7j8tYL1WJ+
+8zLhD65rEXzkvXtkYSFGKhk5DfSun1ePSLm3tovtaW8UTHeioSXPrkdfSseCa2sUdVUSucjKngj/
+AAq6ctBtXIGjeF5ojtPfjkc10vw5uZY/E2nRlvkFyOPriueMrXM0kjALhAMAYrpfh5bCXxXpyqfm
+88N+XP8AStXrHUnqfSpHNFIzYNFYXKOK+KkbyeCpHjzujlR+B714zpc8Ijvbu9Ym3gC4iBwznkBR
+6Z9fQV9CeIrBtU8P3NojBTInUjPvXzTq1pJp2pT2wbzFiKmXZ25PH15oVm9SJLUr31/d6jc7WGyI
+fdgj4RBWlc6Hd2Xho6jdNHBExCpGE+aQnOKd4bextrx7q8aJ02N8sg6H15/zxR4k1m5122haCNxp
+tkpKJswuc4z/ACpO7YWSRnaSzQaim5Fm4BmeQb8E+g9e2PatOHwqUlF3NIiR7txB6twM8dupqrpk
+n9mQPdXgR7mU+YA3UfhWXqGvXd0dnmPtHQZrO8nJ8uw9kbd3q9vp4xGqO+MZ6jH+FYd3rlzdysRI
+3zdQKom3nki81wxyegHNN8iXkJEyj0wSa1hTW4OVhCGeUeYxAPrV1MJgKQT2z/Kq8drck8RN/wB8
+mrUFpPLK0cakuvDN6Vvyi5x3mGRvLXnJzIw9fQV6j8IrCOXxAblk5hjJXjoelcHp+g3kzAJFk9gK
+9i+F/hvUNKe4urtTHHIuFU96mWw0z0ZyN3SihgM0ViWRI25AO2K4rVfhjpepSyGKaS2jnk8ydU6t
+7A9ua66N8oKkD+1IRxEXwo0uBk8p8InOGGST65qyPh3bQ6c9rE6uuPkV8hR+A6/jmuy8w4pRJxUN
+IDxm/wDgtq+oXZlk1W02n1DZFaWlfBC1tCHvL0TuOgC4Ar1YPmkKgjAyPxprsI4uL4Y6ahBdg2Pa
+rC/DfSkfcFH4jpXWBVAxgnPXmnhgoAA4q0LlRzH/AAgGmfQ+wFU9N+HFlYXN/IZRItzP5q/LyBgc
+fnn867TdmlLc1aYcqMKz8H6TZyCQQhmHrW6AqLtUYA7CmsfUUwvjOBQOwE89aKru53GioKP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0002/full/!100,100/0/default.jpg</Url><Caption>29376_0002</Caption><Caption>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Caption><Caption>Exhibit</Caption><Caption>plate 051</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21FO2
+nbTt5605BxingVlYoy9T1S10iATXbFUOeQM4AGSfpWH4H8Xp4ws764WMRiC5MaDGDswNpPPXrVX4
+hSmJbcZDF0eFY8cncRuP4AfrXF+F/EsHhbXba0KQrb3QENx5edsbZ+Vgfx5rB1Fz8pXL7tz2fmnC
+lxkZpQtb2RFwxml20oFOxTaC5WlnggZVllRGf7oZsZqQAEVg6tZLLJPO1o0xCkbrp/3ag45UVraZ
+btb2KI0aRt12o5YfmazjJuVrFEzocEqAT70wxkr8wAPtVgikI4q2BSZTmip2UZooAmUdKkApq9qk
+FMR5t49Fzd6lHbBSiqP3ZA5bPU5ryXxTpUthb2NxCG/0gyKcghg6nBB/Svo3xDpy32nMcYkj+ZWH
+UfSvIPFNhfahaRRXV8rRW7M6DYqsSRjkgc1wVJKnV97qdEY80NOh2Hws1rU9a0djfajBc+R8hjKn
+zU9Nx6EY+tehCvmHSNR1jQb57zS7h4HYBWXGQw9x3r0fw98X/wB8lr4itPIJ4+0xD5fxH+FdUJrY
+wkj1gCq0uo2kF0ttJMqysMgGpra4gu7ZLi2lSWFxlXQ5BFQtpdq941y0eZWweT0I6Ee9aO/Qkdeo
+JLGcbiuY25HUcUQrcCV/M2+UMBO5981DfXtvaqILidFL4xuOCRnn9KsQ3CXESSxEMjjKt6j1ounL
+cZIRSFeKfQRxVMCuRzRUhHNFADxwM1Tk1a1hcq7MMd9tXP4SK5+/gDSE9faolKyGkav9qWEo2faE
+y3GDxmuG1vQ4jdzAxgNkkH61cuvIjx5pC+nrV0XsWoWLQyAmVFyjkdRXHibzjdbo1pNRdnscHBpU
+UV1g44B4rK1fSAJT+7BU8gkdq6+0snvNae1GEZFJJY+ta1x4dkhhJdlkAGcY5rgpVa1+ZrQ6akKa
+0T1PM/DXjS+8E34ibdPpUjfvIT1T3X0NetW/jjT79BdWAe4h2dRwMk15J4uFnGBbxIGdueOq/Wsf
+wbfzWeuf2YJcQ3J3AHsw5r1IVHKF0cc42dj2PVL+K5MshsovPkXaZGG5gPb29qpR63dKMzTupztw
+GwFGf0FQmURowAwCpw552sBxn2rJguGu7qdCAUbCDHOD3/Os5VHfQdrHWpd3i/OjyYHJJY811enX
+JurQM33hwa4c34hkTPypux9B2rqdAuEl80IQR7etbU5tuwSWhsYopaK3uZkcr7IHfOMKTmvKdW8W
+XsTy/ZxM6BsbzgD+tepzAvbyKOpUgcZrxDxEbi11R4ZGIkLEhT8o/AGuavNxSsa043ZXl8UaxKwx
+Z2yAHIkcN+vNbHhjW9UvGv7i8lgW3ih2hY1wCxPX8gawbSDUNYj8p7clWbJJ6FfetK7u9O8N6LDa
+uytJIS0qRqcuR0X+n41xObldW1NVFJl3wz4jin8RSQzMFuWYGOQn/wAc/L9c16PrV0bTRp5V/wBY
+qYBz0JIH9a+d7a9vbrWFvI7dQ+/dhQeDXsy6lPqWmRrLbMLhk2yQOcCQEc4Pr3q1aMeVbkXvK7PM
+NVzB5ssilpZMkknJzmsDToJRqkd3sZdjfJjqTXc6mI7S5EFwiMSPkdsbx7ED+dcvaaxbHWHmaBzE
+hwrDkce1a0ajatbYdSnbW+51kVvrWqxBPMNrbkchT8zfU1Zg8MTQZMV1Msg7hzmoI/G9hbwkxQSb
+gPTg1UtPiMj6yqXMSQxbCWJPT0rSLk9kTZIuvezRB7S8yZI/mSUd/rXd+BJ/tMcjb8hBjHua8f1H
+xA2sahMbBCwxhTjqTXqnwvsb630y5mvo9jOwCYPUdelaKNpIhnfZoppPNFaEkCvWTq/hiw1mQTS7
+o5uP3iYyQO3NXkc1KrZFKUVJWY02tjm7rwZHI4MEvlqBgheM1nX3gD7XayRO6dMqUGDn613Icil3
+msJYamyvaSPJtG8D65p8sqrbQbQPkeQhs1en8O+JbqNkuFKtjb+5kwO/Q9e9el7qYy55yQfY1n9T
+h0bH7V9jx9Ph7fG4xcaZI+OBKZ935jio7nwLfBytvo0iBQQCeQa9kRARkluf9o1Nu4prCrpJh7V9
+jwyH4feIMpt06LYp5DsRxVm1+ENze3rTahbGHecnbOCP5V7VuNG81tGhy/aYOpfocppnw50PTYUR
+IOVO4HPOa6qOOOCIRxgBQMACkLGmFyBxWqilsQ5Nkhbmiq5c5op6CP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0010/full/!100,100/0/default.jpg</Url><Caption>29376_0010</Caption><Caption>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Caption><Caption>Exhibit</Caption><Caption>plate 052</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dIx6
+VMqe1CDgVIiBegAzzxXOkaAq4p4WlAp1XYVxNtKRS4oNOwXGYppWpajkkRPvEZosBGyiqt0g8hvw
+/nUqS292SAVYr+lJcKBAQBgDFS0NEyDgVIKYnCipBTQmKKcKQUoqhDsUuKSloAZIQiFj2rndXvfJ
+i3E/M3vW1euAFUnHOTXn3iS+Ml0UVsKDk89hSY0bPhq5a51e5wflVR06V0tyP3LVgeC7Uppr3Tfe
+mbI+ldDP/qjUvYYqcoD7U/eqjk01DlAR0xWTfXjqxSOQL9Bk1POktRWuabXagkKpOKYL8q2CgP0N
+c1NfXka43jGOWIFNguJRAZnn8w52qobOTQqlwsdDd67bWiZckE9FAyTWSfGsavzay7PXjNURblpD
+JJ88h5OafcaerwsWAUYzT5hG1Jq1rfWvnwOCdvKnqK85vUN3eeX93zZNoBPOKx7rxhZ6JqLr9rUF
+SVIA3A/XFTeHtc07W/ERna9hGOQhOCfoDTA9jsIorSxigRgAqgdamm5jasy1urc7QvTtxWlKf3ZN
+JvQaFjGYR/u1x2prNHcufMePBPI5H612MZAhB7Ba8+8V6jdxzkQPGRnG3HJrjrytFFRKkMBnuW3S
+XFwzkDkHAH41vGNLa2QKuQgzha5+PV7Lw1pNu2uXwhmvHJRG6gfQdBXSW81tcWiXFvPFLCw3B1YF
+cfWrp3SuxNhBdRSKJGdR7V5t8RfHLyxSabpk22EZWWRerew9qqeM/GdrmXT9LZWcjDzxHhfYHvXl
+s9xM52uT16mtkSPVWuCWY555qrJLLZXSyRMUkRsqQcVdsgpRgA289MjrVC/3PMc8H0qovUOh9AeG
+tevbiSzdljELopBx7V6szZgB9QK+fvhrr0N7bRaa48u8thkZ/jTPUV77CS1lHn+6K5oNqUost7Ji
+yNssGJOMJ1/CvItSvo11S5up3UQwn7vdjnpXrjp5tg0Y7pj9K8a19fsmpNHJbeZ82SGYgH8v61FV
+K8ebYaPMPEWp3fiLVZ9QvJGaTdtjjUcRqOgFVILvU4rBraG7lSCQ/PErkA/UV6jHqWmQI7W3h+zj
+uJARJMxLbs9eD0rMh8OW8y/aLe2jimEgYHeTkfToK2daC6k8p581vOp2FSoGN2RjFadloUt8wZo2
+WJR94jk131joMSTFrqNXkP8AF6/SteKxgi+WOM7s4+lcdbGJaRLVO5xtto6WKKVjbGeuOtaFvpqy
+y5NqrNjrtziuo/s6OXbvcKnpTZBHZzHjjHJFefPFLfqbKkzKsvC0beILPVFhlhmi2j5Plzgnk/ni
+vbIBizj/AN0VwWiXYvLiKJPmKn5iPSvQMBYgvoK9HA1JVIuUvQzqxUXZCwf6pR7Vj6r4UtNUmaRy
+VJGK14D+6T6VOCfX9K73TjONpGV7HBXPw2V0xFcAH/aFC/Dy4SPat0uR0r0AGnZ464rH6lRfQr2k
+jiovBdwn/LZAMdOtQzeDdQlyivCgY/M464ruTv7NmgB8cuQfwqXl9F9/vGqskcKfh9JsOL1w54yc
+Vbh8CwIiiSd2wMH5v1rsc8dc0wnimsBQXQftp9zJ03QrPSkAhQbgMbsVdkPFSMT61DK3FdChGCtF
+Gd23djIGPlJ9KsAmiimtgH5pdxooqhCgmgMeaKKAELHFNJNFFAELsRVd2NFFSyj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0006/full/!100,100/0/default.jpg</Url><Caption>29376_0006</Caption><Caption>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Caption><Caption>Exhibit</Caption><Caption>plate 053</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xIwB
+wKeqgk/KRj1FPjwVBHQjIqQCuexZF5Y9KXyh6VLilxScUFyHyl9KPKU9VFS4pHLKuVXd6jPNJRQX
+MrWNW0vQLQXOoyiKInAIQsSfoAaybPxv4e1AHbK64OB5kR56/wCFdHeWdtqlk8EyB43BBBHSvIL3
+R7bRNYSySNwULELnO4dB/Osq1R01dIa1PUtM1HTtZgaSycOqnawKYP5Grpt4/wDnmv5V5tZ6gNFk
+WSCePzONw2nB/wBnPpXpFjO13YQXDoEaRAxUHOM06FVVVtqNpoDChBBRSD7VF+5J2qUJ9BVzFMKD
+0rflQrlJoUz9wflRVgrzRUcqHcfZA/Y4M/8APNf5CrQFQWa7bOAHqI1B/Kp2dY0Z3YKqjJJOABWp
+IjMqKWZgqjkknAFc5deP/ClnO0M2u2YdTghX3Y/LNef/ABH8Q6rrJFppYnGjhiklzEDslf8Au7vS
+vN00uKIgXX7tScbz0zjOKwqVeVlxhfc+jLTxz4Wvc+Rr2nkjqHnVD+TYp9r4y8P3l7JaQ6rbechA
+w0gG7P8Adz1r5xj06CC7m2qJWQbh3ypHau38KeFE8RzSXLHbbx/I+xgZG4HbPA9zWartuyQOCS1Z
+7XI3kusyZKNgOAePrXDeN5Db6vb3kGnm4Zh5TSKD8nGQc9vvY/Os/W/E8+i3Nvp+mtIllaLiRXIY
+v1ySecjp0961Z/GumWGjnUdQwkcigLF94zL6Y/kffmlKUanuErR3Mbw5orapfRz3FoY7SCTzmeQd
+RjPHrzXcWMf9uot9OhSwK/6Nb5IyP77Y7nsOw9+nAf8AC6NEPm2cmkXdvaupTMYTIBGM4yK6/wCH
+viG31fwzHGrfNZjyWYjAYD7p59Rj8a2o0lTjYcnc6LTkkWyQSb85O3zM7tuTjOec4x1qwwrH1LxX
+p2nahFZN5kkzrvIQfcHvWjbX0F5HG8LZDg4HcY65rTni3yp6isxWXmipSOaKLAPXgYFcF408WW3k
+XWgeU7zyxFS0bDAbsP8AH2zXejpXhuuG3tPiJftPbh0dyQpPQ9zjv/8AXrOtKUY3QR3HLquu3EqL
+qIeSBVAW3sWXEYAHBX0+mafcWMV64nfQb0nPAZPl+uBWxFrdvGBHG8cOVBGEKgjn/CnPq0KRs0uo
+nr0Qkn9K8qdWT3/U1suhz9zpisjD+z54CRjcARxXOrquoaTrEaJeG1ZUK7ljCuVPqcc/jXT63qUk
++ms9nvUYBaVs5A7n24rPn0q3u9AWRZIGl3BiyINwB7g57fWs6NRqQpLobf2KJ5TbzzOzqN6zvht4
+6EY6V5x4tmlj1v7DcSyPFaxbIuMKGIzwO2eK09GMkV3LNctI7x8pvkLc45PP+eapXNlNJO11cLtN
+zKHeR1PBzwqjBJ9K7KEXCb6iS7jNC0mHVdAvZGkjF6ZkSNXYAnnkDPc10HhWfXNEt5prC5gMIJEk
+LjIbHH1z9Kr6fpF3phiurVkR5JPMG7+AYIB56H0+taZltLKKR7i48+YnJCnIH5cCtqlS2kdyl5jL
+CaSZZ7qR2Mss+92dyXVAc4/M/pXoHgvVVfVZbZUP+kDfjj5Qvc+5zXkQ1aZ5Z57eIttOF2Hken8j
+Xo3whme/a4neRj5KlNjDkEmlTpS9rzktqx6oaKU9aK7SAWvEPHtnND4onlMaSAvvTOQcemQa9tU8
+VyPizQBfTrcrCX45K9RWdX4RxtfU8v1C9e+tonS28iVRtC8c9iBzz/8AWqnN4h1qzLQpFEuOeE/+
+viuw1TRYk02YLbh5FXfhsk8cnHvXEalepuWOFJGEah2IOQPpmvHnG0lFRvcqV4vQiuH8VayQFDhC
+MjBCD9OtMuNL1Szgjhcz+dbkSHugBGfoO9dT4eubprdZrqO4CEna7LwB+VbdxBJdN+6gMrsAdxOB
+gdK3g4xdkrFWvqeY6ddypA01wGSYHKns6kY/SugF6EtVukINwBlS3z4x2rZv/DoMAFybe2iyABjG
+SeBWY/gaWzie4tpZJSo5TdwR3/SrXLJ3DlMi78QNcMqxRm4nkBYlzwuDj8elYV5fy6hMBM7RQ5wx
+jHyCtpdMu7O7EyRsYyuz5s5xjPfoP8a1df06xh+HcAigjS9RwZQrBick5PHauinZPRA4i6L4LeVP
+OEpZZFA3oeCPYivZPB2hW+h6NshjCvI2527mvEfBF/rVtqMWmxFpbdhuEWOg789q+iLNPKsokIIw
+o4NawT5ncmb0JCeaKQ9aK1IIkfipMhhg1TjkyKlB+v50rhYrXOkQXDb1wrHr71kt4StI3MkVnb7z
+/EEAroQ+OOadvrGVKDGpNGENHnVVCqgA9qyda8N3TWU1zYoyX0aFozGACx9K7TeajkBYghiO3BrL
+6vAbmzyO28Ja/qsQ+22UiSNjc80mdvP8/pXdwaBP9kWGdd5AwSe9b6I4bmRsfWrCnAA5/GqpYWEF
+ZCUmjiL3wK8z+ZbvGpIGUlQOvH6/rVST4f6legQXV/BBa5yy2sO0n8STivQ91G6t1TiPnZhaD4P0
+nw+hFnbgO33nYlmb6k1vk4FRE+5ppcgVasiXqOLc0VXMhzRSuFj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0007/full/!100,100/0/default.jpg</Url><Caption>29376_0007</Caption><Caption>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Caption><Caption>Exhibit</Caption><Caption>plate 054</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dEGP
+pUqAMoI/lSRjipgK5kjVgFp4WkjZXXchDDkZFSgVaQhoWl204ClxRYCF2jjI3sq54GT1o21wHxQe
+6t0sZ4ndY8sDtOPm4NWfh54qOsWr6fdSbrqAZUk8uv8A9asFV/eODRq6XuKaOxcpv2559KieMVcY
+VC4rZoyQyMcCluTGttJ5uSrKVwOpz2HvToxwK5nxdrf9npAICzS+cEbaMhMkE5+o/nSuoq7GQ+Br
+1ornUtFmMitbymaFZfveWx/x5/4EK7NW3Oy4+7ivLNW12S08ZWGoWUKi6I+y3EbZAIbpz3xXplrL
+iPfMQsknzFR1HAH9KcZJ7Ay3S1EJoyQASSenBp4bJxg/iKsgxvFekLrOgXNttzIF3x/7wrwPS9Um
+8P8AiW2ukJXyZgsg6ZXOCK+lmxtOelfMfil4rjxNfx2/zK90RGF+tceIjaSkjrw8rxcWfS6sJI1d
+TkMMio2plhG0WnW0b/eWJQfyqRgM11X0ObqMj4UV85+LvEt9deK7qC/ykMVwyjbxjBwM+o96+inM
+gt3MKq0u07FY4BPbJr5z1SU3usXlhqls8F0JWHz/AHlJPQnuPespq8bMa3OguLst4bs7mMHfDcI5
+LEHGPmI7HqBXuVrIksCyRhQjDIxXzrFcX1lokmlywLJbjc0cmeemMH1/+vXu+hanbSeGNPvJJo4o
+pIUwXYAA45H55opaKwSNkqGGDVW/1Kz0q3ae9uVijA6uawfEXjvStDQxJMtxdsuVjjO4D0JIrxXX
+dRvNc1uObXLyWC1LfMY03lF9lBonVs+WO44wT1lsdv4s+KsE0MtnpUjRoQVaXHzMP9kdqofDvwVP
+quox63qFqYbKNt8Ik+9M3r9K6XwN4a8CTxC70iVNTnjwWe4OXQ+6EDH5V6L0GBwKiNJuXNN3LdVJ
+csFYaahfrUxqF63bMUEfSuX8a+B7XxVaieIrBqcI/cz4+9/st6j+VdPH0qYVCegHzcLi6tZp9M1G
+NobmI7Srjof6j3qG/wD7St7RIH8yWxDF1gzlVJ6sv5frXrHizwYuu3vnPK0bIz5kHJAO3bx6fe/K
+uM1XRNW0GLZcobyxXj7RGhwPqO1YyWhcZWdzn7OKxFqsqBo3LhiJPQVj6/qaXU+2LayqclwOn410
+h0ganCkkXlTKg+4z7Tj+X6VR1FrMeTY6np0duYh+5uok27fZgOGHv1+tYRfK9eho9ShYXN54au7P
+XNOcrLHguueJF7q3sa+ldC1m18QaNbanZuGhnTcP9k9wfcHivmq8jup53tlIIVQxCYKlexz711/w
+y8VReFFuLPUXkGn3A82IgFvLcdRj3/pW9KqraszlF30PdWqFjVXStZstc0+O+sJhLA+cHuCOoI7V
+Yc81s2QLGeKmFQR9BUy0ogxsyBkOQMYwSfSvLvE2ua3ZzlY2EFirhFDDcrAdhxXqpAZSD0IxXB+J
+PCJ1C7KxPNI7AuWdshQBgAD6msq8ZNLlBHIwWtjeP9r068SzvHAY27cJuzyDj7uaZO8N5M+n6xaL
+DcdPnGM/Q9/qK2bbwvPpmtxBrJrm0ZgGdQQUIPPT6Ctrxb4ZXWJZHjg+ZMIrsWyGPTbg4xWMYyau
+0UpWPK73QxpLSfvJBCy4DKM/L/gPamaZ4fv9TRY47i2uTPuNusThslRyCO3XvWxeLfaPjS9ZhEiH
+mGTsR3GfWsu9srmyuodS0Wd7ScklTGeCfrR7Nu6kzZSSs0jsPhroHijRNake7tVhsJVZZU+6Nw+6
+wHr/AI16o9ef+AviNJrd1/Yusx+Vqij5XVcLKB7dj+ld/Iea6oxtG1zKTuxY+gqYGq8Z4FSjJ/iN
+WkSyYU4VGDQdx+6+PwqhEoAGcDqaKgJlB4YEfSnDzMcuAfpTEUtQ0PT9UV0vbdZo3xlG6Z9f1rzj
+xF4Jm8ORS3mjtJNp7czWzncYx6j1H616qCQPmbP4Ypr4YYPT0qXFMpNo8/8AA2gweeNWkhZZo12x
+seOCOa7d+tPxt4HT0xULtzSSsrDvcIycCpgaKKEITzDntThISegooqgJAeKM0UUAISaYSaKKQETM
+agkYg8UUUmNH/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0004/full/!100,100/0/default.jpg</Url><Caption>29376_0004</Caption><Caption>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Caption><Caption>Exhibit</Caption><Caption>plate 055</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hEOw
+BeDjqRU6qQo3dcc4FNhB2LnripwOKwSLKsF9aXEojiuI3cgsFB5wOtXAteL6402keLtR+zXUkEyT
+GaKPkYBGcr6jnkdK6vw18SI7+4NrqiQxFVH76MnBPqVPQdOeaUZpuxTi0rs7/bRtoWWNohKHUxkb
+twPGPXNZV1renyr5cGpxxzhgV7gn09xVNpbk3NXbTSvBxXNzazqJ1poPKEMcg2wb+QFzzIw9PQVr
+3l/baDpHn31yWWJeXb70h9h6mkpJ3sBOBKT8yKB3w3/1qjkiDdQDXMeFfG8fiPVrm2YxRnbuhiU5
+O0dya61hVAhkHMSnpkCrCioLcfuUz/dH8qkmk8m2ll/uIW/IUlsB5L8Tre3i8U2987sCIApVTjcc
+ng/hXnFvti1u0hWUx28r/OxP3F7n8K3NG0vU/iNr+tqLtY3iXzlaTON+7AHHQYz+lYuo6Zd6Jfmw
+1aBoZ4/X+IeoPcVlHXXuavTQ9SgvPFXhgqscL6jpzjck9shkRl7HA5HFNPiXRtYU/wBoW97HcNnd
+Ak7Ku4eqk5WuQ0HxbqOlhILW/wDKtx/A7FvyHSota1u78UanBB5Uclw52owRVY/UgZpuV1ZohwXR
+npeizQ6jpVwLnybC0t1Cj96TIQDnlieR7VwvjbXJ9X1VkMjusn7qyhU8AHjJ9/U1Z1DR9R8MfZLT
+VIBOlyPllRtyh+u05/nWf4XK3HiC6muLiOJrAAxPKudvPYAcnpihNRV2S1bqej/DzwRH4Y0z7Tc4
+fUrgZlbOdg/uj+tdk3WsTw1qNh9nj0u2kuZZIlZ2eWMruy2Scn3attutXGamrpgNgGI1HoBUrIJI
+2RujAg0yPpT3kSJC8jqijksxwBTWwj56We6+F/xLmneN2spTslA6PGxBBHuOPyNe2avoGh+NNIiN
+1GtxC6h4Z4zhlB7qa8v+MPiHRNTtobW0dJ7uJjulTkAY6Z7813Hwt862+Hmnm+fb94oXOMJnjrWd
+OSu49DSd9zl9T+DmkaVY3upf2petHbwPKsWFBOASAT/9asDwLoT3Xi+yaMNsi/euSQcKMH/AV6jq
+fiqxuZbzSTY3VxGMwzOiZUKRgnjJxz6Vy/8AaC+HraSy0qCKK9uY97XRlLssfUE5xg+g/Gom1KSU
+Xp1FGaSdzR+IOq21xJDZIQ6WjGaeRT9xsEBc+tcB4M8OXniKfUr5JTbxeYhSQkjJDcfy/SqcV/Pq
+lydOtc/Zy26Z3G4nHJPua9F0/V7Xw3pGnQCwnitZlDeayAb278A5Pb8M1Upx15tDI9CjhjgUYVVY
+gBmwAT9aRuTXm+p+Plt7q01OAy3OnFmilRQFbdxzk8jH4d67vTNStdW06G8s33QyDjnkHuD70Qqw
+k2olEl5cSW2nyzQpvkVcqvqa8U1qPxt4rvWhMVx5W7CoBsQCvc0xgVIMY4FRKPO99C1Ll6Hjvhz4
+MuLhLrxBcB0X5vJQ9fYmtPxb4g0/7LbyxLst7dGSG2I4foAdo7VS8eeNL+w1SfS4LlFkQjzJF6R8
+ZCrnvgjJry2a7+y3W4lpGdOWZsnP41jUu1yrYaTlqzrPDniC8h1r+0ftQ3Rws0jt8xPAAAXOOuAB
+71Z13W5JpZJdqS3cwCOGOSc9/wCVc94eheyefUZ1MUYGc44PfFW/DOn3Xi/xgZbKAOFfzJZZMiNF
+zzwOv0pwbXuoU431PYfAHhkaVpK3l2iteTgOSVGVGKTxnos92Im06BJJ4lcrGTtG5sfhzg/l712K
+LsjVeOBjgYrAuvEemG6uLGOZXvduY4yCBIR0APQ88VrVUHDkn1IRxPw9+H9/Z3Oo3viS2j2znEVs
+WDAerHHHtXoOl6Va6JYJY2YYQISVDHJGTnr+NW7e6jmjC7080KN6BgSp96VzzTUYxWgIWP7oqUVE
+lUr83F3OlhAHjjcbpphxhc/dB9TzTWw2eDeOY7SPxZqU8swZvOZgOu8Hpj/PauUty8t2gihSdzyE
+wT+ua+i/Ffw/0fxRaQJKPsstuMJNEBkL/dPqK+fdRsLnSdVuRYJLPp6yFI2kXG9RxnAqfZM0UzT8
+ULNa6LFbeYC00uWCngccDPfrXqfgHQNa8N6CFt9Ptm+1IJDIZtrjPQYx6V5v4X0XUfG/iCxt5LZ4
+7C0YPMxBAVc8j3JxivpNVCKFUYAGABVU6fKtSZyuZCajfxxHztHmXA6RyK+f615J4st4B4gk/wBJ
+ECFtwWWJlaH2Br3I1zkeiWOsSXVxqemIHaXCrJ1wOAeD39qwxNF1LJEo5bRfCFvqEEV/Dq13BeOC
+XkhLDf7gk55GM89a78goqqTkgYye9VtIjs4LaS3sIBDbQyNGqjpkHnH45q0/WtIwUVoND0qUVAhx
+UgY5+6f0raKBlDXGvmtUgsYd7SvtkY9FTv8AjXn2u+Btb1KeKJI1EIOSwcZ/WvUwaGYjoufxp21u
+IyvC+iromjRW+398wDSHvn0/Ctqq5ucdUI475pVmdhkRn8TiqETGo9ih2cZywAPPpSqxK5IwfTNI
+TSGV47dLdAkICJkkj1JJJ/U02Q81IzH0qBzzUMaHqTUgJoooAcCadmiiqAWkyaKKGAhJpCTRRSAj
+c1VlJ9aKKljR/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0005/full/!100,100/0/default.jpg</Url><Caption>29376_0005</Caption><Caption>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Caption><Caption>Exhibit</Caption><Caption>plate 058</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V4o
+XDDIB/EYpyDipAKysiiPbS7akxSYzSaQEe2l207bTsUlYCPbShaeBS4qtAI9lIUqQ0lFhkEm1Bls
+/lmmYDAkfTpVk0wjiiwFUjBoqUjmiosMsIKkApkYqWrZIyk45HcU84PWqVxceQd+77hwwP8AdP8A
+hUSdgEa4WOfax/dqM7vQ+/8AnvVrcBgd65TVtZigt5ypVnCuSrdHHII/AVGniZFuIozICwXABYbm
+9Tjv2rCNVX1Bo64OpIAIOaeSAMk4Fcm+tiW2e6iOJUlHA/iXdtI+vX/Jrjdd1q71kJKS7NNJ5dta
+hsBQehOOp7k1r7VDjG56lqOowabbiWXcxZtqJGMs59AK5i88cRyTnTra3mttQHMi3KbTEn97HfOR
+j61wsd/rOiapbpFcGZFG2P7QxdYyRyQM8Vi+IZ5Y9YsdQt5XYvvWaeThnJ5yfrzgemKfO3sXyJHq
+Gh+J4z4jvLC8uBlkR0Zm+XOTx7V2SssiBkYMrDIIOQRXzx4X0WTxj42FtNIRZwr5lxtON6g8Dj1J
+r6IhgjghSGJAkcahVUDgAdBVQT5dRTsnoMI5oqQjmiqJHJTycCmLVC6vEhl2z7VB6Eng+lDYiae9
+hCOu8EgZxgnj8K5bWNWjihYhy8Uina+c8Y5H+feszxBrZs5RLDPmMnjnODnDDPcdD+Vcvd6nJr15
+LHBILe0Rt8sgPLvjBx6D+dclWd0VGLbshNR1WJmAafZz8pbksCPT8awNNu501hJ7iTey7mdj1xjA
+UfnmrclvZWM0u+6t7SV4zs+0N8z+5Hb8cZrnrq5AuEgWUuqjLPuBLH14rGEbstpRj5nWTa2kVxGV
+YgOu1iD1P+f5VHfXotBYXZmKyCNlUAHnK4z7GuTe42yxMXBMZB5/iA/yalnjv5xBcRQ77feHRQeg
+9PbpW8aexNOWjudReTRaLpizfLJeyr8q4yE3evqQP61x19fedGqzTM3ljMjZ7npWjq08NqizySiV
+9uFj7Lx1P41j+G9Oh1fV0ivpCtmWDS46vj+EVvFK1yr2O4+Eugatd6uusxzPBYed+8JJXzgBwoA6
+9fpXvlYmi3lm9hDBYxxpCihUjVfuj+lba5xz1q73M2MI5opT1opgNXpXnXiOSTW/EWqWgLfZ9Lt4
+2ManG+Rucn1wB0r0NTxXkfifRvEaa7fXMN7MiXSqj+V8u5VzjOB71nOzQ1uctqM268a2gXy5G+6v
+RWb0I9fepbOSDRdKuLxi0k6jb5T/AHSe3681E3hjUseeJbgSA/eJJNJJpF1fgR3jO7jqw4z746Vy
+uG2ponZPucncTLcXBeaUtLIdzueSxPrTBjd80hHAXcBwQK7G68Gw20CTCMHIz83Wlh0AyIFaBQOg
+yOtUrLZmXKYGi2EepatFBKymPIBOcgDufyrt7jUdLllntYFQQW6eXGQQBx1Nc7PpE9pKWtA0cuMN
+heMelVWsJltWhTmST5WfB4z1P+fStLXKSsczqt+by4kj+Vgsp2MvZPSremTi3AzwqkHOa1dK8EmW
+aaS5ZkiB4CjLN6/Su+0rwPpMVoCulzXDEZyyNmtHJJWRVr7kHhTx7Z2JSKVJl5/hOR/+uvZNPv4d
+SsY7u3YmOQZBIxXmmneEI59RSOLRpLeLGWmkQqB+dem2tulnaR28eNqLjinHbQmSsPPWikPWirsQ
+RI9OOxvvID+FVUkzUu81IyQW9uRgwpj0xUK6VpyuXFnCGPUhBTt9OEhocUwuNfTNPf71pE3sVpPs
+liODaKMf7Ip5kNL5lTyILkf2KwkBBsUbvygpRo+lg5Fhbg/9cxUgfHQU4SGrURXEi0+yh/1VtEv0
+QVYGFGAABUIc0hkNOwXJi3saYzUzfTGY4pgKWGaKpyylXx7UVN0Ox//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0003/full/!100,100/0/default.jpg</Url><Caption>29376_0003</Caption><Caption>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Caption><Caption>Exhibit</Caption><Caption>plate 059</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2lVJb
+7q7cdc80/wAunoKfisLFkXl0FABmpgKbI2xGYgnaM4FS2BUtLq3voBPayrJGSRuX1HUVY2VgeFNS
+bUraa4a2jt1dyY9qbPNUEjftz1yCPfGe9dJShO6TEyPZQUqSlrRMCLZSbBUppMZpjIWSq5SXPzbM
+e2aulajccUAUWXmipWX5qKLIC6g4p+KYX2JurGuvFFjBerZG6gS6f7kbOMk1N7Dsblc342vJLbw5
+dQxxzBriNo1lQDCE+pzx9aSXxIYePNiZvTH+FYXiPxVdSaNIIo1U71Xb5e4S5O0Lye5I5GCPUVlO
+SsFjH0LxlhF/4SGMQ63p8LLAxYf6QNp7epBX64q5p2qyar8JLrUGuZbu8eSSZ0SQlwwkyqY6gcAY
+9PrXJ3Om2etXsOpxsVmddymRjlAF2lW9xjOcc49q5XTjrHg/U1maQf2fLIfM25cdcEjHeslK97D8
+z034f/EX/QZ7TxHfxqYVRraefEbSqc7hngHBxjvg16Jp2vWOqf8AHtKrKRlWBBDD1zXhst7p2t3U
+M2iRwzTyq3nxMwXI4wQhPBz17VVtV1HQZJnsbj7O6MTJZyDKt7gH+YqoVmtJI2lRUtYM+iY7qCWR
+oo5kaRfvKG5FNkvbWJ9r3ESt3BYcV5Zo3iOPV9M+3RILaZfkkUNyGHv37GuY1XV7iPUHKTvuwcHd
+6HkGtoz5ny2MLWPoHIIz2prDIrgPAvic3hSG4ldjMoABOQhH9Oleg44rRqwiow5oqVl5oouBwvxT
+v5LLR7ZopniZS0gKNgkgcdPrXkseqG402aKRhJcA/aludvzrKOTlu4616X8XraG8sbUPIUeJWI5G
+DnHGOvbtXjtteLFIYpXeJD8oKdOnXP8ASoteOhcXZnTvqut32HN5DAwUMBFCCCPX5s1asfE087Lp
+2sRJHKCBDMi7VlOc4Po2fz9q52w1+6skZGsIbqPdmQyA5ZOnH938K17m20zWbG5u7K7kxEqtLaTR
+/OgLDo3/ANb8a4588fi2NrQkrI05bye3gSaCRUlVi2P7x546H/8AXVtJvt1jLIluJps7bm1PXOOG
+TPfH5/hXMpb6ho0qW+tLLHEwLQSSkZHHTd0I/UVZivXs5Y7uO5RJM7Y/MO0yj2B+8PcZH5Ulq9Nj
+BpxdjC1bTWtX+36TFLBNavukJz8mc4xx09vrWjcavJfaHaXszMk++T5SeigYI+hJ/SumS9XWYoCk
+jxXKuBMiqWVmPHzD8ufqM1y3i7TJdODtHEptuqbBwD6Ee5rV+9aJpTaTuVvDd7dm3ltrVDveUuzs
+PkQEAZJ9eKl1J2guo0abzlkIQkrggmqWhavbQWFwiymGQ8vG56MOMj25PHbFOkSJ1E4uN5EgYknj
+jsK6YR11M5yV9DrPCVysFxhm2yqMJxxXq3hfV47q5uLEsxmjUOcjivBRJli3nctzj0Fd58MdXuv+
+EpFpLIHjlhKnvyBkHP4GqkSj2EjminEc0VIzzz4l6L/aFvbzLcGM4K4PQ147Hod5b35SPbNHJ8rK
+y5BBHX2xX0nqOnx6vpvkuSpIDIwOMGvM/E/hfVLVV+y2DTucgOBmMe7dz7Cs25RKSTPP9Rmt9PlE
+Mao5RcZkGQcY7f561Q0fxEkLXSSKqxzRmJsEqcZBBBHQgjitTVfCGrX7Bmt5YhnLERnj2GAKgTwV
+M+nNDb2Nx9o3hjdSKT2+6BUOUOWzKad9Dq9E1OW90z7PNd2moR7uIL1Q3T/axjPPXBPX0rO17UdT
+uNUjhl03TLd3UeW4h81iOgw2AB04wO1ZOl+F9U0+53JZyz8dGidAD+BrZRru0CteW9v5gbh1UsR7
+bTn9CO9c6UVK8R3dtTDW51nQr9LgWwypz5ikk/lmt+LxTpes33kzKiGRSJU2lVLgH5sHpxnnvVGK
+/wBTkndk0Tzo2bmSOQbx+FY994a1nV77zdP0a7ijH8e0kmt0ubci1tihr2kRw3e2CUPKjdjnI/Cs
++3uQo8u4Rgqtw46fiK3ZPAvigv5otLxJCOcoTk/XrWrp/gDxRcSfvtGlkRv4nULj866Iz5VbcLXO
+ftLmOKffujYYIB3D/Ir0X4UwSz+LxNGVEUMLGTbznIwOenetDSfhC82Hu0jtRjo3znP0BH869J8P
++GtP8M2PkWUYDNjzJMYLmnzX6BLTS5qseaKYTzRU2ZJVspC9nAwPWNT+lW1Y9yKyNKcnSrMnqYU/
+9BFXw5q9BFvdRuqvuNG44paCLBbjggGomkmU/wADD2U/40wsaN5FLQCZDNj5mjB7fKf8amDcDJGe
+9VBIacJDQMtbhSFqrbzQXNNATlvQ0xmPcioi5pjOadwHF8Giqxck5oqbjP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0052/full/!100,100/0/default.jpg</Url><Caption>29376_0052</Caption><Caption>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Caption><Caption>Exhibit</Caption><Caption>plate 060</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rhc
+4z9Kcqg/Njr6jmnIOKkArGxYzZRsHpUmKXFS0FyLYPSkYKoJbAA7mmX95Bp9o9zcOEjQZJNeGeNP
+H2qahK9vAzWtufuoGwzD1NQ7IaTZ63qPi7w/peReanbxkdi2TWbF8SfCM0nlpq8IPuCK+X7pJ7ue
+SWZzgepyTVeOzaRsfNVpID7Js9TsNQUNaXUUwIyNjA1b2V8hadJqOlXAmsryaFl5+VyBXtfw8+Jb
+alKul6yyi4/5Zyk/fp6D1PUSlQOyBtpYbvSrmARkdKjZaTQrlNl5oqVl5orOxRZiyUUnripQKit8
+/Z489doz+VTityAxWLqviSz0x/JAae4/55R8kfX0qh4u8VQaLatDHIPtDDBYEfJ/9evOBrtvcI0e
+8/vMhmzyT65rKpPl2KjG5uatrs+pvI19JEiIfkgRsgfU9zXj/iC5xqjzuxKnge1Sa7Le6ZfvtmaS
+BjlWJzWA85vGw5zWUYtvmbKeisT20iS7jsPP8WecVbNsFAIcIuOgHNQpGlugx1NaMqoYMAZ45rVo
+SMqabGMk47kU5JpVEd1C5SUMBCqfe471XMoErIy5U8EVJBFJBIUjx84+WRuwquUEz6V8DeLYtb8J
+peXkqRzW/wC7n3MBgj6+tXdJ8XWGrX89jhoLhGIRZOPMHt7+1fN9rqd7p1pNDZTOsbMGf0OK2/DW
+uyy+IrRbpI5WMqjzN23vQ+bdDSVj6PbrRTuoBx2oqSSvq2qxaLpct9MpZIx90dzXmusePtXuNNlv
+rWeC2hXOyFTiQjOM89eewrsPiBdJaeC7x3VWBwoDDIyTXiGk3FtBpEmqX9tJdtFc+XFAW2ou4Zye
+PatbMRnajc6hqINzf+e4c8EtgZNQ29i8jrHaNL5xOBtbdz7jArrb3xdc3dta+TokG+NHlTnK7QNo
+OO+3J/ECsu61rTdYjjnjt5rC/XC70PyOf5g1Mr2GmZGpm/skW21W2CSOMqSQQw/CuZaFopSyj5c1
+p6vLJPMqMW2RHjcxYknkkk/54qrD97B5FSlZaA3fcYLrB5zitO3uXmhyPuYwahn01VWOctiJuvsf
+Snx3AOEjhby8Y4HWq0a0FqVJ4S7GRc1Yth5sIDKzGM5wPSt6y0mS/jPkwt8v3mYgAZ7c027tYdLg
+kiLK13JwEXnYuOuR3OaL9B2KI3PgRxFI+mcVL4ftWbXLdoxumSQMAe+DUkQu5rQB5EjhHqan0l1t
+tWt59x8ouFZs4wfWi9k0ho+m49xiQsMEqMiii3bdbRN6oD+lFSIivtOtdVs2tLyISwsQSp6GsbW/
+BenajorWFpbwWgyGHlRAAkdMjvXQxniqOsa9Y6JbmW6kOcEiNBlj+FadNSTyy7+H+vxAstpFP9nQ
+pCscuwOOex78nv3rhb62v49TLTab9mVWHmRq2/aw9wK7nxL451nXZms9ODWVoCd3OHZfVj2HtXF/
+2XJbEy2187l+XMZOD+dYucU7XL5Xa5j/ANnT6lcuVTagOWY8YpzLp9iMK4uZugEYyB+NbR1KT+y5
+NNjgCJITuCDJPTqTySeaoXc2n6fAjrGfNA+6OQD6elTKfQLEcKPfRhZIdsAOdoGc/wCFaqWtstu5
+VYUCsCMsMgfWuVufEV7cA29um1JCPlj5ye2P/rVqWfgrxdrsqQwaXcqdmfMnBRR+JoUZvfQaaRtN
+LBbxopuQzMnJ3EAE9ucVQurm2muGkaRCxbr610el/A3X7mJf7T1O2tgp+6ilyf5VZ1X4NTaHo13q
+X9tCUwIZCgjKgqPQ561ooNdSudHGRS25dpJljaNTj58jJq5HPaXcyWqRiGN5F+YdevpUfhrwzeeI
+754NPiYqpP7xzwB657fWvR7T4PzWlzbTLqUOI3Duvlk9+cE9afKJtI9OtUEVpDGpyFjUAn2FFSY2
+gD0GKKRmRxPxVW80rT752e4gVnZdpbvikhmyoNWVkNXdNBY5mXwBYG3mWG5uC8i4zIwYZxx2rAHw
+zvwiqb6AhTkKMjP1OO3p+tej+ZSiSs3CPYd2eVX3wr1h+LTUbeHI2kqDux9e34de5rI0z4F3Ukkb
+a9q6rEvUW/JPsCRx9a9t8zijzaSSjsJ3Zz+j+BfCeh2ohtNNtj2aWX53Y+7HmuojMYXahXCjGAel
+VSVD78HNPEvtVKQrFnNQ3dtBfWz29zGskLjDI3Q03zaDL9avmHYg07SdP0iJorC1jgRjlgg6mrRc
+diKjMtRmb60XCw5m5oqu0vzUVFx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0039/full/!100,100/0/default.jpg</Url><Caption>29376_0039</Caption><Caption>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Caption><Caption>Exhibit</Caption><Caption>plate 061</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29elO
+TDruH8qci1n+IdZTQNHlv3habYQoRTjJJ9aydkVc0ttGyuEs/ifa3DIH0+Rcthirg4H5V1mm69p2
+sKxsLlZWT70eCGH4GoU4vRMLmhto20ryJHEZWYBAMk+1eRap4ovb3xLHMl7NDDEdyRRyFQRnuOhp
+SqKO4m7Hru2kK1zuleLrCSyDajfW0U5cKse4byCBj5RzXRiRXbCHd647VcWmrjTG7aQpU2KQirAq
+SOiNtYkHGelNKgqGHQjIq2RUbDigZRZTuoqVl+ailYC2gqrrVlHf6Pc28q7lZM4x3HIq4lLKWCfK
+AfY96HsI+fdXszol8ZI8tbyfeH933rT0bUEsZV1G3m2iJ1JIyQfUHHYiuv8AE/h8XcMrJCjITwFz
+uH1rzzTreTQ9Rmiu0LWVwNhOOEOeCf1/OvLkmvVENWZ61f6/aXvhe8uLO4V4jFnIblc9frivHhMZ
+9U2xtuDpyFPPBJIq/dx3GkT7bFFkhmbLRbhtI7+2CKyo4v7Lub2dU3RHaEIbJVd2SD/LNEKrmm3u
+TJ3O18JaPZXPib+1PNUyeWv7piMg4wCB9QPxr0O21q1t7qayuIpLeVHCqWGfOJzyuPpXkGn3oTzP
+JSJyjlSXP3R1HI56k11Nh4hvY8zsYFifoSg3P/tewrWNTkLizutU8TaZpEqRXU4Ds2MDnb9fSr0L
+rOom++rcqRyoHt/jXm01/pky5u1t0fuJkHB+pGDUp8T32l2yLaSxPa5wpRQdo9Bjito17v3kUj0s
+imMOK860XVtU1TW7aWS4nFsXztDY3j/D2r0fHFbwmprQZVYfNRUjDmimMlTpXn3iTx5i/ksbGYQp
+CxWSXAyxHUD0FdjrcNxcaDeRWtwYJmiO2Qfw14xaeG7C6Ejm4MzK2GJkBx+AqKsrKxDv0N2Tx6I4
+dwvGkk244AJ/lWdb6rd6jbPdC0imiBw4dsN9SOlO+w6NYhYnePd1WJcMzHsMCq8y2eoxzWhmWzm3
+Bdu8byD3+lcMn0BJt2LcfiHQYbNPNs4jMF2srKDj/wCtUT+ONDtIg0ltBGpB27lAz68VjXfhzTIL
+dGuLNBCrcmEhmP6c/wA+azU0rSbe6kjuIWQE8I8ZUEf8BGf1FOME5f8ADDcLEWqeJ5Ly4LWIWKJz
+n5IgMjrjH07n9Ks2aXutXMVqZJXnkOBk4C8jk+2M/lWls8LtGlvFpVxJNnCvCcNn2zn9a6Lwp4du
+rG7kvJI3jikBESSEFx8p644rpcUti42Rx/iDS7/Rwqi58+LrxkgnPTmrGheIFuLrbeFTA67WwMbT
+68dq6HxLayzny5Ihs2n5uvPXp+f5V5wiG21FossvOOnWqUFONmNq53gvr+wupPs84VUbkYB5POfx
+r0jwPrV1rFhc/a8b4nG0jupH+INeMRi4HluqsWP3iTnPavWvhtaSRadeXEiFfOdQv0A/+vVQiomS
+vc7JhzRSnrRV2LuQ3QZ7GdUGWMZA+uK8DvdHvINVX7PEI5yxyVbgHvXv5J8pgOuOK8d1iTb4guop
+HaLDYLEc++P8awryaSsIgY/Y1/f+TJNt6xoAQfyP51i3fhqWYG9aJwzNljIwz9c1qS3MFtbFLZRN
+KxyR157ZPapBMj2Si9vsFh/q84/CvNdVwd0wUblXT9btbGIxypcMSfv5VyPpkZq6ms6BcZdluW2H
+DPJETyfoKzWsbaTDECNc4XJ5PFOt7N7Sc3EKKkBHzs/3WHpiiOJjfVFNSNMT2cLi5tbyFGTkYjbc
+OehGOa1YvF11dW0RXT7uWQEMDFCSG/8A11zDayss8giheWOUAEIvMZzyM456A1r2DNBbs6vdFf7o
+TBUdsnPPXH8sV1RxEVuCTZp6wj3VjFdlDbseRHLgOvsRmvMrrSdV1S7dra0MYbgyyEKMeors4LiB
+7oNLGN4PG/5z+takk0ZhaaJDJ6OF4qlimvhRXKY/hjw2mnxoJ5WuHYhid3A+ley6SqJp6KibFA6V
+5Voh1W4ngb7IojEn3MEHHpnFeuQZW3UFNhx930rWhKU5OUiZKyFbrRTWPNFdJI1G4qN7W1mJMltG
+5PUlAc01WIFODmlowK6aDo6SmVdNtlc9T5YqO78L6FfLi40y3cYx93H8qvBzTg5xUOnB9EF2ZA8I
+eH4YFiXTVMYIIXLHGOner32LTI4lhNlEEHRSgqwXNJvLcHpSVKmtor7guyodI0eaMoNOi29wqY/l
+Vy3sbKLJitY04x93tTg5pd5qlCC2QXY1dPskkLrawhj1IQVKYoghXy02+mOKbvNIXOatJLZALHFD
+CMRQog/2VAp7NxUW800ucUwBjzRUBY5opAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0051/full/!100,100/0/default.jpg</Url><Caption>29376_0051</Caption><Caption>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Caption><Caption>Exhibit</Caption><Caption>plate 063</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29AcU
+/bQo4p6KQMEk+5qChu2jZUmKSloIaFpdtOooQCbaNtPFBp2GM200rUlBFOwEJWmMtSyKWGFcr7gU
+zaQuGYsfUigCqyndRUjKd3FFIC0nSn0i9KdTAKSnVBJd20M6wSXESSuMrGzgMw9h1NJiJcUCo3uY
+Yzh5UU4zywFMivra5VjbXEU5XqInDY/KkIsUtc9a69Lc6hcRGMJFAPmJ53H2pzeKLZIpXZQCnq3W
+mpIDeormJvGlnEsUgAMbHBJOMH0pl74nTzVMMoEbAFSDyaHJFJM6gimkcVjW/ijTXgQyzFGztIYd
+Pc1sRSx3EYkicMh6EU9wImHNFPYc0VBViVeFz2qvdTsqoIXXduBYZH3c9ald1jgd2+6oya8+1XxH
+pUQlmRVm8scKvOfQUTnyoSVzsbrxLpdmJPOuAPLALEDj8+lec+MPH/hzVEFqmjvqLD7ssh8sKfZh
+z/KuQ1p9Z1tjJclYYs5SAdFHv6msX+zxApBClz1OODWEqt9ClC2pPdxWD6l9rlhkkieMfuZbluue
+zYyRjtSy3n9nywX+gwtY3KMMvDIzIwPY7v1Bqlc6TuUSsvyD/a/pWWyPbKWhkEa5x8pxURd3oy+Z
+rc9Estfa/eSSAM1xjEhRgdp78f8A1sVTv9ZEYKN5mV4OOpb6VyOkyrG7TNbXEx3Da8dx5XPucEn8
+K6lLG2/tWz1BLO4McYLGG4l80B+Np9x14PoM1ra25MUmVrbVDcwSrljsXJRxhh/9alTVpX0nyckM
+hKqQecdf61Jq1vcaldWt3LaR2dw6kPJE2xGIPOB2JFZccMFqX32s0j/3o32A/hjn8apWd7lOKWx0
+dpq//EvjEsRmYD5tzdfy5r2LwnfQ6h4fglhj8vaNrLuzyPrXgMGt6fbsPtWn3Bz/ALf/AOqvcPAO
+p6PqWhsdJVUEZAlXaQQ2O+a1Rm0zpmHNFDdaKkBskYmtpI26OpB/GvD9c8C6hbXEnlPtjDl0ZVJY
+f0r3FDxWR4h028v7XFk6CTvuqZptaDg0nqeAtpmqLujNzuAPJYbaqHStR3kpdJn/AH816Ze+BvEc
+il4p13ema5aTwR4ve62OLnyx/EozXK1PqjZ8nQ5aew1gIInlQxsem7Jqu+jIqbpJmLAEkFcV3C+E
+fE0UgH2C4kUfxOST/hVPVPD+ryTGI6dOsgHRULnH4DFYTqVIWDkizlbPU/s5XcimKP7qjtzXQW/i
+VpjhYUVB0DcmsaHQtQuL/wCyTabPAS20Obdhn8AK7Sy+Fl2YC83nbSMgJHtP5Hmt/dnqC00Moaz5
+ifNFjnjoaz7u784feUHHQGu0t/hQ8qNn7RH6ZI/woi+EWoKCxmRyAcK/H8q0jC21x8yPMZEaW4xl
+mI71738KrGO18LvKo+aaTJP0FYegfDG4iumbUrW1iiP9x9x/WvTLCwt9MsktbZNsa9BW0LvdWM6k
+k1ZEzdaKa3WiqMyON+KlDnsB+dU1c4p4kNUSXA3HNLuqr5hpfMOKQFndSMxHRQar+YaXzDSAd5mW
+4gU+uakSSUkZjVV7/Pz/ACqLeaUOapAWd1JuqDzDQXOaYErMe2PxNMLHHOPwqMuaaZDigBWbmiq7
+Oc0Uhn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0018/full/!100,100/0/default.jpg</Url><Caption>29376_0018</Caption><Caption>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Caption><Caption>Exhibit</Caption><Caption>plate 064</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2mOMb
+R9KmVKaiBowDnGOxxUyrhQOeOOaxS0NGASnBKcBTsqGC5G48gZqrCuN2Uu2n4pcUWC5FspClTYpp
+FOwXIStROnNSyRFmyJGX2GKawpDEjHA+lTAVHGPlH0qUUIGKBWEoe48cFwH8u2s9uc/LuZs/ngVv
+YrG0DM11qt2TnfdGNf8AdVQP55oe6QLZm5RRSk4GTVECUhpsU0c6b42DLnGacaBjDUL9anNQv1pM
+aCMfKPpUoqJOgqUVKBik4UnrgVxlh4gj0g6Xpzo0k1/cOxKjOAXI/wA/Q1188git5HPRVJrzae5t
+rXxVoocn9wivJt5Kja7Yx1PL1E58skVFXR6ezqiF3YKoGSSeBWJqWtW9x4eubqwnWUZMYZfXdtP8
+jWL4311V0y3soCfMvDnZ/EVBHy49SxA/OuevhaaToFp4aWWVtXaZZGKsQGkY4IyOw3Y/CidTR2FG
+Ox13gUzT6VcXc7FnlnYDnoo6f1rqDVHRdJg0TS4rG3JKpklmPLMeST+NXzVwVopMUnd3GGomHNSm
+oW60NghksiwwM7HaFHWsRvFVjazslxeW8ZVC5Ejhfl65qz4kljh8P3bSlcbOAxxk18/XurRy3bwG
+2/dMQu5cMQM9jisJzaehSVz1/U/GcVzps72k6SwSRSBSEI5AzgZ68d/Y1i3Wr2sPxEn1IbdttZJH
+CW6B2IUH9TXELc6HPBHE93c2UqAqv7sEc9f51FJpt4ICLQyagJ/lLjIGPfOKxlN3uy0rI7uTVLbU
+fiJBLPNCIbYBUbdlSVGQwHfJYn8BWkiaVqXjq0uoHQpBJtDsfvbVPT33tmvPLXQtQisBDPbRo6vu
+iJkyfoevH8qim0m8n/dQ30Qc/N5LSDr3xS9qn16hY+hItUs57hoYbmJ2QZYK4OP84NMGqRS3Rt4s
+lvUjj8K+fVOq2TqWuFUQ9P3uBx25rcsPGGt6WvnsRKrvhV++Se+P/rVp9ZI5D3I1A55rhtF+Jlve
+usd/bNb5bb5mDtz+NduWV1DKcqRkGtVUUloKzRzXj4Rnw07S3K28auCzkZ/ADvXhN7eaat0PsKyS
+jcA0sxCjr1A7fjX0brejwa5pctlOoIblSexrxvVPAd7HdSM1qI7WPIVduS+O/tWNSOt2VFmTLqFt
+DItumlr55+cSnhWHUYPfj9c1pyvrFzbAwytGSR80Z6Duc/8A1zWdplu9ndSws0jJGvyxuCVQ8due
+2abLqmsyXEiwwFucjeMAVi4XlojVJWu2acVy9qC1zLCHB5JUFmPf5s4x7cmqWqeIrSdEi8hXaIho
+hGNgQj/ZHNZ7adfzlpr1sM/TYMc/jXS6bpj2VosgsLUEr/rDFuf65Pejks7tjuraIxI5Jr+VF3ZT
+IASP7zevNT6zc6naqEVVW0YbFRojtU8YOexz3rfttNhZo7mdJZZAOHIAI/KtC8sptSKo9vPIhTG1
+0yB+HrSXLfYl36nn1zcajcWvlSoVdioYEdSDkMO4PWvoDw+07eHrA3H+u8ld3HfFefW/g/UbieEG
+0k8gN8zHAOPxr0+GEW1tHCvRFCiumknbYzkWFNP+VhggEe4qJTUgauhEMhfS7CUkvZwEtyTsHNKN
+NsEXi0gAH+wKn3U7dTsgKp0/TmILWkBIORmMVJ9ns8bPJjweMbakZFbqKcNqjCgD6U7INRgtbdcb
+YIxjphRxTyAOwoJppNFkA1nX1qBzUrGq8hyaTGgDHNSAmiipQDgTTgTRRVALuOKAxoooAaWNIWNF
+FAEbMc1BIxFFFID/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0046/full/!100,100/0/default.jpg</Url><Caption>29376_0046</Caption><Caption>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Caption><Caption>Exhibit</Caption><Caption>plate 065</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YDAy
+elcX4zl8Q291bX2mPHFZW3zyyvINp7FSvfr+tdshDKGHIIyKV4kljaORFdGGGVhkEVlKN0XGXK7t
+XPO9B+JYujp9rqNoRcXM5hMsYwh+bapA9yfwxXoDTxKxUyKG9M81iatbafb6po8jW0CrBMVUkBRH
+lTjH4j8Kx/EnmafqLXtuqeVIuRcod5ic9mX+6fas3zRXcb5W9NDprvWrGyiaW4uY4o1OCztj+dVL
+fxfol5eW9raXizyzttURnODjPPp0rDtrE69p7tqlrb+bgbZYyCJBjqM8j6VwGqeFba4e+bSZX8+x
+wzqOMHPY/hUxqO+qJaPdpG2IxB5AJxUf2mEcGRd2OQDyK8b8O/EiW1t103Wt5VDtM68Mw/2u5r1X
+StUsdUtUOmzxCLHJTGfwFbom5dN3bBlVp41ZzhQzYLH2qbbWHrfheLWb7TZnupI4rObzWjHPmEEE
+ZP1Fbg2QxktJ8o5LMeg+tNeZTtpYyta1ZNJS1JAZp50hC9+TjNX2KKcMwB9Ca8/8SeMdJi8WWRjl
+ErWaks6gkBjxt9OhPP0rt9K1KHWLFbuIDY3SpWrGyxweQeKKeRiigQtkMWUAPOI1/lUZ1WyVJ2a5
+iXyG2ybmA2ntnPrUsAMVlGMZZYxx9BXi/ifUGW7fUHi320rYlXrxnrjjkVUnYErnZeOv7WW0tLnR
+5d9xEjXSqvPmFACeO4welYeh/FyO/C22oaAxmIwWtmDBvX5Wxj8zW/pN3ZTjw5a6BfQ3QjjlZmkO
+SqkDO5R0OT0pNV+HaHVP7a0yeGC+yTLG0e2GQfQfdPvzUO9nbcHuY82vTjeNKsWsgzjZBIQ3JJ5x
+0UewqtqenX1rY3F7dara2txKuHS3jO5yT05OP0rkvFHjCwuLmGOygc3VtL88iSARsB1A7nt2qhqP
+i5dRWBSjptO4qTkk+lc0VK92NtFKawaW6KBi5BwDjrWlpl5e6DchbKR3nc8xKePxqK0ncR3d8ykL
+CpPPqe1ang+zaW5N3OVLSDJB611J6EW1L2oeN/F1lH5slzAqgZ2CPP6msXUfiRq+tWNvp6+YN7fv
+jGcF/YU/xorXepiGJfLjRMux6VkaJFHp0cuoyD+ErCTjk9Cad7rUtLU3tJtdR8TeJZNG0+OOxjYe
+ZNPjeVUAAnP5ACvbPD/h218OacLW3lnmPV5JnLFj/IfhXJfCO50ltFljhwuqNIz3BcfMwzxg91Ax
++NejkU0rA2QkDNFOI5opCGT+d9jk+zBTPsOwMcDOOK8E8Q6ndaffTWOp2MkM80jPJvAwwJJ+UjjH
+0r6BXpWV4g8Nab4m09rTUYdw/gkXh4z6g02rivY8PsrK50q4j1jQ7owXCDcY93yuM5K+4PpXqOhe
+PdL8TWz6ZeM2najKhjaGRsbiRjKN3/nXnWt6ZqHged7YSPdQJ84kZCAUPb3x3+tVN+k+IEWS5jaA
+hSwZU5bHpxzzWPO4svluemp8LfDtxoaWF7Yp5iE7Z4TtkH/Ah1/EYrgPF3wsj8NJDfaVK88G7bKZ
+zlk9CMcGtzwRrfiG3njgkuxPpucEXp+eMc4wRz278V0uofadZ+1efPayWyAGOONCSvPdj3x2AodS
+NtCOXU8i1OWwbRrC2sb2Kc3EoZwoYFcDvke9d5pWnww6ZGzgYTDZ9MVwXiXSYdHgi+xR7fLnYrk9
+c84HtW3Y+I4J/DrmWeRbnGPLzjB/woumlYaXczPE0yanrCWNqdu9suw7Ad6ZYWlr4g8S2ukwsq2y
+ARKxP5nHeuead4hcXCv+8uSdp7hc1J4KuHg8V2b8gmZV/WtoxuNux75a/DjStNSKTTnlhu4skTsx
+bLe46fhW/pcmqbXh1SGISJ92aFsrIPXB5B9q06Q1VibjCOaKD1oqQBelKzqmNzAZ4GTTFPFOOGGC
+AR70wIb6AXVlLGFR2ZTtDDIz2/WvPPEHw9Ouo+oaPcfY7hB5ccDoAi7cgqMDKjP+cYr0VraFjnZt
+PcoSpP5VmXBfRJ2vA0kllK3+kKeTEem8e3HP5+tRJJ7jTa2PDZtQ1fw1cfYtctZ7WXoJQeG9ww4N
+all4jn+1xyrqT3FseJIjww+le132n6frFmYL22gurdxnbIoYH3H+NeU+J/hBFZiXUtD1Q2kSfM9v
+PkqB3w39D+dYypdUFyv4outFfTEJmMsmS0YX5ixPr3H415vc3KCXy4zhnILAdh6fWuivLWx0Cyml
+vS8j3Z/duQN+F54HYf8A1q5PT4ra6uWaSQp/c55HuaVPRFM05CimQSx7ZQAuw/wAdqk8J2zz+IYD
+HGWKygkD61sG00W/tIjcx3C3IUh5Y3JEgHQnOevHNZ2mXOp+FbyNtOKyTyjJDp1XJwfUduhrpjNW
+sS4u59EaNPJbyy6VcszSQjdC7HJeI9PxHQ/hWsa8h0rx5qGr3NsZdKuor6EkK9v+9Vx3Ug8j8zXr
+MMvnQJJsZNyg7XGCPYimmDQ89aKaetFICJWqQNVCO4JH3f1qZZMnpRcC2GoYK6FWAKkYIPeoFk46
+U4Px0pNiItOsl060FrG5aJGPlg/wqTkL+HSk1PT49UszbSuyxlgWC98dvzqYkNwRTSinpxU+QHl2
+vfCW613xRZXNzqIk01GHmRgbSqDnaPr61U8Y/BmzmuFuPD6zWwZfmjQ71DeuGIOPxr11YlBz1qRV
+VPujFNJWsgPn6TwJr/hqxE0Wl3mqTkcZ27Y/fYCSa2vDHw71u/Q6pqwWKWfkRyEhlH0HT6V7RupN
+1PlRXMzM0fQbTSYxsjUy93xzWqTTCcnpTSeKei0EKTzRUTMc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0041/full/!100,100/0/default.jpg</Url><Caption>29376_0041</Caption><Caption>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Caption><Caption>Exhibit</Caption><Caption>plate 066</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IWA
+G4j6VJspUHFSAVjYu5EwVVLNgAd6p2uq6fe3MlvbXMcskfDBDnFcB8XdfvreK10LTZTDLcKZZpAc
+EJ0C57ZOfyrK+Cui3q3eoX13IdlufIRc9WPU/l/OpcRXPYtg9KXYPQU/FRXNxDZ20lxcSLHDGpZ3
+Y4AApJIBxQen6UmweleV6p8T9Y1C4ePwxpKvbKcC6ujtD+4HpUOhfE7Wj4gg0vWbOHM5Co8PT/69
+NNbDsz1nyx6Cq95dWmnwNPdzRwxDqzkAU6/v4dO0ue/uDtihjMjfQCvlfxd4v1jxvrDASS/Zmk22
+9rHk59OO5rWMOYTdj6Hi8deGJ5zDHqkBbOK2URJlEkVwXQnII2kEenSvmtfhN4zgsRfrpgzjcYvN
+HmY+mf0ro/hj41vbLV/7I1EyBc7dkhIKn0xTdNW0DmPcWTnpRUuQwDDoRkUVhYoGvbew0oXl5MsM
+EUQeSRzgKMdayNI8feHNbvWtbC/3sDgM8bRqxzjALAZPI/OrepWMWo+GxaXC7onjRmB77cN/Svn7
+xlLaPqrz2IWBZAJHWNSBuwOfboDj+tbJJks7v4o2Utv4y0+/kTfaT2/lMxGQjKc/1rQ+FmqC3mvN
+JuPkkMgkXd1O4ZH/ALMPwFcd/wAJr4ggSxtNeuTJbWy4kgAKy3G6PK+Y4IJ5ZflBBIU5ya57+172
+DXZdStHe3SWRkhWQl8Ju3KuWJPGAfqKynOMdxqLex9SYryj4sapNealp3hiByscv+kXIB+8oOFB9
+sg/kK1fCvxV0/VHjsdZVNPviQiuW/dSN7H+E+x/OuO8bMz/FG6D5ytuixnOOMZ4/HNRKXu3QJa2Z
+WvrptMhlWFMJbxhQgOMtj/8AVXp3hPwVZ6bbwX97Es+qOgZ5W52E/wAK+gH6145rKt9medjuAn+c
+54wGx/Svo+2O+2jYd1FFKKKk2cj8U1l/4Vxq4h6+WA3+7uGa8V+C66fD448y5CM4iIgL9FY9T9e1
+fSWpafBqmmXNhcruguI2icexGK+Q9XsdQ8D+K57KUskttKdkgGNy9mHsRg12Q1TRk+59hYrhPE/g
+W1vdZg1e0iEd0GyzqMZ4q94A8Wp4q0RJyQZV4f611rKCOajYoowKRBGG+8FANFWSozRWZRyvjiG8
+uvDVvYWlylpHdyJDPcP/AMs4yPw6nA/TvXiHjFba01W5sEuFuktCIfNXjzXHXA9uh9wa+lruJ5rC
+aOIL5hQhNwBGccV5Hf8AgDQ9K0zSVlEx1W+nMkktzkkKqszJtzgfwj1NXdJXZFiC00/7dFp2o6oY
+X1NYAryy7WYnt6AEdO/51n+KdAkvIY/s8Em8HCuOAuepqbU/EMD2csYZEVMgIh447D2rlfBs97L4
+tCwEvasxMqOfl2dz9eleTWozu6zlt9x106qS5Lbmp4i8LoulLKq7ikYG7HXArCg1xria1e8kke6t
+gIWd2yWQfdPvgV6pr09nFphFy22NwdvFeK6zAlvdyvburRsm8Mp6HNLBzclyyCskndHWapc+f4fu
+QgJMjOfl7cgk/r+tfQ3h+Yz+HtPmJyXt0bP1Ar5itJmuNERVXe037tEHVicD+Y6Cvo651GHwf4FN
+9eDMen2YLKONxAACj6nA/GvSpK2hzSZtXV3bWUJmu7iKCIdXlcKo/E14z8ZLvwdruixXcOs2E2p2
+sgUC3lV3eMnBXj0Jz+frXmtz4i1Hxbey6trt2ZMEmOL+CMf3VHYfz71l6kqyN5EcKpLJ8zNjoK6o
+xsyLnb/B3XTo/in+zGfNvdrhc9d3bFfSB6V81/BrRo9T8bieeeMfYYi6pnlz04+ma+kvMRnZFdSy
+43KDyPTNTU3GiMjmilbrRWJQGRI42d2CooySTwBXlHxK8X6NdJZR6fcPJqVlcCeIqvyMuMMpJPcH
+07V13jiwXUPD+3yDNIrgoucc144/h1oZJjfxrA7AiNUJ4GP1I7VMqijoxqNyvf2mnXqSXcFwqiUZ
+8h/ldG9geuKv+A47eCHUJcobuMoAgbny8nd+Z/kKx/7F0yyKziea+lDcgMMA+jd6t3er3V3Gww0X
+lhf3YmIDDPIx7DNclZ+0g4R2ZrD3JczO516wi1PSol37gE4Ze/vXl/iSyFjbWUewEt8jerAHP+Fb
+lx4t+z2sUNvJbxtGMM3lDd78/wCelcvqeuQahJ5lxcSTuo+UZwAPYdKww1GpCXkXUnGS8y1p+qx2
+ep2Doke6B1aCKQEqWB+Xgc4zz71seMPiNr/iLSLrRLpIJ7N0WW5NrbsGjVWDcnJ28gdazfB8+hXH
+iywgvIPLheTLTMSMYGRjuOcCqPiK11bw9rOqabp6CO21LeN0LeYssRJIAY/XB7816tJa6nNJnOyX
+cAQQQB40YDJDE1owy3Wpn7KsYL/89Ox9/aqdlocoUtdssSZ5yea0LZ3t4rqKyYFZmDA90A7Z7VtK
+ore6KMH1L2mWX9lTpc3F5cW7gHYYZMOOMHkdM8/hXq/wd1mzk1LUdOt4SrSRicyM2S+045/76rxF
+p0jk/eN57DsM4r2H4GMlxe6tP9mWNo4kVWA6Ak5H6D8qxbbd2aWSVj2djzRTT1opEFS9jM9hLGqb
+22kqucZPYZrzDWfBvirXZTGsUFrA3DF5gcg9Rxk/lXpkdyrIDhsEZqRZlHQGolBS1Y02jyi0+C96
+JB5+rxQxjHEKsTkdOpA4zWzD8GtMhjCrqd4CM8qEHX6g16D9oHoaPtA9DU+zgNzkzymX4F20900w
+1MwBvvfu/NJH44AP4VpW3wN8Nov+kXupTnviRUH5Bf616L9oHoaaGi7JjPoKcbLQlts4KL4P6baX
+jSWMiwxYwoOWc/Vif5YqSX4dXKJIbaS2M7f8tHJznHY4OBXcgxjPy5/AVIkiIDtTbk5OBQ4RerGp
+NHikPwW1u/1EtqV7bRQbuWjYsxHsK9Es/hb4RtdPjtJNMFxt6ySyNuY+pwQK6nzxnoaDOPQ1qrBd
+nKy/CrwTLydERT/szSD/ANmrW0Dwto/haKePSLYwLOwZ8uWyR06/WtIzAn+L86Z5wx0P407iJGbm
+iqct0EfGD0oqRn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0019/full/!100,100/0/default.jpg</Url><Caption>29376_0019</Caption><Caption>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Caption><Caption>Exhibit</Caption><Caption>plate 068</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3VY1/
+uL+VPCKP4R+VKBT8VIxmKSnAEDk596U0hDAadmkxSimAZoyaDQBTAKQ5p+KYyMScOR+VAxDmmMDU
+uKQikBWIOaKkK80UWQFgUuKBS0wEIpMU40lSxDaKWigQmKWloqkMKSloxTASginUhFIZERzRTyKK
+QDhTqaKdTEY194js7GZopGXK9fm/+tVA+N9M2htwx/vY/pXLeMY9Qi1d5luVjhzwHdQp/OuDufEU
+9vdOtuEmY8NySmPQZrz6mIrRk1ZGiinse0p4usJDhVc/7vI/MVm6n8SNJ07T57lQbhouBHG4JZuw
+9v6V4bdLqN9KZZJJAxOQsZ2gflUSaVNFEQskuV+8objJ6/pSji7fE0Dp2PZfD3xXttZvrmxuNLlt
+rmDBwkokUg4/iwOeayvEPxsXSNVazttEMix5EklxP5eT/sjac/WvJpdNktlYwrJt3AuFJHI9vxqG
+SA6gT9pDvsGE8znArojiE9VsChc+g/D/AMSbPX9MF3FYyxuG2PEZASrcHr3HI5rWh8VedMEGnyKC
+epkXivni0sLiZxIsyRAcAR/Lj8BXQ6fLeWsgi+2tMrnDKQT+R6/rSlXd9GUqeh9Do25A2MZFKao6
+LE0Gj2yOSW2AnJJ/nV+upO6uZDCOaKU0UgEFOqMGng0wOJ8T+DJtYunuImDyMeDK3Cj2Fc0fhlqE
+E3mqEmb0DAV63z60CuSrhYVOrRaqSR4reeA/EISQC3Z89FjZR+uaoQ+CvEhKedp0pePpskwGX0PP
+Ne8nkcHBqLEwP3lIrmWXRW0n+BTqt7o8YsfBurzTNDLo0iRt1Z2G0frmoJ/hzr0lw7R6fsHr5q81
+7egmz8zDFSqCBhmyfXFaRwEU7qbF7XyPI9G+H+tRxgXNvBFk/wB4Z/GtS3+H+pfbxJLPAkKtkADJ
+r0mkwf71X9Qp3u238x+3kMgi8iBIsk7RjJp9HakNdtrKxkFFNJ5opARq3FPDVWVuKkDUATZozUW6
+l3UASZpc1HmlzU3QiTNLmo80uapMB+aTNNzSE0xjyaaTTS1MLUAOJoqPdRSA/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0044/full/!100,100/0/default.jpg</Url><Caption>29376_0044</Caption><Caption>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Caption><Caption>Exhibit</Caption><Caption>plate 069</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3S1G2
+2iA6BBj8qnqrpribTbWUdHhRvzUVbxUjGnNJzTsHJ5GO3FIRQISjNBooAWloFFABk0nNLRzjjrTs
+Mac1GwNSAP8AxbfwoIosBWIOaKlK80VIFXQB/wAU9pv/AF6xf+gCtPFZ2gqV8P6ap6i1iH/jorRq
+hCUhp1Vb2+trCAy3EoRe3qfpUyairsNyYiiuH1Xxvvt57e0ikidgVWVSCy57gdM1yXhvxrfaH4hS
+z1nVnfT532g3z7mXPRg/btweK54YulOXLFlunJK7PZaUVQvtY0/T4g9xdRJn7o3DJrhdW8Z6hDdC
+5ttV09bSKQMYSnzSLnlScnB69K1lXpxdmxKEnselUleV6n8V5n0yG70y0CBnKnzPmzg4OK1fB3jW
+/wBX12TT9SktY9kBbC8EvuAA6+mTirVSLdkS9HY9AFIaI5ElXdG6uvTKnIpxFUMiI5opxxmikBX0
+kY0iyB6iBB/46Ku1XshtsoB6Rr/KrFMRzXinXJ9Lh22zRo5GS7jOPpXkPiXxM6/vbq9aaRueDwPo
+K6P4hasi6jKjy42H7uCa8wW1XUbm7mvmeNIxvVVH3l/GvLxHvTbnsjohaMbl+x1S6uYpntraVkcg
+GViABnocVmX9udRusO9vLcfdXzGYAH0JOADxXQjWI7DSZBJGkLkBIXEWVdeo+oqvdPbx2LzrJGs0
+hBVFbOz3GemcGuWE2pXUSXVZUstLlmhlgbV7m4nwqQojARq2cYLMc49Peob3TB5amzvJBGi7JFnd
+SWfvtxxirlne2FncXF2zsIux8xRjockHJPzcgDH1reN34d1XRENh5n2vdud5kIRF9EycdhyM11wl
+K92tCeeXc5a0CW2nR2Ydm3yDBY4wTzuAzxkdPzq1Ckulw3E0gcTtIdoVvm2nufSnWsLSzzmZW8vd
+lHYjZ1x1B64X8s1f8k2expZYZklYHbGyttJ6dPp0/Ot1O7sZW6nqfwnuzdeFpdz7mW4bIJJxkD1r
+uzXA/Ce2Efh+7nG3EtywBXoQO4/Ou/Ndi2BbEZxmihutFIoSJdkSr/dAFSVEp4p4NAHjXj+wf/hI
+5ZpLDzrcsGcl9vye3vXAXlnd3C7IDNHZZzHHnJwe27qASa+nL2xtNQhMN5bRzxkYKuuaqw+H9GhK
+mLTbZCowuIxwPSuWpQlJ6MG7nzBFpxtIZZfJZlQgYUZO7nb+v4Vs6d4dtrwq17amSYgFmd9zADn8
+Ca+jYdL063GIbG3jH+zGBRJa2O7D20Yz6JjNQsPU6PUcXFbnznrukWttZbIIY2Ocso/Wq8cc+pWM
+xVRArJtRc52Bf8a+h00HQ97sNPjYt94NGWH5GpIfC+hQszR6Xagt1/dg1UaE0rNjqOM0fPjR20CR
+tFsMMgMku4kFfYe+R06nNNSCbyVJwJps7ovXnOK+hpPDOhy/6zSbRuc8xA81ag02wtuYLKCM+qxA
+VqqOmpnZdDA+HulXOk+F1iu41jkllaUIOMAgYyO3SuqNGaQmtxkcmd34UVDO+1wM9qKQxytTw1V0
+JxTwTTuBPuozUQOaWkA/NLwetR0oPNFxEgwOgxTs1FmlBoAlzSZpmaQnmmMfmmlqaTTSaAKl5Ltm
+A/2aKz9WdlulAP8AAP5migD/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0021/full/!100,100/0/default.jpg</Url><Caption>29376_0021</Caption><Caption>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Caption><Caption>Exhibit</Caption><Caption>plate 070</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2eVvK
+iLliAPSsi816SAHy4lOBnk1o6pKsentJuUAkYJPHNeca5r9vaq5MyMysEZc8gnpXJJdi7mmnxAvE
+k/e2KbCeuSv4dakh+JMTzGOW1EQ7MX4/HivLtRv2N8JZZRMVO5YVPX2HpWFe3U13ALq6llgZJSss
+aMy7QVyox6e9TKyBXZ7n/wAJvcDJH2Vh2wD/AI0+Lx/Gn/H1DGgHV/MwP1rwePTb4xs8TTwqihmZ
+Zj/LPXmorCW4u9Wjtr68uJI2GMs+7ZzxjPfjrURa7j5WfSmm+MNJ1NS0dwAM43g7l/MVvxSRzIHi
+kV19VOa+ZtPcaf4gmtIJTHFIGXCk4Dr0P5CvQ/CHilE1qJLid4oQNkiMf4iMD9a2haSuJ3Tses7T
+600qfWoTqdiFDG5jAPAOamiuIJ/9TNHJxn5WBrTlQXEKn1qGQSg/LtI9zVrFMIpOI7lT58cnB74o
+qYrzRWdh3OQ8cLK/gi3CNhv3RJzjtXiV9BLI0hkLMX+Ykc817Z41Eg8EWpU4dUj64/uj1rxp7C5n
+kLebgH0pymovUhxbKEJEMTtIiudwXL9P0qKZGuIYyUKneEPH3x6c8d+9b8Olrbx7rmZjDIRknA2E
+dG/z61E+ky3lrcXEVlMVB3RSRjIb1LAc1zOd5XRslaFi/Hf2lx4bW3jgjiZWeMuj4R2U8HrjkD+V
+czahrfXIpJoX2oclNuD7CrBt/O0ttOYPbyrIZFBXg+oPpVmygv7DRLnzpTMJoQlvFwcMSOfbAzWS
+5Yp6lXd7WMyaO607XzcXURKFGmRM9SeP6k1uWd7HeT5iO109eCR2qnqtvcLoloAUdoQVeSQFRgnO
+0euDmsWK+QKp5Q+o7fpXbSqRlHc55RaZ67pviSKS3KXbLHKhxgjhh6irza/bW86XEF95cg4+5mvK
+dPuibcRGTewJIIPP61sJeXSlT5Ub4AGGXn8xWyXZgj12Px3bmJd6qzY5K5wfwqaHxhb3DoA6oCcH
+PWvPLW4a4t90trIjD24/CtCw3NLHsgQLkY3A/wD1qhzV7F8p6uCGUMOhGaKIFxbxggA7BwPpRQI5
+zxjZrdeEwmAGUIVOOnFeWppl06kRFZGxwPuge9ez+IoxJo0q8ADBrzKG+igvhAqKVXqfUVlVSY4m
+Dfi0061bz5lEwz+6JJJOO3p9a5Hz5L6JTAGgljbJaOQ8+3tXU+I4Y7jUY5EaM70ySvXqetYM0Mdm
+0eZFjDDlcEsffFc8IRjr1Kdy/pqPueZ7ySR9wdizk7/qe9XnZb+EyzTlQrbgkY2hSO3v+NcvGl4i
+P5UU0kQO+MnAxz35qrZwXGqXJS6uJBubAWMcAE46UnCN+ZglLax0GpCOUx/aGmML/wCq3gkNjjj8
+asWGnabfjyvKWd40w6CP5gvWrfh/SzZ6yvhrUv3tm6edaSD+BmGcjuOc/jVKSO+0LUb+1U+ZMScb
+h+RJ9uPWr2Vkxpa6k0nhvT2tEuLTzIpHUOoLbgO+K0rHxDdXASzeKBpUGM7AC+P61x+j6hdaXObK
+4LSW0h2qDyVYntV6ZLiO6W8ihkTawYEr3961u1o2KyZ3DS3Eg+eIIMfw5ot4sTRsxlKhgOH3f1rH
+tvFSCH/SLZ92OqkYNW9P16OS5gZrVh84IORUq63QM9si5hjI6bR/KiliIaGNh0Kg/pRXQQYHjbzT
+4an8osDkZx6V5Hbq8EuY2Zn/AI9wyFNe3awM6RdcZxGWx9Oa8dGt2cNyoxyzZO5a567aeg0RX4SV
+kuZkASOMg8HG0c5Jrhra5n1TVJZY7d5QThUUcBR0FehX2t6fJaSwtbtNFKpVtp/Os2z8QaRYjZZa
+e2QuOE2gfp1rl9rJRa5dS1ve5XktdVNnlLZYD3I64/Gq2lRQWlrE10XjgJJdYYi8hO7kE9FrpYvE
+Vo2zz45I9ww3oPwqvqEml3dtJHBM8byjErBNu8e9c8aj2ktDTmd7la5kfWdZi1a0kNtbWyiJFC5b
+C8gfX1+ta4u7HWVa9Zwt4ABKoODwP/1Vj2dtFDKEsr5EcEAfvM80mq2F/et5jpGZEX5JI0w5+pHX
+6fWt41VJ2EkvmZ2o2UNzL5iJL8pB+Yc8EfmT9BW7pmmu9hGHtpIpMfeM+7P/AAHJqxpElosbeXZt
+cXKKAwY8/wD1uh/Krc11KF8xtLUgdFBHy+1OpVbfKkOKsMNpKEWFrWORSOfk4P59Kjs9CjkvYgLK
+MMWHKyAf1p1xqpERD2Mm08kBiRU+grDq+t28KC6TDbiB0455pQu5KwSSPWoV2QRqRjCgfpRS9OB2
+or0jAZw4KkAg8EGuN1z4fWmoPJLahEZsnaxIwfYiurV+KlDcd6Ukpbgro8b1D4ZayuDZxYx280MP
+yqg/gXxBDCcW16sgI3BEVh9Rg17pvIpRIcVk6a7sd/I8CPhLxhAoENvO24knfF/+v0q5Z+H/ABfP
+DN9r0tXUdIjEFLE/XAxXuPmGkYlxySPocUlBdSX5HgieHNdVsTeEZww/igbb/I1estLvImBmstTt
+iOSjwmTP44xXtiod2TI59s1KrYGKHRjIak0eTW638cMnl2MweV8tttwp+pJJz+VV7jTddWZzBpt7
+O8hyRIvyD9K9i3mjeaI4aK3ZftH2PIrLwb4s1CT99ss4j/z0YDH4KK9G0Dw3baFb/KfMuWA3ynv9
+PatcsSKjLH3raNOMdiXJsUtyaKgZjmii4rH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0035/full/!100,100/0/default.jpg</Url><Caption>29376_0035</Caption><Caption>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Caption><Caption>Exhibit</Caption><Caption>plate 071</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3gEgd
+z9KUMSM4I+tKBSGpsAu6k3H1rxjxVqmotqN9dzXUwMMuyK2UMBGATlt3boPQ1oeHfE+q3Go+c2oT
+XUWBCYTh8OXQAkD/AGd3Pqa5vbxvY09m7XPWN1G400CnYrexlcXcaN1Jik3Lu27hu9M81SQXF3UE
+mjFFOw7jWO1STnA9qi81WIUFsnp8pFTUlJodyA5zRUhFFTYZOKjaSNQSzqB6k0/cFTcxwAMkmuA1
+fV7e6uJVtbhJApIJjbOPyolLlBRuYfxZktI7y1YkiRoCy+X/AMtGzxn1rD8FeJv7JhE19oRmJfcL
+iOTaQB0+XGKr+KvKuhazTT5lhLoRnJCnvj8DV21vrA6JHLBKpH3ePXPSuKo7SckjpiuaCiz17SfE
+Gna1AslpONx6xP8AK4/CtSvE0S2lxIJOSc7s9K0LbV7y2tJo9PvJlljG4FnLDP0NXHFfzIylQ7M9
+crj/ABRMIdRgmWaOCSF1KO+Rlj6kdevTpVnQ/FRvdNgublUPmxqwMfHPRsj6g1yV7dS6r4kurqOT
+dbwzLJCWUHaQq9M+4redRcuhnGOtj0qwnnuIN08Pltxg9m/DqKtVxVt4wvVjaKeGFpAflk6Aj3FR
+X/ibWFiKmEQLIPlnUBhj2960hNNA4tHc4oxXntr4s1OL5HmSXnALAZxXS6HrNzqNy0cwiChcjapB
+z+dXck2yOaKcRzRUFBLjyH3AEbTnNfPuqQ21nqU09iDFL5hOIwSPoR0r6CkG6J19QRXzvqu621O8
+yrkB2AwQc8/WufEO1jSkr3GaZd6a8st1qNpHNO0rHczn5eeABUjnSb68a3SZ9OtnHmDAyN+R+lYp
+jjklKQSMG6lUXH6nmk+ySu6gBVQA/M7Drx/hXK6mupo4tbHSf8Ivq32cvp2q29xFjIKjk/TBNR6B
+qDQW07zrIVz5buw+63v6VkWf9qWV0Us0uR23xLjcfqeMVuaM2t2kd1ItpCUnbMq3L5aQ8/3enU0n
+UpvfQlOa8yxY3Is7Ce3glYkyEoCfuK3JH5k/nVvT78WsEjMgkkKkKM8ZAJH8qxr+6t7WSO4ayltJ
+d2ZFSXzI3Xv15Bqe11jRnnmi3EGMFzlDjHT+tar3tmRdp3N4a5bywhWtik23cVI3DJxnmr8mofat
+KS0PyspdwO+AM9PxrmZLzR1uDG97AsqkhgSAQe/ardpJaRTyPFcRywFc5D7tvYjPvmtYpxZXMpKz
+FSOQuByynoQpH611/g57qPWHhkTMRQ4YHNc/CNMjRZfNxE3QnnFdBoGu6Fb6lDbW8jNcTNsXj/69
+dEZJmTTO8NFFFUIO1eMeJdCeDVbnyIl2tKWy9eyg1zHizT5ZIhPbxM7fxBFyawxEHKGhdOVnqeTP
+ZXEcbLHG7OerBeB+Aqn9nnWYx+RIHwM7sjj15robhrgyss8ptk6bVXLfmen5UkK2qFrhbSRzjaZX
+cl39gSc/lXj1I30udSZmaal3Hv8ALO/J2lVAO38atJdyQN5ZeUSHqOoq3JqGnw2ztDbC2YrkvcqV
+yfTca58eJohv8vTJXKnCPGNysfY4H8jUKjd3E5Mmumtpd3mSDew4ZqrW/hiSVMtI6REDJBByBz2p
+zMdTJudS86EpIDHa25VWxjqWI/Tir8l7YRFEh0zUPOk+6ss4GfpgGuiKnFWTFZHJaxpNpaXWy3Es
+rHqQ6k59arLcLBY/ZoQwmeTcxz0A6Dj6murk0C91W5R0s4tOjyQ0ks6t+QABqpfaTp2mx/ZoQbiY
+thp2XAJ77VHJHvmuyEnbVg7Gbb63eR2i2rbGwxYmRSce1dP4CY6n41sEMb4RjIzDGPlBP5VTsbC1
+4jtdPlmnI5bYxJ+mRnFeqeAfCR0aF768h23kvQMOUX09q1pScpbGdRJI7eikorpMCMNTs+2agDU8
+NQBBcaVp94cz2cbn1I5rPbwfozk74Hb2aRjj6c1s7qdms5Qi90O7RyWofDXw/qLq8y3I2Y2Ks3yr
++BGPzqH/AIVzpEZwbq+wRj5GRePqFrs80bqn2cOwc0u5x1r8PvDttuIjvHyc5eY/0rSg8E6FGd62
+sgbGMtK2cfnW+MDkCnZqvZw7BzS7mUPDGjBAhsUYDpvJP8zU8Gh6Vbf6nT7ZPcRiru6jNWoxWyC7
+GRwQQ/6uFE/3VAqTNJmmlqoQpNFRluaKQH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0016/full/!100,100/0/default.jpg</Url><Caption>29376_0016</Caption><Caption>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Caption><Caption>Exhibit</Caption><Caption>plate 073</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3hadQ
+BTsVNhjc0ZNLtwSck5pDSsITNANJilxVAOBpaQUvWgApDS4prpuH3iv0oGIaYRTwm3PzE59aCKAK
+5BzRUhFFKwE4paBS0wEpDTjTTSEJimu4QZJAzwM+tOPSo4pI7qJuOMlWVh0PcUXAhtmKqZJpCS5C
++wIGOPxq5Vby1WOSFuY9vA7470tpN51srMwLAlGPuDiknrZiLFFRLKXnZFwUVRk++Tx+lPVg2T0G
+cD3qxi4pCKfSEUhkRFFPxRSAcKdTRTqYhrOoOCwB+tJx6ivG/GXifWrLxHdxxmbyUkwgVtoxVCDx
+prUgUppdwwPDM91x+oNYuvBOzZfs52vY90quytE7yIQVbqpP8q+ddR13xXeSKWv761LMdkdsWVUA
+9SvWqNhqfixNWivr69ub94GxDE8pbaf7zew/nS9tC17k8kr2se4+IvE0OhhJ5LlUQ5UCTnBx0Pft
+XD2nxRghv5YyrIDJn6cZJA98CuF8WDXdU23+oB2kLbQsIzjr1P8AX3rCTTpRHuEEkdwsfmDfzmsf
+eqe8paDcZR0se2WvxCgkujFaTAvODtDgn5u+Men867DT9Wa6ePIzjgk9fqB2/wA+tfL1vNqFpIrr
+DNGyZ2lRg89ea6rSfGutWKq3zgE9Dnn3pxm47srkk+h9NDkcUVj+FtTbWPD1rfMfmkXkc8Gtk12J
+3V0RsyM0UtFIABp1Rg08GgDgvE3ho3epSzy7jBIQcKfSuPRZ9OV4GiVnDsBIxB4JOOAP/rcV7Y2G
+GCuR7ioWsbR8FrWEkHPKCuOeFu7pmqqu1jx46sIXZCqEnniMLj86kQtdxq7WhGTwGOM/lXqs2h6X
+OweSwgZhyDsFSLaWUWMWka/8AFZvBtvRjVU8ouA6QbUtYgBywOffNc2LHUJ5WliRgJACiBNwA9+M
+ivfBb2jn/j1Q/wDABUkNvbqMpbIn/AAK0WE01YvbM8Mh0O/uIttxlVyeCn681rab4EkuJg3kll9S
+MCvYfIiznykz67RTs44CmqWEXVjdd9Cno+nJpWmRWiAAIOg6Zq7RnikNdSSSsjHfUQ0U04opgMDU
+8NVdWpwY0gJ80u6ocml3GgRLuoyCMGodxpQxpASqABwMU7NRZNLmmBJmkzTM0ZpjH5ppNNyaaTQA
+paioiaKQH//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0037/full/!100,100/0/default.jpg</Url><Caption>29376_0037</Caption><Caption>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Caption><Caption>Exhibit</Caption><Caption>plate 074</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Nc4p
+TmlUUoWpsMjyaXJpxQlgcnHpRigQmTS5NGKXFMBQTS80gp1ACU00/FMdCwGGK/SgYhzTCDTwhXOW
+Jz60EUrAVWBzRUpXmipsMnUU8CkXpTqoQ00mKdimE4ZR60bCCihSGXIpwFCYABSigUtMApMU6kpg
+NxSEU7FBFIZXfg0U9hzRUjJF6U4U1elPFMRkazriaQoLW8snuozXI3HxMt/MVI4kDbufMbbit/xX
+fW1lCGnYqTwDXmWuz2bxF5jEq5wGdeT+Qrjq1ZqXKjWEItXZ11r48uAFYwxSQ5JPljLYxkdD61ot
+47WNFdrJyjdHB4NeIpqJS7ZbF0WNQRmYEr9RkcVTvba7eW1a7vDMiA7CsmQOc8elZU60k7TdipUr
+6x1Poi18Z2Uo/wBIjeDPILdMVp23iLRbwZt9WsZDu24W4UnPpjPWvnFPEuoRxGIvHdxxqUw5+YD+
+tQpvu5C1s8ELEfNAykEY/E1vHEpfEJUG9j6norwrTPGuuWlokTtJcqihNyS5PHHQitG0+Ilwr7D5
+6uOCGbn8ulbRrwezE6E1uj2TFIawPCesT6zpzTzq4IbALLit81pe+xnsRt1ooJ5opAKh4p+agQ8C
+pM0COC8feG9R1q6glt1mliQYKROFI/PFcHN4PnO7ztD1NWX7pDghvyJr3gse2KM+uK554fmlzXaN
+Y1bK1j5+Hh3V48pbeH7ojOT5mcH9aqt4F1+VwU0qSFeeA5IGfbmvovPsKaSwz8qkfWoWEV73G672
+sfO0Xw38RM4b7Oygf59Ksv8AD7W0dJGgkfbgbVSvoBZJGOBGB9c1Kpfd8yqB7Gr+rLuCrvseGJ4L
+1+F02RSlV6qTxXR6d4Qmu1VLmx8ojk5HBr1LikJ9MUfVYdSvrEzM0TR4tGtDFGWJY5bc2ea0zRk9
+6QmulRSVkYNtu7GHrRSE80UgI0bgU/NUbWUyWsTnqyKT+VWA9CYrE+aM1DvNLvNO4EtKKh30u+lc
+CcUuag307fTuBLmkzUe+gvTAeTTS1ML49aYXouA8tzRUBkGe9FSM/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0033/full/!100,100/0/default.jpg</Url><Caption>29376_0033</Caption><Caption>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Caption><Caption>Exhibit</Caption><Caption>plate 075</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YZoU
+MByxb608CjFSA2kJNOxSEUWATJpQTRio55ktoWlkOFUZJo0QElLzWB4evLm/uZ5pnbHlp8hHCkkn
++X8q6HFKMlJXQPQbSYrIk1Hf4itrJHHKOxA9sVs4ppphsRkVB5TjGZnPPcDn9KtEU0imMrleaKmK
+0VIEwpaWiqENIpMU6jFADcVUvYJJIJUj2vvUgxucfke1XKZLAkwG4sMdCrFT+YpNXA43+3JNMtJh
+GFjuoGTfDKPlcDII3DIB9KWP4kaZd3UCW2VtyWMssoI4HZV6tk9+lXPHF9a+HPBOpTx2qMXjKLGo
+xvZuMn165NfNMuq30WxtiEJguiJhQOO/rmsknH3UUrPVntcnjGy03Xv7TuyIomyicgk5IySBzXf2
+3iXRLu2S4h1W0MbjIJmUfoTXytdk7EE5kk+QkFmyzHPr/npU1iLSSIoWxvYFRg7s1pDRDaufWEF3
+bXalra4imA6mNw2PyqWvmbQdZu9E8S2rabcGINIqSbz8jKSMhvavoCx8VaVqd0tvZTmdycEopwPx
+qtyWrGxiinYopAPHSua1jxfa6VO0LB3cHGFTPP1yK6RxmNh1yPXFeR+KNBvJr9nfZFCv3SZN2P0z
+UTnyK4WudFJ4+ZR8lrJu/usgA/PdU58dgAf6HKSRk/Jjn0615deW8VtJD9pPnZGGUn34OT9DVeS6
+hMEXkzfMvDeW2Bn8653iJWukVyHqI+JllbzOl7ayxjPy4HJ/OtC08d21/F5trp16yZwDtXn8mrwm
+S5mSMyCQumdoClj/APWqKLWry3cNBOI3xgbhn+lONaXYhx7Htfia60zxFaRW2qaTqoSKQSL5YXrj
+HPze9ZOp6loB0u5sovDkkTy27W4Z9i4XJORyec89Otecvr2uXkQSR5JEHpEcUJNegiRtMjkU9C8T
+L+u4Voq0Q5ZHLadYXuqakLOORjKgZiHyQfyroP8AhFb61kSSWSNNhBwqH+vNWYLmy0+/bUWsI5JI
+0WIxlsLkjOe/uK0n8aR3IKDT4VTHAMjHn8qp1EXZmJo2lXE2uTRhV3xKzor/AMXevTPhtPftfukj
+RpbjI8tVVTn+dcnHqMYaG/jgQSjKECQ8g++K6bwjr32O4tbNLRJd7Aec9wAeT6YoVRXHKOh6yRRS
+0VoQB+6ee1eP+MjdG5kKOzqpP3mJJ9q9e4Iwa4rxdoE1xtNlE2G+9tHSubEqXJeJcLX1PEL64dtU
+WMwykiHOF7nn/Go7gRPCJYCFWLGfm5PrxXU3vhSSe5f7Tu84DCqASVFRR+BboqQVWOLdv+Trn8Tj
+9K5Y142S6mjgzmbi5EkF0umRs0kzKxKHtjPT65qgjQrp5mngV7rorKT09SPXNeh23gu+kto/tc0S
+eiHBKj0JHBqvqPgOcRbY1TGM4jQLu9s8YpqvG9iXBnH2/iK/021wk7Tvxu3fMEJPTn8K1LDWX1je
+Zkw6Ae+OvY8DpWhZeCNSKF5rKP8AeY+Viz4x+NW7XwSG1F98qwqoyY0HU+5/OqqeytdaMIqXUzJI
+oARAxLDbuYFwMn6gVUg0uGaTCoxOf4c4/M13lvoVrFHt8pGPGcDOfxNRf2O4kdbSNwewAP8A+qsl
+Wi+ppY52PT5pFKRQGNAfk8zg/lW34c8OH+1bVpZ38xWDAR+ta1joGpeUXdQ0p4C5/nxXWeGvDUlr
+It3en96OVReADXTTUpPQmdkjrB0FFBorsMBgal3L0JFQKxp6sc0AI9paytveCNm9SozTJNMspRh7
+dCPTFTBqXdWbhB7od2Uv7E0/IP2deOlPbTbIMGdR7bm4/KrOaU8jBqVSp/yoOaXchW2s16BfzqL+
+xtLlZpfssLM/3nA5P41aVFToKeDV+zh2FdlMaJpynItU6Yx2pw0jT1YMLWMEcgireaQmmqcFskO7
+AKkYwAAKNwPQ0maaWNWIUtRUROTRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0022/full/!100,100/0/default.jpg</Url><Caption>29376_0022</Caption><Caption>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Caption><Caption>Exhibit</Caption><Caption>plate 076</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RVx2
+H5U5eR90j6inAUGpGJikOadmkNAgBNKCabS4NFgHZopozSjrTsAtIRTqSgCNjtGTn8BUe8McDPry
+CKnIppFAysQc0U92VGwxxRSAtCmsQqlmIAAySe1P7VzmrXksKXKqcxujKwPbIobsBeste06/n8mC
+YtJuKgbTzj3xitIivKtA8eWWixy2TafM6pM6idNpBGeOpB7V0ll4+sru+jhVJgspwGdQAD+dZKtH
+qynB9DsKoXGprbXMsDoQ6QtOp7Mo6/jmmw6vC5yzKVPIIIOPY4rhfFU8uoeIILZb6aGOTMUUiAYy
+2PlYZGVJFU6iSJSuelQSpcQJNGco6hlPqD0qXFUtKN79gjXUIoY7hflIhJKkDoRnp9Ky9T8a6PpW
+pnT53le4UDcIoywXPqavmSV2JJt2RU1zxO2k6nNYtHKVkVMTFMJAWO3czenf6g11SMrorKwZSMgj
+oa8xt9XGv+Pobm0kuFs5BGkkDkASLtbBK/Uf416ciLGioihVUYAAwAKIu+pUlbQKCKcaMVTEY2pS
+MlyoVcjZ/U0VJqTFbhRj+D+popAa3avN/ElzeQX8vlLIVPZSD+lej/wmvFPE2t3UWtzxFmjw5G1E
+DGom7IaVyrLJFCsUn2bEwJfbgEAZ9Pfmr3iIymTT4bWWb97EJHSM4wSBgDH4n8awZ9Q3TtGZpdxV
+TnYueBz/AFqOHVhd30KzXDxcLh2GMbenP+etck46aGsZO+psjRteEBMf21MjqHI/WqF5HfwGC0mk
+ckSK6PKcsuGyQT+tSL4g1VoUjm1I7GGQZA3P4jrU9xd6ibhNstrK4UeW7y4YAgdP1rJQd1qDqLsd
+lB4rk8oYlOccBZBn8qxUubESX9xdxCS6vJ3MLEfMrAYH61zkyzzxEXSqcHdxMDgn3qvdQiOLCHGH
+GCZBwCM9j611t8yszKHuu51OjS7L+ymhgjW9ijJc9DtPIHoeCv5iuxXXtSXlwmfQ4x+gryeS5Nnd
++dDJIkmzZ+6fsD0/Sri+JtUMIEJnJ7lguaqF4xsipavU9QGuXrP8y4HfaOP5V0dnOLi2SQHORXkm
+n65qrzxlwp453xj+lenaBcS3On75QA2ccDFWpNuzJaJrxEaYFhzt/rRVmSJXbJoqhDyflNeYa5d2
+iXsouViLOx2gLyfwr00ciuN1jRngvWuorV5dxziOIN+YrCuna6Lha5ws9hZjNxsEasNoJHOO+B1q
+KPTLSaQE2+/0MpJ/QV0lydTg3SPbzBP7rRYA/DNZrahczuBCwjGOrNgfpXDKrbc15ShLp80QaKIW
+MUZIOPLJz7nJpt5p95eTbYrmJIgqgskeMnAzV0Weuyy7hewvGf4ViLj891adhoV+YcOXdv7xjIpQ
+quWxLikYEHh2BVYT3MsueuPlzV2Hw/bS+axiBLuGw+cDGf8AGultNJmjO2S1cMfTOKtyaWyHc0ZV
+QP7p5rZTkldhZHEr4fN5K6x2SoFLfO44HJqSDwfGpB82RmHUDArsI7SYjcrO6HtyMVWnEtsyqttO
+Wc4+QZI/IUOo3sUkU7DQ4BModX9OWP8ASvQNMs4bK12QxhAeTgViaZobu/nXMtwSf4CxAFdJHEsK
+BEzgepzXTRUrXZlNocRk0U09aK3IGK1ODe1VYnJRT6jNShjQBKQjDDKCPcVF9jtM5+zQ59dgpdxp
+c0ml1AVYoUHyxoPoKXzEHBXH4UmaXNFkIcJVOSFJ/CnjaQDjr61GDgU4GmApjjbqin8KAqjoAPwp
+M0Zo0GOJxTS1NJppY07gBbmioyTmilcD/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0047/full/!100,100/0/default.jpg</Url><Caption>29376_0047</Caption><Caption>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Caption><Caption>Exhibit</Caption><Caption>plate 077</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2RI81
+IsWR90j61Ii81Jg1Iyv5JzSmOp6aeaQEHl89acI6k20AHNAiPZTtlSbacFo0Ah8uk8oVYxSEUDKx
+gqq64/5ZSfkP8a0sUxxxQBnGHmirhWigCwo5p+KVBzTiM0NgREVWuLyC1uLeGZtrXDFIyehYDOPy
+z+VN1LU49NaFXilczEgMqZVcD+I9q4bxjJeS3kC3N4q2xZWSNMrtb3Oc+tY1KvKiowud7b3cF20g
+gkV/LbYxXoCO1YviHxdZeH5BC0M11cld3kwAEqPVieBXL6NfeIbO0ktLS30+KP8AgkZmcj37AnNO
+stO+yTTzX8pnuJwWllYZyaxliHbTcpU1fUuWnxAv9R/489AYD+9LPx+gouPFviKNv+PKyjHvuNYc
+F7/ZOoEL8luzYIk45PpVnUNatT5kSN5skh+RR1HFY+3qM2VKPY0h4y1+2j86fSbe4i7+TIVP4ZzW
+nonxA0fWbxbErcWl63AhnTGT7EZBrP0xJP7DSN0LSj5SpBH86x5NIMXi7S76NMOkjHaP4gF5renW
+lflYpU42uj1LFNYcU23mM1pDMy7DIisVPYkZxUuVPAIz6V1M5yseKKew5opiJwcAmuau/FcdncmC
+SaFX5IBRv6da6ORPMgdAxXcpGR1FeRaha6tp15Nlo54wx2+Z94D61lUk47FqNzvbfxPHIm6SWBlI
+yu04P5E1TufEs03ywwWhB4zK+7+VecXNteXMqzQRxI/TA3kD9cVXFpr8MhYXETZHII4/nXM60h+y
+Z11w9yJ/Pke2BB+VkQKF+mKoyTXgkxC0hidg8zSMCcA5OK5a/S+s9DmMk6i5lkBCs+3ag9OepP8A
+KsCNtWkCmOJx6FiwH6mpi+bVhytaI7SUS6xci4RFZFYlCW7g4zV5G1lJVD3cMO7oW2H9RXIfZtR/
+s2OXaFnhJDjJw6nv9QT+tUPtV+EVZbZyobIYyd63hy2sKUZt3O5j8W/2fc+S5aTkhpgP6d6dqXiu
++SYQSoijPyvGwJH9RXMmTT7BoZ9QZvOI3CIYYj0zz+lWotT8PynzJ3nkdjnk7QP0rN8rd7GqckrG
+3eeJLy3ntoYZmkR0zjdkseuT+f6V0fhHxPLqOrpbeXI27OWLDAAGelcvc2WkXMcLvhDJCBGTJhiv
+rXaeCtA0+1uDfQIRIF2q28kH14rSNSLaj1Ikup2bdaKVutFdBmPzwRmuS1W0Mkr8lutdWDXHeLdS
+k06VTHCSjdwueazraK5UGZv2KWRgrHA9qnewVEAVeneqFvq8k2GkUj8OSa0mvYwqxvExdhkj0Hua
+8+U0bGY2jW4ufMEcTysPvP8AMatDSF2qfJRVH3zwAB61D/amnrMd7KrL0AJyTVmSH+0IZBFdPEMc
+svP86zVRNgZmtQWNrpwZmZDneUTAeQdMZIOOo96k0XT9H1CykmtrJAmMBpWyx/E5IrmbzQI77UHN
+1rlw2ONuwZrd0vwTFJCI7TUbsJjsRj+VbRqRk7REvMFtvD7Sy25jgjuF678ZPbr3p3/CGWkuJCEK
+k5GDWpbfD7T7WYTXAlncc5kfAzXTRaYfJVYwqKowFHatrSK5kcDf+FptSmgjlMawwpsRE64z613P
+hTQYNFtGWNAGbvk1PHYGOTLkGtaFNkWOa1pp9TOctBx60UGitzIj3c0OI5Rh4wwHqM1CGNSAmjRg
+At7Xg+REMc/dFKYLds5hjOevyik60dqVo9g1K6aPpkblxZQ7mOSdgzUqWdjb/ctUUeycU7Joxu4P
+Ipezh2FdkJ0/Snl8w2MLP6mKr8SxRqBGioPQLiq4VQchRmng1ShFbILsnbYwwyg/UUYUDAAA9qi3
+UFuadkO45lQHO0Z+lI0g9DTC1RsxosFxxfmiqzMQaKAP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0042/full/!100,100/0/default.jpg</Url><Caption>29376_0042</Caption><Caption>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Caption><Caption>Exhibit</Caption><Caption>plate 078</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vDBc
+gFj6U8KSASMe1PVakrLQogKkUmKlYZpNoFPQRHtpcGnmgU7IQgpTS4pQtHKh3G4pCtMuLqG2eJHY
+CSVtsad2PtU+OKLILkDJwcDJ9KgPmFgDCQPXcOKukUxlpWGUmU5oqwVGaKiyGWUp2KF6UMyr1IH1
+q0JiYoIqJru3T70qD8ai/tG3Y4Rt30oZJORSgVWbUIgPumkGoIeduB9aOYCxPPDawPNO4SNBlmPa
+ueXxNc6lIY9HsWlX/ntLwv5Vk3183ijW/saMV0y3b52X+M9zj9B26muytZLG1t1igZI416DpU3cn
+psPRFHT9GlW+GpalP9ovApWPHCxA9QB/WtC9vbbT7V7m6lWKJOrGlXULJ32LdQlvQOM1znilkuNY
+0C2d18iS5ZnGRyQBgfqat+6tBrVmpY6/ZahOIYhNG7DKiWMpuHtmtMjiuY8Z4SPRpbdgJ01CMIVP
+Yg5H0xXUYyKAIsUU/FFQMeW2RlsZwM1xWoarNc3DeTdw7ckeWQQ4P0JrtHZVhZm+6Bk4ryHWbjSb
+zUJHivim1/4lIKn2pSlZbglct6jeahbbZD5hU9SVzj6gdBWXL4p1GEhY2QN2Cjr+dWY7zzYRDc6p
+mMHJbbliPSqtxd6VboxifOMksYjxXP7dlOJDdeK9UghLz6nHFjtwTWHfeP8AUJIRHb3s+6Q7SzKF
+AHfmsyR/7T1FrmfJiztiU9l/xqQW1vdwyQx7A2SAQCQPqfX6UvatMORdTsNJgvdPs1MNzMHf5mZT
+hW/PtVk3+pXLGGSSZlzzk9fyrL0q81PSdNjt1dLhl4VZF6D69cVXu/FWsAPHE1u0hyCIojhPfJqo
+Vr6ITgT6jrllZSGMLJNcxnlYxyh+vY1l3fim61GewiSS9WeO5RovPO4DPHWnaTbQ2cuLhCWbli/f
+PerGoQWczmSOGVWjwV2dCfbvVqu726GnIjprqXWrmW1ecxSi3mEo4I5Axz+ddx4b1S7vnZLiBEKj
+qjZFeH3Wpa7dNsubyfHTap2D9K9I+Fdq0X2iWZpzIwwN5yMVspXM2j0kiilPWikIhuMfY5QckbTw
+K8i1GwMcrC3hSNQT0Gc/j3r1q5i+0WksO4rvUrlTgivMptGuLOeSFpJZYyTjcSxrnxK0NKeuhycx
+ugSqDnPJFRfY76+eSN0zbIM88bz7nsBXZQaTIkRK2xT6LTWtJCmWil8tT0fP8q4ZVOVbGnJqcVcW
+UMUAt4C7SSgruIK8YwSPatzSvDTC2RYiE4wDmkuoIzcA/YZnbswzkVds1mEiJDdtCzc7W61m6mmr
+Hya3L6aS0ChEjklcDlmIwartYJ5XlHTFGDk7SQCfwrSt0vIm3PdGRR3q4l/CG2tIuT6NWkY+YW7H
+L3GmXN5KGWAjyxgYGP8AGobjQNTJXZvHHau8ik3DKDj3FBa4LYSJW59DW0YruHqee2+l3TShJYy2
+3rk16p4StkttOwgI56GqMcDySgSQxg9jiulsoVggAAxXVRi07syqNWJyeaKaetFbmZEjZFGyJvvR
+g/hVa3lLxI3qoNWA9MRIIoSP9WuPpUUlhaS/fhU08PS7uKlqPVBqRf2fZIMi3T8BVVtK0oyb2txv
+9ec1e3Uu6p5Kb6DuyqLDS9pUQLz6Z5pkOhaTHMHS0+f1bcRV8NgUoeq5IdguwWytlGBCgH0pwt4R
+0jX8qTzKDJTSQXYrRxdDGv5UmQBgDApC9RtIaYCluaKgLnNFK4H/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0032/full/!100,100/0/default.jpg</Url><Caption>29376_0032</Caption><Caption>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Caption><Caption>Exhibit</Caption><Caption>plate 079</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tE4x
+T9lOVak28VFhkGygpUyqTnIx+NBWjQCHbTgtPC0oFPQQ0LS7KdTgKLDItlIYxU2KawbPG3HvQBAY
+hUbRVa2nHOM0xhQBnvF81FWWXmikBaUVIBTIs+WueuBmpRTAYeKYc1KwphFIRHThzUF3dQWNs9xd
+SrFCnV2PAqnpGv6brbTLYXIkeAgSIVKsv4GjmWwGrThxTRS596YDuKCKjMqguCfujJp6urEgHpQM
+QimMOKmIpjDigCqy80VKRzRSAmA4pwFNXpT6AEaq13cxWdrLczuFiiUsxPoK4bXvEeoWWr3MT58p
+ThNny8VyviHxIbjRpbaN5lZ8Bgckbe461zSxCvZItU2zqdZ1NfEFqoGUi3B4yp5BHeuXsmfw94ug
+vo7xIBM4ScynEciHqCR0I6j6Vz+k66YI3tppVeMD5WXtUOtX0WoAH7SWSPBKY6+nNckZzU9TocI8
+uh7ff+K7C0sorq2DXqSMVHkEHGOvU1Uj8YaZecRO4kYcxsu1h/n2rxXwvrq6fNJ5sjNaqSGhB6jH
+DfUdK6ZxdX5hv7JdsbP8u4A+WPXg11SqyvYwVNHdL4h/0obn3Iyn5vXB6H3rX8P6l9sV2diMHGT3
+ryUarfiaZJtPUzIxztyoPvz2rR0jxY1vG0MlrKpzkGMjiohOpzXkPkZ7UORmmtVDQrn7XpEM2X+b
++91q+1dqdzNkRHNFKetFIBUOak7VAhqTdTEcnrukrLdF1QMSc4PasOXw/HdAxPGrMT90LXo5Ck8q
+D9aFjjU5EaA+wrlnh7u9zVVbKx4/f/DZ5W326mJ/VTisS5+GWqBPmmyD97Jr33j0FMYc5CKRSWHa
+6h7XyPCbL4am33CcyvnqFOAfauqsfDF7DAsVsrQxjsTXpY+Y/wCqX8alQeqqPpQ8M5byBVbbI8vu
+fCWrXLMjOxQ/xEk5otfAM0ZCuGZT3r1PikOfatI0EgdVlbTrUWdhFbj+AYqdulLk01jxW6RmyInm
+ikPWimIYjVJuqkkhqYOanmHYsbqN1QbzS7jihSQrE26lDCq+404MafMBYzTg1V9xpQxouBPuo3VD
+uNJuNO4EpamsajLGmsxxRcdgLc0VCWOaKnmCx//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0045/full/!100,100/0/default.jpg</Url><Caption>29376_0045</Caption><Caption>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Caption><Caption>Exhibit</Caption><Caption>plate 080</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21QFX
+J6VLtoUYFPAqAGbaNtS4o20tAIdtLinlaMU0kIbijbT8UuKdkBHtpCtS4pCKLIZCVqu0kYz83T2q
+4RTCKWgFPG7BHQjIoqcrzRU2Aq6u8iwwohIDvtYDqatQSJaxJE7tnA+9zVLX50tbOKdwpVJBndXL
+P4oM7usUbF07sepPasqk1DUaO2kv0jnKtkIE3bsd6sGeNYvNkdUTGcscYrz7/hMntVaWeCNli+Y5
+4249/wA64rxpr+seMNDuLu0Vo9PQqqxocEjrz6njOOgFQqy3Go32O91n4veFtKuGt45Zr6ZTgi1Q
+FQf94kD8s1z0/wAdbVWAg0KdgTj95MoP6A14/YxKkLeYhbPB2HBHvmtzT9NtkhkNxIsUiKChbLCT
+Of8APFKVZor2Z6fa/G6weF3uNGukZQPlSRW/nitPSvjD4a1GdYbj7TYOxwDcKNv5qTj8cV5Pe2BW
+MSnaokjGVxg8Viy24L4C7gG+b0IqoV2xunY+rba7t7yBZ7aaOWJuQ6NkGiaUxxb1AYfWvnHRPEd1
+4N1QKk7CxufknTsv+0B6iu7vNTvjDG0E8ioQHTDfe9M1p7W6uZyjyuzPS4boyQvKwbaBnGOaljlW
+aPeh4ryePXdWtnQx3LtFIcvHt4Pfit3w54quLm6eO+8sQoo2sp28+h5pxkK53RHNFO4YAjoRmirA
+yPFto114enCfeTDDmvK7W8VLzZgiQsDI5HRfqa9ovrc3dhLAG2lxjNedT+GoknfcxZuQc5HesK8E
+wR594p1BTJPZRTgu6FiXbHHp+P8AStXwuzN4Ms0QqXF0S0f8TDkZP4Go9W8BXd94sWcKn9nyKrO+
+cbdoAx+NdNZaXHZyyCMxxhT94nnHTj8Qa56rUYcq1uaQvc5zWfBtuJTKVRVY8qF6EnqD2+hpPDOn
+2z6NPFqNwEQXDCEHJbaMdPxzW3qAZr1LWKVneYgZLDA4z/LJ+oqzZ6T5K4RRgDaMc4Fc0Oa1pM1q
+TWjijnvE2mLJbILYSSkj5W2kEj05rntLsQ0skVwgjijXczMOM/XpXcMkl1qrQI/7iFMYPTd2/QH8
+6oWFkyavcaZID5cmZI0cZH+0v8j+da07/CU2kub7zm9fgtNVgzbsmZCNpxgAZ5P0/nV/Rby7NvDp
+bxkT26Z83O4sucAj14rXvvCd2B5djKIoGOXiK5J9MH09qz7PQNT0rX7MzTgbnKGTYcOp/wDr10U3
+y+6yJ2mroty28yRjdLj5dpXBJP68VUtbaTdF8sZYyKcsQAQD0NdbcabOcgbWPqUp2iaO76jCs8Sl
+FOfu4z+FdCt0OayPSIf9RHwB8g4HTpRUm0KAAMADAoqyhSf3Zx6VyWor5s23aCCcHJ611YORg1lX
++ji45Q4PrWdaLcdBxavqc01jbkgOjx46/NwTWdc28sV5IkaRMjgBXkz8oHoB1710Y0q7j+Vi7AHg
+5qKazlTKtCJPdkz/AFrzJqSeqN1boc1d2EdrLBduwk/hkKjZxg9PzP5VBZA3V6TYWzeWnLyyHAHf
+8a6CXTHmieNoiY2Ugjpz7VFb2EtlCtusQCHIILZJrNX7Ddmcm0eoQXVxFaTtAHlLvIY8g8DpzWjN
+HLDpQv2eSaa3lR2kcDOARnp7ZFaR0u5hvSVgxETxt5xU8sM00L20cO6NgQx25rVSegLe4+8kWKIT
+NPCEOCrM23IrF1G5kFkVcptkbKMWI59Rnk/hVi10V7e+Es8aSmMExoEHHuM07UNITU50kuYp2lVc
+IQWBUZ9jitYvoxWtqhjeIxH5CXKr5kx2pg4LkdcAgV03h64jubpSjMCD911INcZP4ONzd27mW9le
+A5hDSY8vOMkcZPQV6VoVg9nbASD5gMZPU1009ZKxlJKxqnrRTSeaK6DMjVqkD47GqiPxUgemmBaD
+ZoIVuoB/CoBJSiQ1LAlKp/dH5VGRH3i/Sk30bzQrACiA9IM/8BFSRxQgfLCE/AVH5lODmqtEBzW8
+DMGaFCw6HFBghP8AyzT8qTzKTzKegAIYkbcsS59QKcW9sUwvTS5o0AC3NFQs/NFTdAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0049/full/!100,100/0/default.jpg</Url><Caption>29376_0049</Caption><Caption>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Caption><Caption>Exhibit</Caption><Caption>plate 082</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29E+X
+pT1UkcjBpyDin4qBEe2jGKkxSEUWQEeKMU/FLtosgGAUuKdtpcU7IQwrTdlS4oxTsO5Ay4GcE+wq
+HJLAeU4z3OOP1q5imMtKwFNkOaKmK80VNhllBxT6aOFOKz5Lu4WQ4HTtgVaRLdjSxQRWadQuB/yw
+J+lQvqVxuwqlfqpNJi5jXoxWUuqShcFAzeuCKkXUzj7gzSTFzI0sVm3Gv6XaXwsp7yOOc4+Unpns
+T2qP+2WQ4kgGPVWFedeJdPl/tGWTS7oSpJlng/ijJ9B+NTUm4K6KhaTseri4gO3E0eWGVG4cj2qS
+vCvsMUZk+0xuZiC7swyxz3P61TtPF2reHZY7ixupJLJW+a3lJKEZ5AB6fhUwrqTtY0dOyPoA00is
++x12x1CzhuYpU2yoHALDIBGavRzJL90g/Q1u0Z3GEc0U4jmioKFlJFu5XOdpxjrXLvqF0lxhpAyp
+nI/vV1EjiOB3boASa5Ke5jeVmCAL2JOc/hQ3ZEsWfUTIBtldRkNtIIrO+0zrMJYp3aXk5IPQ9qzN
+cvZo4GaMScHIyoAGK5K68YX7Wa2VqREzjmQclR7elYyqIFBs7i68Sy29wsEcvmSZ/ebpNoT/AOvT
+J/FgghhuZLo/vFISJXJLHOM47/WuEh042+nSztBv83jezc5Pf3rYtNPis7F766IVlXO9uoHbrWCq
+NtlyglZHUWXiYmykuLlZHJfCpJlePUA1m3uv+H7hh9rWRcNuA27wD+Fctp/i2xa/ex1VQ1nK2IZZ
+ODGT/Q1b8T+Cpkha70q4faOShO7j2zmqV29RpWRLeN4cnczNqFy8jcg7mTH8qy7670Z4hbmYPBG+
+8fekZj+PauLnN9aA7zubPO4DFS2/n3s7IjAEY6fStVFdx3Oo0PxJeQ6mkUE0zwZwkbjccfTsK9s8
+OC7ZRJcBdrDsuMV4B4cWXT9WjklHyBuT1xX0folxHc6ekkZUr6rWsW72IkluXiOaKG60UwI7mJJ7
+SWKT7jKQecV59qusQaMreTA7bR1PevQmG+IqehFcb4j05JrSWIQjOMHis6iugW55hqnia81hmjjU
+QxofmzyT+FYtqs1tdTySxYlC71DjgjHFdZoPg2/F75lzGPIAPLdSc9vauql8PwyIk0kcr+WeIcYB
+I6ZHp3rllZKyNeaxz+m+d9gj1LWiQsfMUIwMD6eprldb1qbULqR5SfKT7kK9AP8AGu61Dwxf6o6y
+XO5EH3YkPA/xquPAwaJg8Z3HpgcgVClZk2OG0rw/Hq9hNdTqu9RnB7V6J4AvDfeHzb3T7/Ldo0bq
+cDpn3/8ArVUh8EzxufLDxq6FWCkgEe/bNO0bwff6Dd/aLCR/JLZkgbIDe/19615k0FjG8Z6CYblb
+yCPdEeJlUcj3rEstJFs32lDvhOCSBytezTxxTQq8ibWxkqwrlotCWLWrgW6E20yhioHyg+1XGWlg
+Zi3WnQPcebDhk2hiysOOOprrPhtezTXl5BFuezRRl8ELvz2z149K5mLwp5OvFfsdxJBMrEGMkMnq
+p9q9Y0Swh06yWCCLy4wBwRg5q6VxSNE9aKax5orYkYjU4qjfeUGqaXA9DUonz2NK6AmEMX9wCg20
+B6xLUfnjHQ0ef7Gk1ECQww7ceWOOwpuyLB/ctx9KZ5/1pRNS5Y9gHbYiOIXPsMf405IYmHMRX/ep
+vne1L5uarlj2DUcbWA9UB+tKttAo+WNR9BTRJml8zmnaIairFFGSUiAJ9BTi3FRl6aXqgBn+aioW
+bJoqQP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0043/full/!100,100/0/default.jpg</Url><Caption>29376_0043</Caption><Caption>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Caption><Caption>Exhibit</Caption><Caption>plate 083</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xFwv
+TNSKuVyRg+lOjWnkcVnYoiwAaXaKdik6UrIVyI8UopSM0YqkkK44AUMMU0LT8Zp2C4zFLtFPxQRR
+YZAyPu+ULj3NNEb4O8L7YqcijGRSaHcpPH81FWGXmio0GWE5UEdKU1FZk/YoSevlrn8qbLeQwqzS
+OqqoySxwBVIlkxoxVG11iyvVY21zDLtODtcHFcb4u+ILWUsmm6Oqvdr8sk55SM+g9T+lTOSirsEm
+3ZHa3+oWWmW5nvbmOCPOMucZPoPWo9N1aw1eNpLC5SZVOGA4K/UHmvG7KC41i7W61S5lvJBwu984
+PsO1egeHtD0/S7lbu3uXEh4dTJkY9Kzp1ed6IJR5dzpdVu5rGxaaCDzpOgXOB0rgbT4h6raaif7V
+0/dZE4LwxsrJ+fWu8vNZtrS2lkPz7FztU5J9q4HxLryzWFwktqqSYypQZB5HB9Dg1dSbgrhBKR6R
+YXttqVjFeWkgkhlXcrCpyK8l+HPiE2GoSaZO+La5XzYQx+6/cD6j+VeoDUYG6NWlOXPG45Lldizi
+jHFVvt0ROKsxusgypqmhIjYc0U5hzRWRYxCF09WbjEYJ/KvM9W1aC9E1vtuPvg5UdcHPfivTJ/8A
+jykB/u9K8u1UPbyuxs3kAJxsbANZ1anLoCVzI1HW5LG9S5hgMbeQ4wT19Dx74qr4Ws4bpzJcyBjn
+cdx5JNRazFc6nboY7UQyR5Aw+7ep6ik0CA2qyC6Ji8wbArDBJ9vU1yTlzJamkdDXu0s7W4WaIeW+
+S0cqZGOSO3WrkGtxMmxYGfndne3XrVF31aUeTDZrHCBhfMQk4qzb2eqKqfu4Oe6qeK53VcXZENNs
+nkvXmyY7NgWHJ+Yn9aLeyEyM92smzlmWToTjiqrHUFuTEbmQAckLHmn6lqLwadEJJzJmTG7btx6Z
+rRVnNWHCNmc1qzva3cbg7ZEcN8vbnpXWSLaXErMXmRdoKmOTB9888Vw97MtxdKo5LMCST26mt5bw
+Xl2l1NHtgXiOMAE49T711U5tRKnFXOggQt5f2OaVSOS8zFh1/wA813eg3EM6t5Rk91YHiuDt7y3k
+AALIPXH+Fd74d8trYtHLvH1zWtObbtciSNVutFK3WitCSOYotq5c4UDkmvLvE2qW1pG0kx3AMSih
+sEjPOPWvU8BkKnuMV4z44+G2r3d5Jd6cxlDMSUJ459PSsasOa1yomefFem3TpFAjA/w9vzroraW3
+uYcS2qysBwQORXB6f4C8RLIplsSqhuuev9a9Q0vQtSRS0sGwYHQDJrlnBJ+6aq1izAWFopLMpUAK
+rZYn/GsltRsopmjvZCZWbaEY9/p+NaGs2OtyQmK0tnGFwNhxn8a4qfwd4umDGGxEWTks8g61m6Ll
+5CbR04liDmRZY41z+FU7+wv7uxbe3mQnkBVXn65HH4VW0vw/4h0mMy3lgs4UZIUkn8K6u2W2u7YJ
+tmQ5+aMg/kaz5Z02I4PSfDMd27NcQpGyt1+Y8duCcV19j4b05V83/XsOrMM8/TtSS6ZfDUV+xW7g
+c5YrxitJdO1W3jWQh5VJ+ZU4IroXPJbAPt9Pt24WJB6ZTp+VdLpkJhhIMap/u96p2VvKwGUdR71s
+IpRMHrXTQg1qyJMRutFNY80VuSRI9Sh/aqUbkgVMGNVdCLIIPYU4EVW3ml3mpdgLBbjgZpvm4PKE
+VFvNG80tAJhLn+A0qEHPybfy5qEORTt5qlYCfIpN1QbzRvNUImLe1MLVGXNMLnFAwZvmoqFmOaKV
+xn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0048/full/!100,100/0/default.jpg</Url><Caption>29376_0048</Caption><Caption>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Caption><Caption>Exhibit</Caption><Caption>plate 084</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD22NOK
+kCgjjBp0a8VIFA6CoGQlKNlT4ppFAEO2nBKftp2KLIRHt4xijYKkxTgKYEPlimmOrBFIRQMrMgAy
+cAe9REITgMCfrVwgHqM0xkHUAUhlFo/moqwy80UrICxGOKkxTU6U+mIMUmKdQSMgdzSuA3GKTFOr
+O1bWrPRola5f945wkS8s30H9aOZJXYWuaAFOxUNndR3trHcRbgjjIDDBH1qene4hMUmKdTA6sSAw
+JHbNMYmKaRUmKQigCsw5opzDmipuMlTpStKifeYD61HlhCxXG7HGa4rUNb1BJjG1tlwT8y5AFTUq
+KCuwSudx9oi/56L+dMeeFhxKgYcjmuLtrrUZ8NKqCPGcDOfzqhrGryafCzj5AflRU5Z2PYZrknjY
+rZFqkzt5ddsoVbfISV67QTXnd7qtrqXjS5muVfyE8qNFbg7MAnH1JNVEvLq6cLfWl+m4ZXDBg35G
+ormzjyJYVZSRnk4PFc9TFOWjiUoOLuelJ4j02KyVYJlLKAoRnywqnF4tSNt11hIVyWc8DFcVaeF1
+vR9pkuApP3mJyQatanFY2lmqiIXUyD/WSMcnHQcV1RryfQlQu9Tq7X4gaJeXiWqNNHJJ/q/NjKB/
+oTWhHqitDGFgclDjcMc4OK8b1O5lvI1e6WCNkOU8tQojH4d61fDniC/kuHto5ri4TCiPOWA65Ocf
+StVVlbUp010PUJtWuB/qrcf8COTRY6hcTzhJigB42hSDXJX02qiNZRGwdOd4OMVseF9QuLyYrcoQ
+R0yo/mDTjUbdiHE6dhzRSt1orQQ0coRmueu7RBMRtyCe/NdCnSqV3bkHeiFj2AGaxxEFOOvQqDsz
+JkiPk7FwBWDNp8kjnz1Uc5X5AQPoa6eG0nuWLS70A/hGRmnnT3MpJU7ccHNcns1L3rGnNY4q4067
+kiZDezbGHIDk8e2c4qjYW1rbu9rb/u/KxvY85Ndpe6ZLLEywfKfde9c6ng26uGlaS4njyeiEAN79
+KajbQLmXqGo2sR8sSMz5xtTliapS2c77POBt42bH7xhn8s119n4OtrRVL2zySjOX5Jb61MPCSXJ3
+3dsAsZyijkn8e1VylKSRx9lplvc3H7q3kkgjJBkdQoc+o9q7C3+y2FrllVffHT6ULpuoXDmG3j8i
+MAY3A5FPfwnOiFmaS4nPO5m4/KlGXNHmivwG2urM671uF22puYKOSFya2fC7Wr3BljbEjdcgjNVb
+bwldxStJtiUv15zXS6Zpps0zIEL+qirowk582vzIm420L7Hmimt1ortMRkbcVJuqkjmpRIaLiLIY
+GnZFVfMNL5hpNoCzx6UzeB/Aai3mjeaSsIlEoJwEP5VIr5JBUj61XDkU4OavQCxkUZqAOaN5ouMl
+LU0tUZc00uaLhYRm+aiomY5opXCx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0015/full/!100,100/0/default.jpg</Url><Caption>29376_0015</Caption><Caption>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Caption><Caption>Exhibit</Caption><Caption>plate 085</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21Fwt
+KqkjJXB9KlVeKUis7DIStJj2qUijFIVyHHtRipdvNBwOpApITZHjFV5L21iOHnRT7motWnaK2OwZ
+yOtefXksklxKZ5EUAjYrdTj2rKpV5HZIa1PQk1OwkJCXULHPIDCrWxWGcAivIdOaCTWWlkbbhd2w
+fxHPeuqfxJNDCuz5Yl4DF8DAqViFs0Ukzs/LT+6PyqBowetsf/Hf8awdG8XQ3kskU5GRjaw/iPoP
+WupBDAY6V0LlkroVyk1rHn7i/lRVwrzRS5UO5YBwMmoftMZmSMZJcEggcf55qRzthY5AwOprm7rx
+XpljO0bS7yp4VO/45qtkJnTYoxWFY+LdNvzGAzxmQ4AYd/wrSvdUsrCxlvLm4RIIhlmzn8PrSuiS
+S8n+y27S7GfHYV5R4m8d2ouxAbqV5ASGitwCVPpkkDNZ3iT4gan4o82x06M2Vl1V/MVZJOO5YjAP
+oOa5W10tIIlk+Rivys+8NknocA55yTjnge9c1R8z30LUe53Nh8TrfTIjbX2l30sO0EMXViM9Dg/U
+d6qyeItN8QSb7ORluWyUh24dR2znr+Fc9PaqJkTzUEYzyUy6qenOT09cduKg1/TbFX2W7xpIAed3
+zcKOOOCRzwP0pW5kkPlR2KW8GmWqTzMJbtz8zDgAE9DzWfqthdzMslxcIkTKCEHGB6Y/KuO0nW5o
+LmGW8jW6UcI7dc9Qc9629S1stHiJirvySw9ulEabjLTUTLukvHYamjtI8kaH5SQMD9a7vS/Ft1c6
+vb2zIRBK3GQNwHvXmVrds9sn7tXYDOc5P+FdR4Kmmm8U2ysgEZXOSMDOD0rpje5J6/iin4xRQWVd
+Xm+zaNdzc/JEx4+leM2SxX8csxBjlWQdTnIIr17xJJLH4bvGhTe+zAFeA2Ut/aXQ3MrQbuUSQAkf
+Wpm7IXK2dik0Gm232p5H2Id20JyfauW1jVm1Z0e5nfyZn3xxZ+VV4AAJ46lScjofpS6rqTm1ihj2
+xCSZEZS53sDnkYBGB7muf1K2VIbWZmkCQ2gjA34IkzyT146cVgnfcrlsXdMeI+ZLcv8AIck7MKdo
+J4GTj8KqreXct3LNZS7bJ3CqJ5QM4HPVsZ/GqNx5WlxOst8JY1zHGIiw83198c1VGrLLMEEHmJ92
+ML8uPpQluxNnU2jzRE3gMKi2UK5hCkKvOThTz16nrzSahK97aG4eG1d4sBcGNWAPIKrlivPoQaqw
+20jWxzBLa5XO93GB75qHTJLl78wxXBYhdoML7Rj6AYpp3eg1e2pqabY2Wp6e9koWC+kIkSR0yST9
+4LyADVSQ6g1zbWdxps8c0gbZEynLAZByD0zg0jQeXrDRRANHENrbD1bj6dPYVea6uyjCWe4bK4Cl
+yNv1NbJolvWzKOn3xgxFLbtC0seR5qcgZx+fFd34FuIzrUCu2QDhdwzg+3pXJx2szWEomuLYJIow
+suWYEHggjp3/ADrpfhyI/wC3o8sMqeW6hvQCneNxHtRHNFKetFUUc/4089vCF+trII5WUAM3TqK+
+fH0HVbiYsbyPJ/u5NfTVzClzZyQyAFWXBBrze+0SK2uZPLHy57DgVMnZCdzzrT9C1K0uopWvMgNy
+pHDD0IzV7U7G5nuoraGP5FXLSEngg/L9c4/WtuWymeXIZiueMf4VVc3TkLHHKRnrnAP6VzTs3cFO
+SOJ1HStYaWNGtonSDIjA688nOaqrfzW7NDLpzLJHjLIvI49uK7O6OqRuD5BC+rpu/pWZM1/IGkh8
+vLcMUg5OPfFVGzIc2ZT+J7LYg+xpI+Pm84Hg+3/6q2NP8TaZLAMO9vKvTa3Bz19/T8qwr20uJIXW
+ePJYYDGMcVkDRJMbhHKGA+8vQfhWipxsNVD0bR9P0C7JmYrLcSNveUkE8noAenFdStv4XP8ArkdC
+OivkZ/WvGo9F1FYTJbyB+5CHDAfSkt9SvYZNjTyErxhm/pTcPM0TPa49E8LXDCQROy5/ikIH6Gut
+8NaZomnzEadYxwuedwGT+ZrxjQvEWouotpWiKZyPlB5/pXsHhQXW4M+CnfFRGVpco2tLnXHrRTSe
+aK2JI0ORiq11ptvdj5xhvWkSbipFk+v50aNBYx38LxbgU2HHqKil8MFzyqEfU10HnfWlE3tWbhFi
+OYbwl8u1VH/fRqhJ4Ic52RjHpvIrtvOprfOc7mH0NSqcRNHB/wDCCXDOP3MeB/ebP9KJvAuoYzbw
+WIbv5mSP0rvFXA+Z3P41N5mBjmtFCIcp4zqfwt8SX7sTParG3OyNyB/KoNM+DOqQXBkn+xMAPlWV
+iwz+Ar20SUpeq5EVdnlWnfC3WYJZTLqVjawyMCYrWNjx9TjFem6dZJp1lHbqdxUYLHqamLZ9aYWw
+c801CKd0Dk2OZuaKgZjminYVz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0031/full/!100,100/0/default.jpg</Url><Caption>29376_0031</Caption><Caption>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Caption><Caption>Exhibit</Caption><Caption>plate 086</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tI/l
+qRYyB8xBP0xT0HFSYqBkW32pNtTYppFKyAjK0u2nYpwFLlQXGbaNvtUmKUCjlQXItg9KaYxVjFIR
+TsO5WMVVmhnyPmiIzz8h/wAa0CKYy0WQGc8XzdKKssvzUUrIZaQcVJUFu2bWN27oCfyqK41O0t1y
+9xGv1bFUQy5UckiRKWdgqjkknFc1d+NbRTttA0yg4abZ8n0H94/TiuM1aW/1yQnUpyI/4LdeFUf1
+NY1K0YlRg2eqxXVtPnybiKTHXY4P8qmBz+FeHJp0Fqyyqzwvk7ZImKsgAyTn/PWtbwj8Qby21Uaf
+rU3n2kq/urgr86Y6BsdR+tTCtzA42PXAKdisGTxRpwCtHcxuTgKAepPrV5NasfJMj3UYUAsSDwBW
+6ZN0aGKTFZ1rr2n3kQkjmKg5wHUqcDvg1ZGoWjdLiP8A76qhkxFNI4oWeF/uyIfoadkEcEGkxlZl
++Y0U9h81FSMqzs40RmWMu/kghAcZOK82nkvZJmAtEjZjzlwWH5V6dMzrp7FEDME4XOK4TUplh3ST
+FI2P3gHBx7VnVk4oFFPcpaZeadYhhJBl/u7pJATkdgg6Vmanq009yyW1oVQ9JHHrznFVbrWLGJ2a
+BJZeDuYLk/rWBe+JriPKWkG0dcvXE1Uk9IjlMsTNeXUixyXARVOMDgE5/Wrj+GJ101Ls3JaYnMSA
+chckZOKNOSDXNKWeEqJ42UXCNlWBPPy+ua00e80hpHgtpZlEexPOmB2/hihXTtIUU2rlDTLDUY59
+pl8wAZww+n9BWvDeymfyBaGeFCrSBGzwDnHp29axJfEup2jBpLDZ6MGyP0FdbaQpcWQmvGjVmT5s
+ADfx1PvTjOa3KjFMlJjkiF1MVjklOBEeuPf86SOYKMK5z6bv8aqJpVtdwSsIh5aAbTjsfSuK1uK5
+s+bWeTy1P3N5IFbRnKT0dhygjvpNfhsiBcTuEJxuU5A+uK67w9qNrdoBDd+aWXcoLZyPb8q8OXbJ
+bxyZbdIuW55JyRivQvhvZ+XqMkykMvl4JB4H0rojJ7Mlx6npDfeopW60VQhqgeQVJ4xivOvEA0qO
+Z90gLf7Kk16Kh+Q/SuQ1mzjjZ3WD5T1AUYqKnNy+6OJ5+/2ZwUSBpIyf4gBVK50yO5dSlq4xxjPA
+/Suha2VJwywsVXnHOD7VYhujJGY3RUx0GcV51WrWhrYahfdmFoKLaPNa26SSSb95CRkgY4x610fl
+3t7Nzay+VxlduCR3rDv5L0ll3ssec4QnDfXFVLNr+znE9k5SXGCz8ce1YKtCUrt6lLTQ1NUltdO1
+WW0umKR7PMDrgkUyK/sWRYreKW6L5YF7jBP4AVCVe4Jl1J0mkPLMTjJ9KqiziedriImObOAVIGK6
+lyW0ZWp2FjrWl2WmmO4haCc5DBdzjH41yd0trfXbrHcxKspOxjkBfrkDFWYYLszKsl7HJGeSsi5/
+WtNbO3iQ7YlYnqQOtDrqDV19w1ExG0y10uwgtt0F/dM3PlZwoyTy3413ngTTxayyyqJFDLjYTkCs
+i2s/OQrHHg9OFrs/D9ibSE7l+bHWuilVdSV0rESVkbDdaKax5oroMyONqJYYZ1xIoYe9V4mJVfcV
+KD7CncRG+lWkg5jH5VTHhnTt5by+TzyAa0t5xilDmolGEt0O7MyTw3ZONpGB6AVXbwlZEkqwH1rb
+3mggEEYA+lcn1LD3vylc8u5gSeELSQffUH1PNKngqwzvyPTgVuooGcjOfWpVO0YAAHtWkcJRWyFz
+MwV8HWaE4YY9CtTx+GLZFCs5YfStjeaN5q1h6S6BzMqwaVa2+No6VbyoGFx+FNLGmM5FbRUYqyQt
+WDNzRUJc5opXHY//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0030/full/!100,100/0/default.jpg</Url><Caption>29376_0030</Caption><Caption>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Caption><Caption>Exhibit</Caption><Caption>plate 088</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOPi
+nKpOcrj096kQcU4cnFYWLIylRTSx26b5GCj3qziuD8eX08d/bWkTEL5RkwO5zisa8vZwci6UOeai
+drEyTRh0IKnvUgWuZ8C3rXmjushJaN9pzXVgCijLngpE1I8knEi2Uu2pMUpFbpEXIdtJtqVyqKSx
+AA7ms86h5UipcIIt7EKSwwfb607IpEzCTnEWfT5qTYSuWXB9KsAhhkEGkIpNBcovFlulFWWUZoqL
+DJWYpC7gZKgnFc/L4tsEnliMhzEvzY/i+n5GujH3D9K8iu9B+0Xd7cLIyEzyrjGcAOQAMf4VUpKK
+1FY6OT4jW0Mrr5DuuAUP+NYHiXXodaktruKIrJbZWQHj5Tj+VcrPofkicsJmlU8bn2/57VktNfW0
+7FNgj+6A4z7ZBrnc41bwL5Z07SPSfCmux6TezK3zQXAyuD/EK7uy8RWV5bNIG2uoBZT2zXz5aauL
+SQW825UY5Abnb7it2O285lkN9Iv8TBj8uPUH6VlSk6PuS26FVf3nvx+Z6RdePYobkrHH5qo4VgnP
+H1rSsPGdneSrC0bJMeNvXmvLbO50+JzEtz5TlSnnLz+orqtIfSopxe/ame6K7Q8hJUKPT0zXTGo2
+9jHl0O2u9QDzIigBM9+pNc14p1wadBvklU8ZVT1Nc1r3iqzsbu5ltLvZcTDBdTkr/u1xY1WW+uFv
+9VlaZEOEDdZW7cVdurLSOxsPFt6jAvKyuQWUE8AelejeHdZbWbISsqhhwcGvGEnmu5Eso8ea/wA0
+xXoB6fhXpHgVWiu5YVKiFY8AA9TnkmqTBnaMOaKe3Wiiwhy8x5bjjmvNPEOvaRZXU8WZ3JYk+Wp2
+lh3616USBCxYZGOa8m8TTW/2t4Yvkd3wIwgJJPPcVlVeiBGMfEOmXdyq2yFH/jzCvP1O6qHiO6tJ
+tJiaKPbcAEYA64PGKlk02WeNrU2zKH5J24zV/TtHFtepLdR/6JBFuJI6MMY/rXHe0k0aqzi0ZFv4
+XR9KivtbmELNgpDnDe2T2+lVdQm0yB42muHaKPhLdT8pA9areOPErTzrbQuWCnp6VzWlhtRnYT7n
+Crnk9PSulXerMdnY6STVZLqLda2cEULcDdzmo31W9MAgacRL0G1e/wBarNH5car5vl9jGDjHpz9K
+v6TZTXW+3ZVkXPGec1qrJXY9Wc9cWjxXHnyPJIQc/MuRSm7nkuUuZmJjjOY0U8Fv6V0WuW/lGaEx
+HYRkEVg2QVbceeu4M5BB747/AFq1JNXDXY7Tws0f2JpmkVrmVuVDDdj6V6H4J0u4h1B7uVmZdpAB
+G3HPpXhBuxBOyeaFaMmvUvhX4yubvWv7EuJBMroWRxyVwOhzzU8rvcLnsB60UrdaKoBrMBCxPTBr
+ybxFDbalqEgWJ2kOAVjY846Ej1r1Z18yBk/vDFeca1bazZGaGx8hdxPKr81ZVdkOJjSy6xcz25uZ
+ksIYEEandvdlHcKOAfc1leJvFqwaabO1JmC/I0jNuOff3qC50PWriQ/a7593XYq8fjTYfBpkkUSE
+sxUBiq4yfU1g5RHY82l3TXDMNzM3Umt+0A0nS7Z4oS9xcShip4yAen+fWuyn0bQtJu0iaNpcKC0h
+Ubc+grMuprOO8WcW05VTnBHA96Upt6BFJbkWv2MI0tbqNBmUjHPfjNY81xqNvbLd6arwNNw44yOa
+6K71nSrq1WO43bQ25VCnrWYdX09P9XBK3++hx/OinUnZKxq4Qu3cyYbrUX5lY+c5O/GeR6ntmnu3
+nzDzCFCfewMACrH2ya9m8u2s53dv4VXH+Nbmn+BdY1QAXCLbQ/ewO59/WulSS3MrNs5G5hhkf7Qj
+bjI2SvcV6d8GtOg/tqe7V8TRxEFR3Bqza/C21EQ3yyF8de35V6N4X8O2Wg2Oy3hAkb70hHLU4Svo
+ElY3GPNFMY/NRVEjI24qGayt5yWZAHP8VMilyAfWplcelLRrUCgPDlkPur+fNSrodsqEKME96uiT
+ilElQ4w7BdmPJ4R0yWUSSRbmHTNRXPg7R7lDHIo54Izit7zKXzMjkVPJDsF2crB8PfDtudwgQv8A
+3mOf61aHgbRSgxbxlfpmugDhegxTvMq1CHYLsx7fwpplr/qreJP91AK0E0y3QAAEY9OKseZSeZVq
+MV0C7FWKKPAAAp24Y4xUZkphkqroQM3zUVCz80VFyrH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0026/full/!100,100/0/default.jpg</Url><Caption>29376_0026</Caption><Caption>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Caption><Caption>Exhibit</Caption><Caption>plate 089</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xI+K
+f5dSKtLtbPbFY2RRFso2VMQFGSarPeQocbs/SlZAO2U7ZVY6jAKj/ti3Bwf50Kwrl/ZRs9qqrqkD
+VML6Bv4qqyC4/Z7U0x+1L9qg/wCei5+tSKyv90g07IZXMdRtH7VZaIkk72HsMUMvFFkBmtEN3Sir
+TKM0VPKh3LiiiWVYU3N0pyisDxBqHkOIh6c0xC3uqbshTxWHqF5dpaNJaRJLJnAV3K5/HBqg18ZZ
+VUsEDMFBbpzxV/7NPG63D2rSiLIVlO4N9RUslsw21vVftiQPpOyPhpJjcAKq5wcccn24rUWRHOUb
+KnkHsa5vxhapqFsSYGjlXkfJjPtXI6L4mvdNVrCd12r/AKrfjKn0p2vsiU9T1kXSRIGkkCgetUbj
+xCFbbEcD1NcTLrUki7pJMtVCO/e7u1hEyBmP8TAU9ldlpX2PQodVDtnzfmPvWxaa0YmXL5rgUtDG
+VCSSM7AkEj5Tip4b5lbaxww6j0pU6sKnwluDjuev2OoRXqfIcMOoq0wrzvQNUMd4nzHmvReqg1bQ
+isw5op7DmipAnWuB8a3q2d8xYPyvGBmu+XpXD+N7P7RMjY6LgZpSdlcErs88bW4nl2+TJI2cqhXg
+kcjuO4rc0ab7Tfwag1/OuoLbKklk42o2M4ZQevJJyCetYcuntBcJMiZKNnA71Z1fSLbWoIZLTUBZ
+3SDOfuMPriiE1LRkVItO5i63pUtpDdfabu6lSeQyCN5MlSTnr9a5rRdB1LVtXVrO0knfPLHoB7sa
+6Wz0rWrjXrbS9XvVubV2ws0bBjgDOD06161bxJZiGz0+CKHCZJxhUUdz61c58uhlCN3c82HgDXBC
+0krW8aquSGkzx+Ao0DTI3FxazQJ5sU4LsU5HGQM+tdbf+MbzS9SVY9Pae0RwJZHQq7gjJZRwAMHv
+1pkU0TxzXwBAnYy4PU55A/LFeVmOKdKmlHdux6GGpc0tSmZraLUlglYDfhQCMDI4x+R/Suc1+9tY
+NTRYZczKMS4HGe34461pakEvLkOcAdfSq2paAl9ptxdLEUMSeYJNp59ifengI9eyNMSkvmN0TVle
++hXeclh0Fe8J/ql+grwPwhot1eXybEG2Nxliele+qMRqPQV6XNc5JKxERzRSt1ooEPU8VheIIlmU
+bhnFbSnisPXtUsbDAu5fLz0yhOfyFRUfujjucnLZLn7g+prMu9Hiuv3ZBGc8p1rZfxJoRY5vUUe8
+bf4VBJ4i0ADMWpRCTsWRsD9K4JN9DcwtO0yOSIYh2TwtsY45DDv/ACP411NnqFxb7BPHvKjG9RyR
+7isG21TSo57mdtdh3SvvCJCwGcAYJI5HHtWmviPQ3QZvYxnsQeP0pKpJMTimax1PRZYRDfQNtwVC
+zxEgD0B54/Gq11q3huOM7xCqDjIUgCoBrmi7eL6Ij0IP+FU7698M6ggW4vYht6YB/wAK154y+KKf
+yJUWtmKmqeFeZ4bV7s54WNSVz75NM1S51PxDALaGFbWz7ooxnHr/AICltp/DMVys66iruAAMk445
+5AHNbEer6O3KXkWT14P+FaqdlaKsVbqw8JaIumEAElicsTxXd9q5zTdQsZZlWKdWY9gDXQ54ralq
+jOpuNbrRTSeaKsgYj1W1DS7HVECXtusoHTJIx+VKjmpgxpaMDDfwN4cl+/p35TP/AI0wfD3wuOmn
+H/v/ACf/ABVdBuOKXcaTjHsF2c9/wr/wz2sXH0nk/wDiqY/gDw4nIspse1zJ/jXR7jTtxpckewXZ
+zi+BdAY8WtwB/wBfcn+NTf8ACB+H8Y8i4/8AAmT/ABre3GnBjiq5I9gu+5z48BeH16QT/wDgTJ/j
+Th4J0ND8sEw/7eZP8a3txo3Gnyx7BzMzrPQNOsJRJBFIGHQtM7fzNaRPFMLUwsaaSWwtWDNzRUJJ
+zRSuM//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0029/full/!100,100/0/default.jpg</Url><Caption>29376_0029</Caption><Caption>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Caption><Caption>Exhibit</Caption><Caption>plate 090</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FUwK
+cFBGR+oqTFGKiwyIikINS4qnPqNtA2zfvf8AupyaNEImwaUCq8dzJLyIgo9zzVtOeoxQmgAClxTs
+UuKdguM200pU2KCKdhlSQKgy3A+lM2K4JHPbpVwimlaVgKBgGen6UVc20VHKhk/UZHSiorIlrC3Y
+9TEpP5CpjVkmNqmoET/Y4mw2MuR29qbBaxxrv4yRyayplaPWLl3yWZz27VsQHzbdh3xxWb1Yx8cp
+z6irqSArk8YrEtZ9yjnp2q4spdwg/wD10kxM00ffyOlSCqMkhj2qOPWrcLCRAwOa0TAkxQaWg1YD
+KQin4pMUmMixRT8UUgI7H/kH2+evlLn8hVT+2bFpmiFzGsinBVzip3do9JLqPmEOQPwr591fX9Tt
+dQlLQ7RvPzMuR+dAmezaiyy30ckbqd4wSpz0q3C/2eGSR+NoJ+tcR4B1OfV9MaSZVBjlIBXvxXb3
+wIgjjDIGfJAc43EdBWbGULWxcoJPN2bhllx0ras7YIvmHlj0zXP+HYdSRbiPU1AleXhkk3KV9vSt
+bUdQSy2w78TSAiJfUjqfwyKlWEV9VvUhkWHeTJJxhf4fc1Lp+oiBPKm+V1OMGuc8SXkXh7RH1CR8
+zuQsZxnLH/8AVXOeFfH73mpiLU3ifI+SYgKVPoa0SvqF7Ox66lyWAIQ84x9DU+7jmucuNWuLbTbq
+eO33CCFnRt3J4PGPwFeaj4qeIFkOEtXUHoUxn9a0iribseyz3KxdfUZPpU4IYAjoa8XX4p6ncFhJ
+pdsT/vNzXdeCvEl3r4nE9vHFHEBjaSSSaclZAnqdbRS0VBREyAWZQn+DGfwrxvX7CMXUqpMZQSSy
+Ov8AKvZSoeMoehGDXFat4UR53n5Knkisql7XRUbdTkfDesjw9atCtqJIXff8pwRW5P8AECG4QxNp
+bSDBA34xWVcaOTcMsaSFB/s4FV30icv8sTH6DpWTqMfKdT4Z1uzWwCPNHbyLIxKPwOTnj2o8QBbm
+8g1KC+hMkAKKhGRz178ViR6PE0KC4Z1kz93AJNTpo1qiEswVh1LVCrdxOJmXXi65kh8iazt5ozxh
+gT/PIrgb6e0ttRZYYtk0kgAhj6Lk11PiOykV47eylQux3SbOSo7Vl2XhyaTWxOYi5QBz9ela05Nt
+Ckkk2X4PE2r22ly6eJC0TDZuIGdv93nPFc87mEkNEGYn+Fea6yTSnkk2eU4B/ucEVUfRWj3v5RyD
+1I5rsTRzKTe5iwh2AJUo3TBHNet/C5CLC8Zgc7wM4xXD2ug3U54gkBPIC5/UV6r4Q02XTNMZJU2s
+7Z+tEnoXC9zoqKTNFZGpEGp27IwRmq6MSKkBp7gONvA/3oUP/ARTRZ2oziCMZ9FpwNLmpaQERsLQ
+tu8hN3rjmqs+jadPky2mfoetX80A0uVAZg8O6Rs2rp6gD04NTW2g6dbMzxwYZ8ZJOav5pwNUopCK
+x0uyP/Lun1xzS/2bZd7aI/Vc1YzSE1QWQxYYUOUhUH2UU8mkJphNAxS1FQuxDdaKVwP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0013/full/!100,100/0/default.jpg</Url><Caption>29376_0013</Caption><Caption>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Caption><Caption>Exhibit</Caption><Caption>plate 091</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7Lg
+cAZpRbnaNwAPfFQ65eyWFj5kRUMTjJ7Vwt34n1aFDNDdLIQPuADB/Cs7A3Y9B8gUnkiua8J+NYNb
+BtbzbBfJxtPAf6e9deMGlyiuVTCKBF7Va21ynjTxBLpdkbKxfbf3ETMrgZ8tBwW+vPFFkhasXUfF
+2haZrMGkXFyWvZnCeXFGX2E9N2Oma6EW4z0rD8KeErfRLNZZx59/J+8llk+Ztx6nJ5J966jaKtDK
+n2cY6Un2Zf7o/KrmKMU7DuZ72nHyKufeo/sQOdyJ+ArUxSFalxRVzIOmQk58pP8AvkUVq7aKnlQX
+MvxLbfadMIzjB656V5+2leYjLuXrweleka8dujXD+Xv2rnbnFeVLrtjI8kZEkMwBIWQkZ/GlUlYl
+xuUrnRJbecziNgVORIr81uaXrN05EMoaYg7SyuQwrmrbW7x7t45vLaEnIJbbtFbVsjXM3mQRtHJ0
+OTzXPKpoTy9jubfVLu3tfmYMijhpOTj3NcjrYudQuJ9SvI0h3KqQiQjcAAcBV/3iDzTU1H7ZDDZO
+J2aWTZF5R2+YRklg3YDHJ9x3Nc946vY9L3fZoIRcx7GkmZiXZ+Rxnk42oc1UG2rtmijbQ9RHjW03
+7Fs7k47/AC/41oWviWyuXCsk0Oe8ijH6GvlxFlkt2mmuXe8zuZy5yuf5V6B4I1zUrTUrfSNXcyw3
+S7rWZzkg9dpPfocVvGdyXCSVz3SK+tZ/9XPG3tuqcsoGSQK5J4lUAgL071jXs0kbnyzMcf3Gxir5
+xI9G3qejD86AQehBry+31bW4XzG8hQHpNgj/ABrr/D2p3mozMZlREVeQvc0XuM6DFFOooGVtRjEm
+nTIQTle1eC+LNOeO/R4SMEdD1BzX0DLzCwPcV51q2lW7XjSKEJHqucVlVdtS4HmcenXV5AHhWdST
+iRBwPfBrodKR45fIu7uUExlCgKAhcfxHt+ea2JoPKtpQm8Aqc+WuW6dh61yFv4W1C8l3TGaOMOzR
+xhvujPBb1OO5rkt1bL0vY3f7MvLeCVrW7Mq/MFjDY2L3Axg//rqne6emtW7XE8U0ihcordQTjk+u
+BnjityE3dtZG2uRJK4wIj57RKuMDkpye5Oc1RvIRFplxcl5lVVDLMZiu5u20BgeOvzZyKuHvJWZL
+dmzi7Sxmg0eY3UcS+Y2IGAwZB9KuXVlcQ+GtN1DIJs3VsBsnaG5OKrRwP/ZsWtmJpJbR90iPnBQ5
+4A6DnHT1rX8JX1zqum3mksI7fT7qQsHlOSi5y2OlaxQ2zV1HV9Lt8C3LtIygx7H4Y/hVWx8RzG/j
+juIY5LUnDsI8kf41yGt2T6JdKbaV5LSUZhmGQHA4yK2NF0yQQxXDyEs4D7AMe9NRstyOXsdofEnh
+pZfLlVkIOObc/nXo+hQ2qWiy2mwxyKGDIBgivEbzSrvUbiKO2s5C4J3MSBnNenfDvTdX02ymjv5I
+TbjiJEbcVx1yauFwasdrRRRWhJHK22FjjOB0ri7iCR7qRyMgn7ortTypFYl5b+W5OBzzkCsqquio
+vUwxAkCgso54AFK+cZZUjjx3pk95FHISgMrj8hSLdJdQYMsQlY4AzmuKSNSnKIrm3kGSqOCNxGCB
++NecauBp+orYSmdIS+5EbJSVcADDdsY6H869AvbS6BMhBKj+L/61Yt5ZxajH9nuYRJESDjJBBHQi
+iE3F7EuNypBpjalpc0cEg8qSNkK9Mn/HIq9onhb7DZwxSkMVQBsdCe9auk6bb2dsUiDhSxYgZJya
+30ULEAqqR7mrU+w7HM6xpVtrFg9ncxH92AI2UcjtxWNpaXeizW+nXaxvvB+zygZ3BccH0OCK7CRP
+KmZiu8E/wgDFLFYxXE6v5fI6HHIzWqlfRjsJZSkuCsYD+uK7TSYkiswEQLkknHqaw7XTHRgVjbHu
+K6W3Xy4gMYNbU0ZyZLRTc0VoQRhqDsYYZcj3FQRMSgPtUoNIBsllbSptaFcewxVOTw7pUzKZLRWK
+nIySa0N1LmoaT3QylDpOn2rOI7b7/J6kf/Wpp0jTRljagZ5JxV/dS5zS5Y9halNNPsQDtgOPanCz
+s/LK/Zm2kYI2mrYOBwKXNUox7BdlVNKsVUBbdQPfrU8drbxDCRIPwp+6k3VaSHccSB0FNLZpC1NL
+UCFLUVWkkIbFFK4z/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0023/full/!100,100/0/default.jpg</Url><Caption>29376_0023</Caption><Caption>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Caption><Caption>Exhibit</Caption><Caption>plate 092</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJSj
+5h0I+oqULSlagZCVNJg0XdxBZWsl1cyrFDEpZ3boAK5K2+IdpqE7rpmkapewJ964ig+T8yaTaQjr
+MGlwajsby31G1W4tn3I3qMFT3BHY1Q1vxPovh6POo30cb4yIgdzt9FHNO8bXCzvY1MGjbXn3/C4t
+D8/Z9h1Dy/7/AJY/lnNdZofirRPES/8AEtvo5JAMtC3yyD/gJ5pRnGWzKcJLdGrtpCtT7aTbVkld
+lCqSTgDvUOUc7VZSfQGrpFMKD0pWGUjFzRVvaKKVkBZFISB1OKUVx3ibxfZ6TcG2a9WN84YKcsB6
+ADvQ2ktQOqmaF4ysoR4mGCDz+lME1vbxKEj2x9PkXAFeVP40tPPZolnmBHJ2Y2ntg9c1VPi3WJ2J
+tLG6B3AqTJj6jHvXNLERW4WZ3muGXSpvO024EH247XGzIDD+Ieh7Vy+q+FNMtoFvnaWW6dwZZZpC
+xf1rD1vxTqcVhby3dssMgmxEpfPbv0rDu/FOt6iAVj84pkbViJjHbrkZrkm3UlpsbwfLG56zYaVo
+scITybfJHtk1z3iHw1b2M8eqaQ32e8hO9HQ9D6e4rmdK8Xa+k0cL6XbGJhtYD5c1uaXr7azDcbgv
+koDjJ549apxjGN09hwm5M9E8L+IofEWlLOoCXEeEni/uN/ge1bTEKCWIAHUmvALnxRd+FNU+3aaq
+SFomSSJgdr4PHTv/AI102h/E+LxASJIVgmUZ8hicn3HrXdSq81PmZnUhyysj1XzYz0YU4YI4rjl8
+RAqCz+XkfxrkD8q6HRp/tNoXEqSDONy1opKWxFrF0iikkfa2PaigCfoK8A8V6npUuv3UiuwbzWBA
+jJJ56175M4jgkc9FUk1816vcWR1Gd1kAkLt8yg8g561jXeiQ4pdS1Z6vpyuv+kRALzgqcn9K6W28
+X+H3tQ0l0qSA4CyKR0rzvfZpG+wkkkZbb+lS6dbWE10guAzQkNklTtBI4ye1eZUows22zS66Hcpr
+Vh4juJbITxNbpjeMcH8f8KsGPSoB5SyKyRAARh8D24rziPTIpL64S11COCNGGG3E7h1xx6VEbFjd
+bW1DzQW+8CazWHV7KegXv0PVUt4UiztWM9gOa5PwjaST3+tWkFzh1nysZ4Z1GQcVTsA9upaDU9rD
+AEbNnP0z0qYaKs9000zmMMd5kt+JN3PfPetaKUeaDe5S0d0V/ENktk9wZJt0qnBXOdg64+tYfh6R
+P7bjumJWK3JbI4LH0qeTR72PcR867iSrPktn1qnhrW6EMkYQkBiMEZ4GOlehTso8qZFSTvdnqKav
+bTxZfJcjJ74Neg+CZEl0iQohUeZ1xjPArwiPEDjBMLAEbCxwx9fWvYPhXNcS6Dd+fJvAn+T2G0cU
+6UeVkN3Ozn++OO1FSSAFufSitxC3C+Zayp/eQj9K+Zdbs3tdQmVsArIQCeD1r6czkYrynx54JuXd
+7qwiaVHJJUckE+1ZVk7XQjyULGG+c9f7pqRWWOVdhZSRgEirTaXdabJ5VzbSpz1KHFDQMWPkpvAH
+WvLqVPe5WOxClvaTOytkSEfKx4w30ot4sH7RkAR/Lz1Y46U8Wq8k/vDnBXOcVbit47Z0Vk2jOeTk
+DNZudhWLNlpwEMtxtDS7WOAM7RgnIHetS10g24SSW/MqtuIMqlMptyCo65zn2qjazOt04t5GV9oC
+umcCkvtT1e0IjMzSE/xcAL9OM1vSqXVmXFpIk1VXgFvMG2GXrEByf8KxFme5uQ0igso6kY6Hj8qt
+vdm18y8aQTTyfLGp5Cj1zVaCCW4fcF3McnCrnJ966Kc0xSbbJNkQcv5aBm6ncWIHtXtHwvjCeHJS
+oIVpieR14FeX6LoOpatOFh06QDoXxtA+te3eGdJbRdDitHChwSzbemTXRT5m9RGq65NFKTRW4hgN
+O3e1QqaeDQAS21vcLtmgikHo6Aj9ar/2RpmAP7PtcDkDyV4/SrOTijJpOKe6AovoOkOctploT1/1
+K/4VFJ4d0WQKJNGs3A6ZiU4/StPNGaSpw7Bcz4tC0iEfudItE+kSj+lOPh/R593naTZkng5iU5/S
+tDNLmj2cewXZkf8ACI+HvlH9j2mFOQPLGAfpV6LSdOt8eTY20eOPliA/pVrNJmmoxWyC4iosYwka
+qPbilJ4pCaaTxVABbBoqGRiGopAf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0027/full/!100,100/0/default.jpg</Url><Caption>29376_0027</Caption><Caption>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Caption><Caption>Exhibit</Caption><Caption>plate 093</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3ERYH
+AGaeE4GQM96exCLk1CbqL++v51Fh3HlaTFQG6jzjzAaq3GoKqkAdP4ial2RNzRxRiueXW2t5Mk+Z
+H3Gen0qdfE1oTgowPpTViedG3Risk67G2PLhdqtQ6h5nJjA/GqHzFzFBWoxdQ45OKlV1cZU5FOxV
+yGRXA+RQx9zimhHIO5QPoc1axSEUrDKRhyaKtbaKVgC8LC2JTg1y9xfLbN++uY1574rpNWQvpc4B
+wducg4ryS+sYyzfNL5jMOWOcCpnPlRLOpPiS3GcShz/CAvX3qlPrwZsvA/J78j+dcfFbmKd4WcsU
+IKYPVT7/AKVsf6SdOdYEVrjG1Pr7Vzub7itc3VvUuEAEkak9FK4z+dQyE7/mjXcOR1FcxHqt3Nbm
+G8hVSpKM6nJ4AySP8Pyq7bSzwwFEcyLgkZOcfSlCoKULPU6myvxED56ABR6j/JrROr2YjO0sHHVc
+ciuBku1Kb3MkRToACetWrLUbRVA3SSZH3tpNdMZ3Fotjon1a+SfzFVWhJ4U9R+NXIvEAUjejIfY1
+hNqUbxbIztX1INPF1bMgDMjevFXzFI6qHVd5z5uR6Hg1tW0yzx7gc1wkM9krDbNt9ua7DRJoprVv
+LOcHBOKOZMpF/FFOxRQMqaxJ5WjXcnXbETXj1hrf2q8uRNEoWIDbnnmvZr9Fl064R/utGQfyr57Y
+R2mszB2ZYgxBUZw1YVtNRN2H65qb3N1FPp8e1lJygTkD3ptjrGs32pwxWiDyom3SMRgN7ZpYlg8u
+e5huAs5bCx4ySOcdfpXQ6YmnWHh2B4kVbgYkaUHHI9T6VxzlZbbmlKN/eZk6tBqtvLcXE0Uce4gj
+y1DhBzk5x1zisZNYuYEMlzcnyyec4XNW7zXby/vpIxFPKM7fvgrj+VSjTdNuLZ7q9LszIFihVuVO
+P15qYy+y9hOPPIsweJEv4c2zjapCu8ibQCenJrZ0++SZv3kcDOh2nb1B9Mis7S9LaztkkWFQk0Si
+SFxn5lHX696n0+5sLTYNQm8qUMTGuwZI9Scf4VUVGPwlOCSNzFu6szQkfSQ1LFb2bpt8uVT7tUVr
+cW9y7GKRMdhnrWlbusQZoQpcAMck4INaKfZkJElrpcRTeqygDuTXYaTFHHa4j6Z71hadqklzIIpI
+gnr3rp7cARcAAe1dFJ36lSSQ/FFLRW5BDdrvs5lAzlCMV41eaOlvdSEWzySEnvXtDZKEDqRXKS6L
+qEtyzABVJ68VzYiLdrK5UbdTzq30qad/khSJRweeas31m8FoYZYmkiIxjaAuPQ8Zrsr6wewDtiSS
+QLwAvGa55U1LUJo4WVVJfIQMM4rzasXsjReRycVqQ4jiQpEOgA/w5qci6jjV542jRWwm/nP0716H
+eWFzY6cREs3mMP8AllHls/U9K5AaJf3eqJcXBkc54inAJH48Cs/ZSTsLl7GTZxXMc5FvJ5WecjIz
+9c1WvLcXE+94ITIOCUcLn8q6G4iNvOVurh5ZA+0pwAP0FPuY7SJ4ZYrONpdrMcITyBxk9OtVTnLm
+sS9DEtLR0UfJJGD+Nbljd3mnHakkhHXGwkYrS0aC9v7bfLbHYeceQVJ/H/61aE3h2RIPtNslzFIO
+qIM/pXYo3V7FKxX03xVYXNwkU7eTJnGQOp989K9GtiDApHpXJaLo0d63mX2nRAjjzNuCa66KJIIh
+HGMKOgrrop2uRKw/NFNorYkjR8qD6jNODH0H51UtHLWkJPUxqf0qwDRcCTg9QDTRFErbhGgPqFFJ
+mlpaAOOD1AqJkUfMYIz7/wCRT80UaAVzZW0hLtZW5Y92A5/Snx6bYqdwsrdWPXCD/Cps04Gjlj2E
+OWOONdqIqgdgMUvFNzSZ5qhiknsBSZPekJppNAC5oqPNFK4H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0024/full/!100,100/0/default.jpg</Url><Caption>29376_0024</Caption><Caption>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Caption><Caption>Exhibit</Caption><Caption>plate 094</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7NH
+/wA81/75pREikAIBn0WrQFLtqbAV/K9h+VHl1OVpCKVgINlKFqTFG2mkIZtpdtSbaAMGmBFsoKVN
+ikxTAqFgCRh8j/YNDR8Va200rSGUmgBPSirRWikIsgUuKBS0wEppFPpDSAYfWlApcVBcXH2W0lm8
+tnKLkIgyW9AKVxEV5qlhpzIt5eQQM5wiyOAW+g71m3mttLdiz06PzLjvkgBfc/5/CvN9ai1LUdeF
+1qNuiTySKI4VblcAbV56dyfTnpxXbWk1npGjOscge5cbpXT+JumB7DoK5/bN3vojVwjG3VnQWk7x
+WRkuJxMyjLFVAAPpV/GRmuWtLxFWKFmDM7CQqGGDjn8ADXRxSCQBjJn2HSt6c1JaENE2KaRUmKaR
+WjEVpZVjbB9M0Vi67O8V6iq2B5YP6mipA6YVT1DU7XTIw9y+0HpxmrYrnPE9tBctGJi3yqelEpWV
+xlxfEli6hk3sp5yBQ3iOy3YAc888frXKxhEAVHYKBjhR/jWRNd3LSlmuBCmcKioN+B7iuOri1AuN
+Ns7u68T6fEvLMfYp1rmPEniWxit4bmzujD5WXURfLvY8Yx0P+fSsW61DSbZ080y3ErYxGZCxP4Z4
+rD8RXmm3sAa0hZHh+cRuOBj+X61zyxMpFqi1qXobueW4e+vJjnBAVedoPP457mntqjxYWW1m8ksC
+sgx0J4OM5q9oU+kX2nRtDNErMBuBb5lPpg1rnRtMMDeYxkU8EvJxj0rPWT1LjGKWurMG31ARyCYu
+Nx4GGHAHb2rorX4i6VahInWU/wB5gO/sKypNDtYUJgIWM8gAcVy+p2scd4ZGjBUcMemfTFdNF8vw
+kSjc9V0/x5oeoXcVtHcuJpThQyEDPpXTHpXjXhgWqa7akWByJB1GMH16V7MelddKpzozlHlZz2tx
+b71DjP7sfzNFbE0Ecr7mXJxiirsSWRWdrN1aWdv5t0+xfpmr4NVNTsVv7UxkA/UU5XtoCtfU4uXX
+tNm3rbNz03FgMfhXOSWdtNM8s2pKCxO1VcV1cvhKDcS9puJqKPwbBn5YSnv1rzqsJzd5HRFxirI5
+SbS4Li3DT30AIA2tuBbHbpXOXOmhCRDKswB7OwOPpmvWD4VslTDQkn1xWdc+DrSQ7lzGT6c1kqMo
+sHUurHl1hZwvdGMReVL164NdDPYST6eiXN267T93zufrXVJ4DglKyM7bh3KircfgtY5AQpYdzjmr
+9nJ9AU0jkC17HZ+XaXalQMAshYj8TVGPw7f6o/8ApN+5Udo1xXqI8OoEwFfNWLTQ2gbIDYPpW0KM
+gc0YfhbQltp4mZWkaM/fdjmvQT0qna2SwfNzu+tWz0rrp01BWSMJycnqRnrRQetFUIjSTcoYdCM1
+IGqjYOWsLZj1MSn9BVsGmBMGPcUZqLdS54pWAfkE1GzbRny84oBpc0WENWYt92In8amViRkjB9KZ
+mjNMCXNITUeaTfzTAkLH0/WmlqjL89KYZPakMeTzRUBmwen60Urgf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0040/full/!100,100/0/default.jpg</Url><Caption>29376_0040</Caption><Caption>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Caption><Caption>Exhibit</Caption><Caption>plate 095</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3DYwx
+tXPrzT9lSgUuKkZDsNBU1LijFS0IhK470balIB6gUYpWFc5bxnqPiHTNKibw3pQ1C9llCbW+7GuD
+8xGR9OtcPN8QvG/hra/ijwxGLY9ZrY8D8QzD+Vew7aZNHE0LCZUaPHzBxkY96fKUnY4Cw+LnhS9i
+DS3Utq+OVliJx+IzV6L4k+EppRGmrx5Jx80bgfqKwde0jwK8kkh0KIvuwDbv5QY/ReK5K/0bwjcQ
+zJa6dcwPgiOaGcsAffPBrH2qva6NEont9rc219CJrWeOaM9GQ5FKUlz/AKoY/wB6vA/AeuXvh3xQ
+tjLKzQM+xlzwQe+K+h1KsMggj2rSEuZBOPKUjb5NFXSoop2IJSdozgn6VUnu5V+4qgf7VSX15BZQ
+b55RGCcAmsNdTs9SlaO3vI2ZRnAP+NaqxEmR3mqX8Eu+KUN/sY4q3Z6/LIuLq0MTf3s8Gsy8vLbT
+mPnXKBgMncR/KqL+JLGZvluYemPmJH9KtpPoZXaOyj1K3kH3sVMLmA8+an/fVeZf8JLo8m4f2nFu
+T7/BH5cc1BdeMtEs4ldbrzc/wqrEn88VnLlXUFKfY9VN1bqMmZP++q5PxZ4mSxiMUc8aKw+ZmIwR
+3rzu98YavrH+j6RaG2hP/LZxlse3YVlv4bJKz6hPJPK3VnfOK5qtWNrJnVTpTestCC41G0u5W33q
+eWhJVXOCTU8F7F5DszRrEBkMPX1NWtP8N2V3cNGUGwA5OKxtf0GPTnDwDIB7iuVcuxv7HzJ/D1r/
+AGl4lN+4228R8wswx8q967Dwd4muZNfWE3E3kTSsSu3cCT/KuUvL1v7Ji06wQRiRFaZweXbGcfQV
+b8GWU0XiK0DSBZFkUkbgDg11QpytzGVSSvyroe/Yop2KK3MznfG0U0mh5gVDIrggt2FeTRymJ2Aj
+Y3GclyQcH6V6z401COw0cGQA72wM15lbXtpc3OI9obqc9zRKbSsibIx703HmS+ZIZHUFmJ+ao302
+P/Rjvlubi4OBFFgfqaXzZrK4ulviGjuM+UYSdx55wuM+2falshcR6nZXMVuy25YyggdAMjFc9SpL
+qbwpxTLN/wCGLa2tA80Xlynqu/d+tU49FtVvI8rlcitnVdVhvm8lc+Y3HTpXPyXk9nI3m8rGRz6j
+OOPeuROTdjZ2PQ7eyjjtkEaKox+Vc7rU5EvkI2T6g1PZXt7eIimVbaHH+tmYKMfU1KieH7Njcalr
+NlnqF80Mx/AE0QpyuDmkP8OuYLWXzR+9OPmPpz/hWd4rObfIGas6l4htzHE2nWbHT2T5rkjBx1BA
+9AetYmoai9xCAVWSFhlJFOVb6EVTi07lxdzmdT1L7KY4Od6xqfpnnH5YrQ8L6j9q8WaUqfITOqkn
+kYzWH4ghZZmvkUtC4AcY/wBWQMYPtxwa2vhxdaa2t28UlnLcag9yi2/zYRF7k9yRXpw1gmjhndTd
+z6fHSigdKKkDzH4z6mdP0Sz/ANGaRHkbLg4C8cV4b/aM01w0duGZSCDhvvHH8q+l/G1tHc6XH5wJ
+iVssAMk15Dfrb6dDJcRWqqVU7UA5J65PtVcyXTUnlucrb3c9j5pgIFyQCfw/h56Ctaz+IDaQhtW0
++OZJPnw0vCn2OM1wk99d3ckqxElnfJb1NXbLQNQnKNMsjLuyT0OKznCmtZ7le0ltE7/R9ck8SXr3
+NzawW0FtyCg5P+8e/WuS8UeIJdUv/Ksi6W0TYDjjd710o04Jo7afp8UkRlP7xjzx/jVNPCkNrGjT
+uPbLck/yrijKKm5Jehc23FRTOJd5pn+dJZiO7MTWrp+jXF1E0hjliAbAxHnj1/WvUdAs9Ps0BuYl
+O0cFwMf/AF66G51fRIIA2EPH4Guj6xJqy0M1BXuzzeK6httDWyjS8kkWJoyrRZ3E55GOnWs7QdO1
+qzkVsC2hYYKShdrfUHqa9DTU7GYk20Ict3UDj8ayr+C5uJFkeLZsztKvk4znB68VKm1dW3NN2vIw
+9e1W0t7WaOK3QSH5QQODxg/hnmqnw1tg3jTTmKnPnA56YpbjSybkySRNK7NnOM4/oK9A+HXhc/2m
+moP8qxHIX3xW9KKhG3cVSTlK56/RSZoqiCje2kN/atbzZ2N1wcVyd54EDk/Z2gcc7RMDxkYPr2Jr
+sVNPFNrqNOx5zB8JbG2JaAxK56tt/lWhH8PEiX5Zo93qVruAadmocU3cLnIr4Eh2jN0Q3fC9arXP
+w9guWXfehNp6hckfT0rt80YDDkCs3Ti3qF7HDyfDm0kj2nUWx2OP/r1WX4TWbTb5tRldQPlXZ/Pm
+vQQiqMBRTs8U40oLZBdnIw+Aba3i8uO6YD2QClHgK1yS97MxPsBXW5ozWihFbILs5iHwRpkTAyO8
+g9GOAa37a1t7OLyrdFRR2FTk0wnimAuaKjzRQB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0001/full/!100,100/0/default.jpg</Url><Caption>29376_0001</Caption><Caption>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Caption><Caption>Exhibit</Caption><Caption>plate 096</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Hyyo
+yAT7U8JxUoAA5qpc6pYWkLTT3kEcanBYuODUWAm20bajjvrOaHzo7qF4v76uCKes0b4KyKQehBzm
+pshXArxSbTVPVZHtxb3A3COOZRKQeNh4OfoSD+FLqOtadpRQXlysbN0HU49fpS0W4Et1cR2cDTzO
+qRrjLMcYqFtSs0sxdtcp5B6PnrXHeK75Yopmn1OKSzl5CD526dh0H4157qXiWd3ighaQWSY+Xpgd
+PpUe0fNZILnvkTJPEskbBkYZBHeq81/ZQTiCW7hSVuiM4BNc34d161vPDssNvcqsoj2R7perY7el
+cDeWv2a8kvNRczXO7g7j2NU6iSQ0e0MBg4+YjsOtRgbzjY4+oryPwzr99D4kXdPK0TsA4kc4b0r1
+21v4byRkiydvU1aaY7jTb5PeirhUUUrDEvtws5Cpwcda8R8SRs1/MFEnlnO8uMDPbFe0a1OLXRrq
+c9ETNfPupeKVF1KsrkoRkEpgf41NSLbuhI2tGmS00/bPPIzyqdqqeAB61oaJ4viaaKxtIpmEBJO4
+devv71xOlahNfXRuUIVGUh1Y8cdMCk0nUJrLVmm+ykRsecHkc1i5WuJxPcYtettWs/s0v7tJo2jK
+uQG3du9c/ruoaXqGjwtfKjXka+XJyeq8Hp78/jXIpqsrREiNFJJPXmqzagsd0kt7Duifg7SWKsOh
+x3B/oKlVefRicWR6tfx3Fklss+xQAoIOT9BWBcwXEEXnwl5EjI3cZ3duKt6hJCbr7RARLhshSCNo
+/HvUL6jMqu0duA5xyzDmmk1sCT6jbEXen3CzI37tnVihHIPXHv6Vq69qxnDY3MzE/KhwB+dc42rX
+AkifaUkjOd2QR9MVZlv/ALZLE8sRA43FVwD16fpWqi7pspLoa3hieZtQy20RvgMCwJr2jwujedIc
+ttA46YNeHWd5b2WoLcWNrLJKB0kPy5+leufDq71K98+S8VEjAwFVe9aq1x2sju8UU6imBn+IRnw/
+eDsYzmvlvX4pZrtgijYDgEHJNfTXjBgvha9ySAUH8xXz1HZteantUjYDudicACs5y5WOKvoHhiy1
+HT5Bei1eSIfIUI4IOOKNZ0m5iWe+VbmzUMGNvIWAweRgk+xrutPuYoReWeFeBSrqSOvyHOD9VFcq
+3iF9eguxfD7VHaAiJXJwCSOeOvOMZOeTXMpuTbZrKKSsc9Bf6jNcSLERGqEgkDOB+NaMJt5jiW6u
+JZT28w/0qlcpdwXKabIsUfnfMgjHy9SP6GussH02PREgl8u3v7fl3dcFgR2+tS0riVkc29sBdsDL
+OkUf+sR5d2Bj61qxroF5D5UV+lvcr08wHBNS38SRW7BJBMynez4++T7/AJVzVxo8ImtLm9WSOCRO
+Z0BKhsnqR0rVRT6gpeRZ1rRL2zC3G4NH/E8Yyg9CKxib1EEhLNGTwytkfpWrq8+peHdSjsra8kls
+5lDRlgGBFOWO+t7Z76VIp7ZhiRQMHH4Vqm0lcOVN6FWw1KWB+GI+vNe4fC6/N1a3CnG7gnnr+FeC
+uI1ZnhnUoDkLIO31r2H4K3kdyt6gLF0xg4wK2SXQzdz1aZ9j49qKScLvGfSikSZHjP5vCt4uQMqA
+M/WvBZCbfRmkbIHnkyso5KqM4r3/AMS2Zv8AQriEZJxkAd68D1ZLsRPpcNu/7wlWO35VGeTnPPFc
+9d6pGtKyuzmrTXdYF28lrM6WrOWEDAMu3056cHHFaH9oHQrmS6hSQQTLvfYqkDPYZHHcVq2mkvEy
+Lbxkt0PFWNbtIViMFw2xHi6FSd/Pb0NYe1UpaIq3dnEajr8t7qRmjtUTLDaoJJGPQ11F3Ytr2hLd
+LcCG9iQEb2xvHpx3rF0jR/LBd43Jydo28kdq6izsL7yWENu2xxhlYdR+NTOtFStHoSlfcxdPmA0m
+T7RLIqRExssnOSRyAaZo2utL58MrM9ptYxqeoPrV3V9EvZ0gtXJS26sh6g5yT+OetX7Dwii229Vy
+OhC/41arQa7hZpnOWscmpTQrPN+7tHZFXGcc+tbsumRPGEQt3zjPQ1tabpCWkuFs8qzEsxf5snv0
+rqIIdNVRA8aRk8AP1JqXW5paOxSWh5onheFFJik3E8lSf8a9U+FVoLRbpWhKv03Y7U9NCgVsi3ib
+PA+QfzrrNAsDaRMxXbu6Cuim5N6smWxqTq7OCvTFFOc/NRXQZCZDDB5BrOk0LSpXZ2tYt7dWxzVx
+T0qQGk0nuh7Gevh3TkGFhUA9gMVSufBunXMgc7h+RrfzSg1lKlCW6HzMxY/CWkxqAIAfepRoNjGN
+i7EX0wK1s0hAYYNJUaa6C5mYp8NaVJIHk2uewJFW08P2EabEiVV9ABWgoC8AU7PFXGlBbIOZmZ/w
+j9mM4Xr7UkXh6xiff5alvXaK1M0ZqvZx7D5mV1srdMYUcVONqrhcY9qCaYTVJJbCI5JNrY9qKrXT
+ESjH92igD//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0034/full/!100,100/0/default.jpg</Url><Caption>29376_0034</Caption><Caption>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Caption><Caption>Exhibit</Caption><Caption>plate 097</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2KAbQ
+BtJ+lXlXiq8C4q4orNLQoAtP20oFDukalnYKvqTimAm32o2io57u2tYfNnmjjj/vM2BXKQeLbnVf
+EkVvpsanTVbYZWGTMe5X0A9aTkluNRbOv2j0ppUelS4oIqiSm0kQz836UjIM1ZIqJhzSGRRLzVnc
+EQsegqGMc1Y/gP0piKF1rljZ2ouZJl8rdtJB6V5b438S6jrHiOHSLGYwWONzsp+Zu34D/PSsLV9R
+lnvdSBlaSKO42hWPBbPOPof51ajtX+1rMzhTcv5jH0jQAKv4kGuSVRy0N1FLUtasbbR1DXN3PdMs
+XlpBvO09OP0/Ku/8DaNdQ2g1XUoliuZ0xDbr0gj9Pqepri/A+kxeJvGV5qk+ZbOwYLEr8gvzj8Op
+r2WtKUPtMmcuglIa4H4jeLbrTNPu7DSX23yQCbeuCQocBgPcA5rD0vxDd/8ACYT6hc6pONJh0pbh
+AxJR+PmJ465zW9zM9YIqJsZrlvAXjm38b6bcTJF5NxbybJI854PQj611D4zQwGJ1ov5/sumXU4/5
+Zws/5AmhOtV9bG7w/qK4620n/oJpdBHhuhKl5eLBcqVkMgkfd3+bcT7/AFrX8UXFpCymFiWC7EVe
+SeemK5PRzIYvMDATrkqxz0Bzgn6c10nhmz+2NLqV0wcgHYD/AAj/ABrz5+4zeL5hfBt7ruk6bcw6
+e0UEcj+ZJJJHuKn3PSrt7488VWMnlC8hmL8BvIHy+/FX4Pn06dVTavmHfj1IHNYen2C3fiAxXMix
+wxDexLfeX2rONefNa5pyxtqdP4S8IS6lc22sapI7SxTPP83O8uACD7ZGa7bxBoemajoN1aXcKpbF
+Mv5Y2kKDu7fSrmlT2s2mxPatmHGAcY6VYumRbWUyDcgQ7hjORivSh8Jyt6nk3w88U6PfeNrrS9B0
+tbSwFrjfgBpChGCQPqeteqv1rxf4f6hpmo/Fm7k0rSmsIFtJAyucMzbhzjtXs0pwRVXEhoZU5Y0l
+00ctlNG3KuhU49CKz9WmEFqJWkkQKc5TFc//AG4/kmRJpQhB+8orO6tqS5a2PIbe0mM72ybTF5nz
+AnBwMgiuha7hhltxax/Z7QDbM235R+NU4EW2vrmbzTFvISOTAIDZ6nPbv1FW4jFbW97bTubgeWZF
+KgYYknB4Jrzpy5pXOmOiKVz4klvtbGn6XJJFaQA/MoOJH9W9q5668aXVprZAWNTEWiDMMt6EkdK7
+bQdGg02wOQGkc5kfH8XUj8K4XxB4etotTe4Visjku8QO7B7n2roioN2aI5maQ8XNb3aMxnmnQh0D
+yYVT1yAOK958J+JF8RaAt1IFWZRiRB/Ovmu3jhinae5XdIf4QcYroPDPj280vXIYrVo0tGcLMhHy
+kd61jK2iIep23hfxHZ638YLmOxsEt4Le1li8zZh5W3KST+XFeqyHkVzWlaXolprEur2loI7q4X5n
+DDGDzXSSHODWl9BI5bxpM0OnoQVHP8QyP5GvOH1ktHJDIUdSDtXZxn9K9R8T6c2oWSpkhQeQO9eR
+apYL9vS005SctsLjnJ7n6CuOafOWkXo7e5ktd8IwCxban8agYxzn1qppGmahHPLFd2piEvCEEYAF
+dbaRrpdhFCHEjqDg5+WsfU/EFxPut7dkIB/1y8c+g96FFNDbZcmuVgj+zWocueNwXlfwrhvELrbT
+MWkDSEYxuztHoff1rWOvW2naW8bzI107EZAyQPr3ridRu/tk5ydxJzyK0jB38iTPuJyx2qT8xyTj
+rWhoOlSXdwGUERA5ZzWhpHhq4vyJnQrABnJ/irpE0ZrePC7kX+6honUUdEOx1/hi6t0uILdJX2ph
+RuQZP416axG1cdMV5L4Xtliv4yyORkdVNervwqgdMU6bbiwtqRXVr9ttnh3lN3GRXN3XhaS1hZrW
+MPKFxu7ke1dZGasqciuh01LUm9jxHVU1G1mMLwk7h5YJU5J46Cs+706awtmjeCSW5K4Xy1JVfb6+
+9e/MiN95VP1FNMUYGViTI6cUvZoLnynd6Jqs0iytaSkn7qhDgVq+G/AmoapqiRvC64w0rMOFFfSp
+C94V9uKegx92JVz17VXKx3OHtfB8NtZxwLHkIMZPennwkMAJGgPqc13BppNZ/V4j52c9pWgrZEsw
+AJPIB4rVkxkCp2JqtMfmHNacqirCWrFgJxVpTxRRVR2Ex+aTNFFMQoNLmiikAhJqPcc0UUwGN0qn
+MTuooqZDR//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0017/full/!100,100/0/default.jpg</Url><Caption>29376_0017</Caption><Caption>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Caption><Caption>Exhibit</Caption><Caption>plate 098</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tYQo
+zzTxGGUEZwfUVMBS4pWEQeVTTFVkisjxHqyaFoN3qLFcxJ8gboznhR+dS9NQM/XPEul6DLHDeSOZ
+5BlIol3MR6+1SaJruneIEkaxlYvFjzI3Xay56cV5PYW1x4hkuLya7Ml/kSbpOmf7vsMcV1HgnRNR
+svFAvfKkFrcQMjnsD1HT3FclPEOdSy2NZU1GOu56R5XFAgqwFpwWuyxiVTBSG3q5ijbTsMoNAApJ
+zx6c1F5Ks2MPz6qRWntpCopWAyzZAnvRWgV5oqbICcUp6U0uEjLk/KBk1lyeIbGN9hkG7uAelXdC
+Zq15T8ZL9yNL0tWwjuZnGeuOB/M1d1fxVqNv4xgntbwHS1jAkhGDuOeQfQ45BrjviZq8Gr+JbCSB
+gUSDaRuzg7if8Kwq1E4uKeppCLum9ibwcrQ3cysDhiDmvVNBhSG6kFtGwgKASM5wd/Xp9DXm3hq6
+g8iR2A3RNjr6V3mm+IrUF5/NjE1yFd4y4+U4xiuHDNObbNa+h1mOacBWG+o3UgzG6L9OcCmW+qzf
+aWjmY7B0cetempq9jlN+lrNN1csf3LxsMd+tRrrG1tkiZfp8taLULmrTTVIakCu4wt+dTwXcdzwm
+QfQikVceetFKetFSMpX2DoUm7vEM8+wrxm9tkM0pM79T9017LrAJ0K4Cjny+K8Lu5giyTMQAhJPB
+6CuPFN3SRpTKTWvk3CtFKwI5+bqaTU9LF6I7mNwkwPzA8A0WuoJqZ3wHgcfMuOnf9afe3Is7bLAs
+2flXIO4/0rhbmpW6m3QtWluLa2lWKYmSQgnZg4Peo7zTkkkUrPNNtUbixGT+QrEhTUb9i3m+UrH7
+qHbW/pXhR5ZlkuZ5GTH9/rRrF3ciWmyW31SazjCRXMitj7nmZFdNpfiu3KIt4WWXb1Ukg1yX9lwQ
+63tAURoN2W4AI6U6C6t4Lh5Fhku7g/KFjTCJzkZPetqc5JaNkOCvqd1/wkVkJRh539z0/wAac3iX
+Tov3qzSDrgAHP5GuNnjcWzXF7IkK8naDiufGuz3l8YdMtkcRKcyyk4x9K6KdSq9xOET00+NJSCUj
+kKds4Fa/hbVby/1XDxgRcknPtXkEPiV7e+EGpW4jxjmMkD8q9g8F3EE7K0Me3jrWkXVcld6CcYpa
+HbEc0UtFdBmVrqJZtPkib7rJg/lXjuq+G1M52MUjBI45Jr2UjfCV9RiuavtLySQAV69KzqQUlqVF
+2Z5YPDscCl42ZFXn5ep/Ksi6kR9QFiRvXIUNjJ3eor1K4sFWIjb0rEbSQqh44QpByOK4KkHc3UlY
+4PU7iO1nSFGxsYFyPatFfFd29rHbWts3mZBDEY57VtR+Emkunl8xkDnO0L0/Gt638PRRwJGkYZkA
+wzdSaiMFZXQpyu9znbKCXWczX1qsLKRkKCMkd8Gt2DT44IyY169SeTViW0NtKiO6jPJOc1fjhBgB
+jGcjOK2jFLYVzivEenf2jZtGgb5fwqj4NtoPD3mNfWjTbicsuOK7WS1iu1fbJvZThgvUGq6+HzMw
+LK230Faq9rD0OA1/S21zxBJd2sDw2x/vDk16r4AspbeNNytgD+IYxxTrHQlUhRGMemK6zTrX7Mo+
+UD2ArWClfUibVrI0M0UmaK2MiGNvlFOwrdVqCMkKKlBoAR7S3kHzRioX0q1c5Kc1aBNKDUtIZROk
+W20hQVPqKrnRrcqEZ5s4xmtfNHWs3CL3QXaMM+HdOeVHYSsyjGWOavpptoF2CJgpH0q5gDoKcKqM
+I9g5mZcfhzTIm3RW/lknJKEjcff1/GrqWFvGAAuQPWrNNJq1FILsaI40+6g/AUbvbFGTTCTVCFLC
+ioWY560UgP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0050/full/!100,100/0/default.jpg</Url><Caption>29376_0050</Caption><Caption>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Caption><Caption>Exhibit</Caption><Caption>plate 099</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0008</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EQj0
+pSiDGSB6VMBQxRRlyoHqagZCYR6UwwD0q0cUzcKWwFfyB6UnkD0qzS4piK3kD0o+zj0q0BS4pgUj
+bD0pDair20Um2gZnPbKoyxwKj+yq4ypyK1CtNKCiyAxm0yNjkqCfpRWvsFFTZDuTCql3OiTLG4yu
+0nH+fxq4tcj42vX09YbhQNuCpOamo7RuC3N03sYVED/LjGfas69161tQJPNGCMkZry2fxnLEjLHJ
+uDZz9awzqmpauWhgjeQp2HYVxyrSexXKe822uWk8YbzByPX2q5Dc+fhkIIYZH09a+dU12eOAESMG
+UbSOevpXpnhjxbbpYRC6uY0O3lnYAL7AVdKu5StIlxsekL70pwBk9BXNr430KNC0l8No43hGK/8A
+fQGKydf8aafMbSCyvVaORm8wgH+78v1HX9K6XUilcIwbdjsbPUIL8FrfeyDo5UgH6ZqzXCR/ETwt
+oxFg145mGNy+Wc5x34xWvZeONGvyBBMxyeCRxVKStqwaOkpCKqR6nbSnCMSfarmQygjvVXXQLEdF
+KetFAh69K4v4haadTtIEFwYdhJBCbs59eRXZr0rnPFEqKFWQ4XaTjA5/E1hiJctNsuCuzxCXQ301
+282QSr13Dv8AnWtoniez0gSQpcm3ZmBcSRjNQa1qPmMyR2F2Fxkg4x/PFZ9z4bc2D6ncGERRLkxH
+nI643eteeqjfxaG/LbZGhrh0fVfKxf2doVbcZI0bLjPchsfjiubGr2GkasDbRLqCbdrGVd4H0zWy
+mkaK9pHdDRL4wMgYuG65GcDA5pbLTdOvJWjj0W6t4wpIknc7Sew4WtEratmfNd2SOi0XxfYvCY2m
+jhjccw/ZVUZx6kmnw6NZXNtI9gokRMnLzDjvx8vFcFLfx2OqLbNBDJFnnyiSQPrnrXcPp8EtgBBc
+sIyu4oj5/wDHaPZ3V0y1Oz1RkS6JFqr7baeJ3i4lkz0+mOtVW8OX2mTeZaXio3YAYP5ZrXtp/JUN
+byeaBnLIuGHqNp61oQamLqHMdvHM6tgjzdpP6cVLVSL90ttSRa8O6zqGnMsd/wCVdRt/EPlZfwr1
+q2kWW1jkT7rKCK8eXxI1vJ5cmkMJAPmxIGH8q9Z0m5S70q3nRdqugIHpXVhpSbakY1I21LLdaKD1
+orquZAp4qhq1sLiLlQQPUZq4pp5KkYNKSurAnY861S0AB84sYvRUzn/AVhppmmOCqhVGc7W9a9Zb
+T7SQHMYOe5qi3hnT3feQ4Ocgg15lfB1JO8GbxqrZnmd/4fEkG5ppQMZ++cYrkr/w3cuga2nMjZ4A
+fkfga+gP7FsvL2OrMvfJqB/DekO257dCTg9KVOhiIrVpkuUD5ug0HV7a+WSQXSsp4YsRivQdIW++
+z4mxISP4kU/0r1EeHtLViwVsHqCSR+RqddGsPuogGP8AZH+FdkKc2veIcl0PJZ9I1Bt89vGgcAhQ
+Bjr9KzfDnhvUYLueW6tgpfoQxBHr9fxr3FdIs1HEYp66ZaKeIxV+xGqjtY8iubfVhfR29us/lDGR
+GVBP4mvWtKhaDS4In37lXnecmpFsrZH3CIZ9cVPkYqoU+V3CU7qw0nmikJ5oqySJWp4NVQTkc1Kp
+PrTuIsZozUQJpwPFTcLD80HB6im0uaOYQ4YHSnZqPPNOqrgOzRmm96SmA4mmFqDTDSuMYzHNFRSs
+Q/BoqWx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0020/full/!100,100/0/default.jpg</Url><Caption>29376_0020</Caption><Caption>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Caption><Caption>Exhibit</Caption><Caption>plate 100</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0008/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0009__xz111ffbb66842f49d5f2e023e5131778d.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0009__xz111ffbb66842f49d5f2e023e5131778d.xml
@@ -1,0 +1,2889 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719890___29376_0009__xz111ffbb66842f49d5f2e023e5131778d">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="q1">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">1</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719890</Param>
+<Param name="viewid">29376_0009</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0009</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>5e578e8676a8171e378d502e6a18cd19</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719890</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0009</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719890%5D29376_0009</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719890%5D29376_0009</ItemUrlEncoded><TitleForTagging>Bos%20Americanus%2C%20Gmel.%20American%20Bison%20%28female%2C%20and%20young%29.%20%28v.%202%2C%20no.%2012%2C%20plate%2057%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="1" name="S_SCLAUDUBON_X_B6719890___29376_0008" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008</Url></Next>
+<Prev><Url index="17" name="S_SCLAUDUBON_X_B6719890___29376_0028" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028</Url></Prev>
+<Self><Url index="0" name="S_SCLAUDUBON_X_B6719890___29376_0009">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776094</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;q1=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719890]29376_0009</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/539,417/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>538</w>
+    <h>416</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0009</m_fn>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_flm class="fieldsRef">2014-12-11 10:37:15</m_flm>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</istruct_caption>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<m_caption class="fieldsRef">29376_0009||||||||||||||||||Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)|||Exhibit||||||||||||plate 057</m_caption>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-9</istruct_isentryidv>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_title class="fieldsRef">Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</istruct_caption_image_title>
+<m_iid class="fieldsRef">29376_0009</m_iid>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0009</istruct_isentryid>
+<istruct_caption_image_id class="fieldsRef">29376_0009</istruct_caption_image_id>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_m class="fieldsRef">29376_0009</istruct_m>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_x class="fieldsRef">9</istruct_x>
+<istruct_caption_plate class="fieldsRef">plate 057</istruct_caption_plate>
+<levels class="imgInfHashRef">6</levels>
+<height class="imgInfHashRef">6664</height>
+<u class="imgInfHashRef">1</u>
+<size class="imgInfHashRef">7731098</size>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<access class="imgInfHashRef">1</access>
+<width class="imgInfHashRef">8620</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2014-12-11 10:37:15</modified>
+<md5 class="imgInfHashRef">28e3bc418abcab245230f28dd8be386e</md5>
+<use class="imgInfHashRef">access</use>
+<basename class="imgInfHashRef">29376_0009</basename>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/2_/p5/7/audubonVQ_v2_12_p57/audubonVQ_v2_12_p57.jp2</filename>
+<loaded class="imgInfHashRef">2014-12-12 17:07:32</loaded>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:6/0/native.jpg</Part><LevelWidth>134</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>134</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:5/0/native.jpg</Part><LevelWidth>269</LevelWidth><LevelHeight>208</LevelHeight><LevelMaxDim>269</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:4/0/native.jpg</Part><LevelWidth>538</LevelWidth><LevelHeight>416</LevelHeight><LevelMaxDim>538</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:3/0/native.jpg</Part><LevelWidth>1077</LevelWidth><LevelHeight>833</LevelHeight><LevelMaxDim>1077</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:2/0/native.jpg</Part><LevelWidth>2155</LevelWidth><LevelHeight>1666</LevelHeight><LevelMaxDim>2155</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:1/0/native.jpg</Part><LevelWidth>4310</LevelWidth><LevelHeight>3332</LevelHeight><LevelMaxDim>4310</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:0/0/native.jpg</Part><LevelWidth>8620</LevelWidth><LevelHeight>6664</LevelHeight><LevelMaxDim>8620</LevelMaxDim></Level><MaxWidth>8620</MaxWidth><MaxHeight>6664</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719890</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29376_0009</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Bos Americanus, Gmel. <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Bison (female, and young). (v. 2, no. 12, plate 57)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1846</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank">Lithograph</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/res:0/0/native.jpg?attachment=1</URL><Filename>29376_0009_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719890:29376_0009" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719890:29376_0009" canvas-index="52" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="sort">istruct_caption_image_title</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="q1">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">1</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719890</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0009</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. II; [title page]</Label><Value>29376_0025</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. II; Contents</Label><Value>29376_0011</Value></Option><Option index="2"><Label>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Label><Value>29376_0002</Value></Option><Option index="3"><Label>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Label><Value>29376_0010</Value></Option><Option index="4"><Label>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Label><Value>29376_0006</Value></Option><Option index="5"><Label>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Label><Value>29376_0007</Value></Option><Option index="6"><Label>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Label><Value>29376_0004</Value></Option><Option index="7"><Label>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Label><Value>29376_0008</Value></Option><Option index="8"><Label>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Label><Value>29376_0009</Value><Focus>true</Focus></Option><Option index="9"><Label>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Label><Value>29376_0005</Value></Option><Option index="10"><Label>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Label><Value>29376_0003</Value></Option><Option index="11"><Label>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Label><Value>29376_0052</Value></Option><Option index="12"><Label>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Label><Value>29376_0039</Value></Option><Option index="13"><Label>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Label><Value>29376_0014</Value></Option><Option index="14"><Label>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Label><Value>29376_0051</Value></Option><Option index="15"><Label>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Label><Value>29376_0018</Value></Option><Option index="16"><Label>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Label><Value>29376_0046</Value></Option><Option index="17"><Label>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Label><Value>29376_0041</Value></Option><Option index="18"><Label>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Label><Value>29376_0012</Value></Option><Option index="19"><Label>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Label><Value>29376_0019</Value></Option><Option index="20"><Label>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Label><Value>29376_0044</Value></Option><Option index="21"><Label>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Label><Value>29376_0021</Value></Option><Option index="22"><Label>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Label><Value>29376_0035</Value></Option><Option index="23"><Label>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Label><Value>29376_0038</Value></Option><Option index="24"><Label>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Label><Value>29376_0016</Value></Option><Option index="25"><Label>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Label><Value>29376_0037</Value></Option><Option index="26"><Label>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Label><Value>29376_0033</Value></Option><Option index="27"><Label>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Label><Value>29376_0022</Value></Option><Option index="28"><Label>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Label><Value>29376_0047</Value></Option><Option index="29"><Label>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Label><Value>29376_0042</Value></Option><Option index="30"><Label>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Label><Value>29376_0032</Value></Option><Option index="31"><Label>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Label><Value>29376_0045</Value></Option><Option index="32"><Label>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Label><Value>29376_0036</Value></Option><Option index="33"><Label>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Label><Value>29376_0049</Value></Option><Option index="34"><Label>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Label><Value>29376_0043</Value></Option><Option index="35"><Label>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Label><Value>29376_0048</Value></Option><Option index="36"><Label>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Label><Value>29376_0015</Value></Option><Option index="37"><Label>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Label><Value>29376_0031</Value></Option><Option index="38"><Label>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Label><Value>29376_0028</Value></Option><Option index="39"><Label>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Label><Value>29376_0030</Value></Option><Option index="40"><Label>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Label><Value>29376_0026</Value></Option><Option index="41"><Label>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Label><Value>29376_0029</Value></Option><Option index="42"><Label>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Label><Value>29376_0013</Value></Option><Option index="43"><Label>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Label><Value>29376_0023</Value></Option><Option index="44"><Label>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Label><Value>29376_0027</Value></Option><Option index="45"><Label>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Label><Value>29376_0024</Value></Option><Option index="46"><Label>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Label><Value>29376_0040</Value></Option><Option index="47"><Label>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Label><Value>29376_0001</Value></Option><Option index="48"><Label>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Label><Value>29376_0034</Value></Option><Option index="49"><Label>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Label><Value>29376_0017</Value></Option><Option index="50"><Label>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Label><Value>29376_0050</Value></Option><Option index="51"><Label>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Label><Value>29376_0020</Value></Option><Name>relview</Name><Default>29376_0009</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2ZE+V
+fpUqpzSouFX6VIBWNihAlOCU4CngU7AM20u2nHhScEkdhSIxcZKMvs1ADdtNKD0qUikxQBAyD0qF
+4we1W2FQsKLAKn3R9KZKlzvzC424+6QOtSJ90fSpVoAqlb1WG1lYZPYcDIx+maN1/n7ijr3Htj+t
+WJbiK3AMr7QeBxR9qgGMv19jTAjBvN/IXbkccdKdKboMREARnjPpj/GnpcwysESTJYZGPSk+1W8W
+FMwJPTJznmgRCWviOI1Bx6j/AD6Un+nbv4cZHGOnHPepxe2zAkSjAGack0Uv3HDfSgZTDX+PmjXP
+4cfrVh6mNQyYpAIn3RUq1EvQVIKEArwxylS6htvTNM+xW+7d5fI75NKIkLEkHJ9zTmiRjk5/76NM
+Q1bOBHDqmGC7QcnpTF0+1AH7rGOnzHip/LXAHOB70giXH8Q/GgCH+z7XGBHgY24DHp6daVLKCJw6
+IQwGB8x/xqXYPU/nSFAe7dMdaQDieKgcVL0GKhc9KGMUU8VGKkFJANWLGfnfkY+9TxHgY3v0x1pR
+ThQIaI8fxufxo8vjHmP+dOKhhgikESjbjPy9OaYCbCAfnbn3ppU5++3WpTTaAI8EDqT9ajepmqCQ
+9KTGPFPFMWnihAPFIY1Y5OfwYilFOxTAaIl/2v8Avo/40vlL/tf99n/GomtwBlWfI9ZGxRHEXX5m
+YL2wzA/jTAk8pQc5b/vs/wCNKaFQIu0En6nNBoAY1Qyc1M1QSHFJgPFSColp4NAEmQBShh7/AJU0
+GnA0wF3D3/KjePf8qM0ZpgIXHv8AlTdwP/6qUmmE0gBjVeU1IxqCRqQAshz2p7Sso4AoooGILl/R
+actw5OMLRRTEThyfSjeaKKAAsajZjzRRQBCzHmqs7sF49aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0025/full/!100,100/0/default.jpg</Url><Caption>29376_0025</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUHp
+UixD0pQtSAVmUII1x0pwQelOApSQuAQefQU7AM8sZ6U4IB2oEinnD9AfunvR5i+jd/4T2osAFR6U
+0oPSnhgxIAPHqMUEUAQsg9KqXMQKjI71fIqvOvyj60gJVFPApq9KV1Up8wBxzzTAkGPWnD61iyso
+uTngY7Y9PrV63CdViBI6FdvH5GmIuc5o57kUveq8wQJuIXODyceh9aAJ+PUUhrEilxhU2sT0zjit
+KCZNg3Tx9Pu5Xj8jQBMagn+6PrUyuki7kZWHqpzUMwyBSYyRegp5+6aYv3RTm+6aAMu43LMxz1IH
+U+1WLUgHafMHqwbr+dV52P2hhx0/p9as2sW5RvQNnrx/9egReVNpJ3s2fU5pkufL4J7+voakVQow
+On1qKb/V9uh/kfcUAZON20Lkk+5/xq/ag527XVQM/MTzVBGbcMbSRzgkD/2ar8Hn7cYCg99oI/8A
+QqALRFV5hwKn7VBKeBSYx6dBT2PyGokPyj6U8k7DSuIzpZCs77SM46Ej0qa3lZcOXQj0GBVefP2g
+5fpg4yc/+hVPbA7BtkJyecbv/iqYF9ZkYgBhk9qbMcR/n3x2NOjXYuMknvkk/wA6imJ8vqeh9fQ+
+4oAzl3OygHI7/Mf8a0oGzHj0981nQAmQkSYxjpk/yaryzkKAVYn2H/16AJSagmPAqQPuz8rDHrUU
+rcCpYx6fdFPP3DUafdH0qX+E00BlzsFnY5GAB3H+NXLWLzF3Fk68BVFVbhsTtyeMdz/iKtWsnmIW
+dpDg8YzTAu1BPjyxnHQ9ceh9anBBUEVFLny+M9+mfQ+lAjIBRcbjlcZ4P/160YFVl3bB7Nx/SqCy
+HcMFlPTIJ/xq7Ddx7Qhcu3sDSGTtUEo4FTk5GRUEp6UmBIh+UfSpB0qCM/Iv0qYGqQDWtYnYsdwJ
+64NSLbxLjCDI70oNOzTAWmtGrj5gDj1pc0meKAIRZwA5KZ+vNKYYgQQi5HTipCaaTSAaxqGSnsah
+kakAkTHYv0qdWNFFCAXec0u80UUDF3Gm7ziiigA3mmFzmiigBjMcVVlds0UUAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0011/full/!100,100/0/default.jpg</Url><Caption>29376_0011</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2JIRj
+lQfbFTLGABgYFPVakArj5UakXl0uypcUhwAalpAM8ul8uohdKCVPUGsDxl4kttF0WUm5MUsi4V1P
+Ke/tUOcUriOiYIgLOwAHcmsI+MtAW+Sze+WOWR/Lj3KQGb0z2/HFfOuu+OdV1AeQt7czQqx2tLIT
++hrm3mubgiSW5lY9sseK2jCTs9kTzH0dq3xAk0PxBJZ3lvbS2ZwYZYZPmYe+cjI/Cuit/Fmh3Fvb
+zC+jQzglEf73HXivkp43PzGRyfXNadnq89rEsM4M9sG3FCcEfQim6U1dp3GpH0rdeONFs74Q3Mrx
+QNkC5ZDs3Dt6j69OK30ljlijkibzI5FDK6cgg98184w3VtcxRN5s00UxI8uWQsqHHbPSvZvhubk+
+E4EmJZYyyoT/AHcnAH5/yrKEpNtSWpVzp2TminsPmoq7IZaWnVHI+yMt6Vg3OszI7BU5HP4VRLdj
+oiwRSWIAHUms29vZYwuyCQgnAYgD+Z/pXOSa3dTbpE2HZyBv4+tcT4k+JmotbSWml20vmgc3DoCq
+j+8Of51jJOWiYJnV+JfFNjotqZbi9SK42nEKMd7fQfnzXhGv+Jb/AMS3Aa4kZbYHCpuLY+pNZ969
+1JcvcXlxJJPIdzO7ZLU0CQhmH3Rgnjt0zVU6MYvm3Ym3sM+zswZCPmXv7VL5QVdhXkDFLKzQy7GB
+yR19amjieYdcZFdKJ6kTYSIE4Cn7opqoHycDGOaZKWL4PTtUttuAkB6lCBWnQSJdKb7PfLBKSYHb
+jnofWvof4b3Q/wCEd+zzTpvE7rCjMAxTjt9c/lXzmBvtxICQynNekeFNYvrrVdHeAEyPIsbMcY64
+P6VjVT5k0WtD3UrzRUpHNFTYsp6rcraafJM3QD8685udbmkBcSqzA/KcYxXU+P7hrXQY2BAQygE5
+56H/AOvXlSX8c0XzMV+TK56kevQ/5/CuWvKSdkS7Fi41S+e8aZCjQE5dGA+Ze/8AnvV61t9fuHMy
+XMUto6lQMKAF/mDjtiuWvrgNCVhiYrklnBwB+J6fT+VYkepSae7SWt9Isv8AdViR+PGKdOnUtqSp
+WOg1fwrGkUaDc0xzj6nH6cH865+8tvsMEhyMFfLB9TnJ/TH51r2PjErGx1K2cy4Kh42Bz6jaTkdO
+f8iuc13UZNW1Dy4EKxDgZ4Jzz+FbU09mNtWFggfVctGVVUfG+RgqhcdST9Kt/a9LsiIUWa+kxh5Y
+jsRf93IOfrVQWDzRw2kKsyg7nK/xN6D2FdLZeHobW0d7p1RguQuf0qpzSe44oyFh0q7j8tYL1WJ+
+8zLhD65rEXzkvXtkYSFGKhk5DfSun1ePSLm3tovtaW8UTHeioSXPrkdfSseCa2sUdVUSucjKngj/
+AAq6ctBtXIGjeF5ojtPfjkc10vw5uZY/E2nRlvkFyOPriueMrXM0kjALhAMAYrpfh5bCXxXpyqfm
+88N+XP8AStXrHUnqfSpHNFIzYNFYXKOK+KkbyeCpHjzujlR+B714zpc8Ijvbu9Ym3gC4iBwznkBR
+6Z9fQV9CeIrBtU8P3NojBTInUjPvXzTq1pJp2pT2wbzFiKmXZ25PH15oVm9SJLUr31/d6jc7WGyI
+fdgj4RBWlc6Hd2Xho6jdNHBExCpGE+aQnOKd4bextrx7q8aJ02N8sg6H15/zxR4k1m5122haCNxp
+tkpKJswuc4z/ACpO7YWSRnaSzQaim5Fm4BmeQb8E+g9e2PatOHwqUlF3NIiR7txB6twM8dupqrpk
+n9mQPdXgR7mU+YA3UfhWXqGvXd0dnmPtHQZrO8nJ8uw9kbd3q9vp4xGqO+MZ6jH+FYd3rlzdysRI
+3zdQKom3nki81wxyegHNN8iXkJEyj0wSa1hTW4OVhCGeUeYxAPrV1MJgKQT2z/Kq8drck8RN/wB8
+mrUFpPLK0cakuvDN6Vvyi5x3mGRvLXnJzIw9fQV6j8IrCOXxAblk5hjJXjoelcHp+g3kzAJFk9gK
+9i+F/hvUNKe4urtTHHIuFU96mWw0z0ZyN3SihgM0ViWRI25AO2K4rVfhjpepSyGKaS2jnk8ydU6t
+7A9ua66N8oKkD+1IRxEXwo0uBk8p8InOGGST65qyPh3bQ6c9rE6uuPkV8hR+A6/jmuy8w4pRJxUN
+IDxm/wDgtq+oXZlk1W02n1DZFaWlfBC1tCHvL0TuOgC4Ar1YPmkKgjAyPxprsI4uL4Y6ahBdg2Pa
+rC/DfSkfcFH4jpXWBVAxgnPXmnhgoAA4q0LlRzH/AAgGmfQ+wFU9N+HFlYXN/IZRItzP5q/LyBgc
+fnn867TdmlLc1aYcqMKz8H6TZyCQQhmHrW6AqLtUYA7CmsfUUwvjOBQOwE89aKru53GioKP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0002/full/!100,100/0/default.jpg</Url><Caption>29376_0002</Caption><Caption>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Caption><Caption>Exhibit</Caption><Caption>plate 051</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21FO2
+nbTt5605BxingVlYoy9T1S10iATXbFUOeQM4AGSfpWH4H8Xp4ws764WMRiC5MaDGDswNpPPXrVX4
+hSmJbcZDF0eFY8cncRuP4AfrXF+F/EsHhbXba0KQrb3QENx5edsbZ+Vgfx5rB1Fz8pXL7tz2fmnC
+lxkZpQtb2RFwxml20oFOxTaC5WlnggZVllRGf7oZsZqQAEVg6tZLLJPO1o0xCkbrp/3ag45UVraZ
+btb2KI0aRt12o5YfmazjJuVrFEzocEqAT70wxkr8wAPtVgikI4q2BSZTmip2UZooAmUdKkApq9qk
+FMR5t49Fzd6lHbBSiqP3ZA5bPU5ryXxTpUthb2NxCG/0gyKcghg6nBB/Svo3xDpy32nMcYkj+ZWH
+UfSvIPFNhfahaRRXV8rRW7M6DYqsSRjkgc1wVJKnV97qdEY80NOh2Hws1rU9a0djfajBc+R8hjKn
+zU9Nx6EY+tehCvmHSNR1jQb57zS7h4HYBWXGQw9x3r0fw98X/wB8lr4itPIJ4+0xD5fxH+FdUJrY
+wkj1gCq0uo2kF0ttJMqysMgGpra4gu7ZLi2lSWFxlXQ5BFQtpdq941y0eZWweT0I6Ee9aO/Qkdeo
+JLGcbiuY25HUcUQrcCV/M2+UMBO5981DfXtvaqILidFL4xuOCRnn9KsQ3CXESSxEMjjKt6j1ounL
+cZIRSFeKfQRxVMCuRzRUhHNFADxwM1Tk1a1hcq7MMd9tXP4SK5+/gDSE9faolKyGkav9qWEo2faE
+y3GDxmuG1vQ4jdzAxgNkkH61cuvIjx5pC+nrV0XsWoWLQyAmVFyjkdRXHibzjdbo1pNRdnscHBpU
+UV1g44B4rK1fSAJT+7BU8gkdq6+0snvNae1GEZFJJY+ta1x4dkhhJdlkAGcY5rgpVa1+ZrQ6akKa
+0T1PM/DXjS+8E34ibdPpUjfvIT1T3X0NetW/jjT79BdWAe4h2dRwMk15J4uFnGBbxIGdueOq/Wsf
+wbfzWeuf2YJcQ3J3AHsw5r1IVHKF0cc42dj2PVL+K5MshsovPkXaZGG5gPb29qpR63dKMzTupztw
+GwFGf0FQmURowAwCpw552sBxn2rJguGu7qdCAUbCDHOD3/Os5VHfQdrHWpd3i/OjyYHJJY811enX
+JurQM33hwa4c34hkTPypux9B2rqdAuEl80IQR7etbU5tuwSWhsYopaK3uZkcr7IHfOMKTmvKdW8W
+XsTy/ZxM6BsbzgD+tepzAvbyKOpUgcZrxDxEbi11R4ZGIkLEhT8o/AGuavNxSsa043ZXl8UaxKwx
+Z2yAHIkcN+vNbHhjW9UvGv7i8lgW3ih2hY1wCxPX8gawbSDUNYj8p7clWbJJ6FfetK7u9O8N6LDa
+uytJIS0qRqcuR0X+n41xObldW1NVFJl3wz4jin8RSQzMFuWYGOQn/wAc/L9c16PrV0bTRp5V/wBY
+qYBz0JIH9a+d7a9vbrWFvI7dQ+/dhQeDXsy6lPqWmRrLbMLhk2yQOcCQEc4Pr3q1aMeVbkXvK7PM
+NVzB5ssilpZMkknJzmsDToJRqkd3sZdjfJjqTXc6mI7S5EFwiMSPkdsbx7ED+dcvaaxbHWHmaBzE
+hwrDkce1a0ajatbYdSnbW+51kVvrWqxBPMNrbkchT8zfU1Zg8MTQZMV1Msg7hzmoI/G9hbwkxQSb
+gPTg1UtPiMj6yqXMSQxbCWJPT0rSLk9kTZIuvezRB7S8yZI/mSUd/rXd+BJ/tMcjb8hBjHua8f1H
+xA2sahMbBCwxhTjqTXqnwvsb630y5mvo9jOwCYPUdelaKNpIhnfZoppPNFaEkCvWTq/hiw1mQTS7
+o5uP3iYyQO3NXkc1KrZFKUVJWY02tjm7rwZHI4MEvlqBgheM1nX3gD7XayRO6dMqUGDn613Icil3
+msJYamyvaSPJtG8D65p8sqrbQbQPkeQhs1en8O+JbqNkuFKtjb+5kwO/Q9e9el7qYy55yQfY1n9T
+h0bH7V9jx9Ph7fG4xcaZI+OBKZ935jio7nwLfBytvo0iBQQCeQa9kRARkluf9o1Nu4prCrpJh7V9
+jwyH4feIMpt06LYp5DsRxVm1+ENze3rTahbGHecnbOCP5V7VuNG81tGhy/aYOpfocppnw50PTYUR
+IOVO4HPOa6qOOOCIRxgBQMACkLGmFyBxWqilsQ5Nkhbmiq5c5op6CP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0010/full/!100,100/0/default.jpg</Url><Caption>29376_0010</Caption><Caption>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Caption><Caption>Exhibit</Caption><Caption>plate 052</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dIx6
+VMqe1CDgVIiBegAzzxXOkaAq4p4WlAp1XYVxNtKRS4oNOwXGYppWpajkkRPvEZosBGyiqt0g8hvw
+/nUqS292SAVYr+lJcKBAQBgDFS0NEyDgVIKYnCipBTQmKKcKQUoqhDsUuKSloAZIQiFj2rndXvfJ
+i3E/M3vW1euAFUnHOTXn3iS+Ml0UVsKDk89hSY0bPhq5a51e5wflVR06V0tyP3LVgeC7Uppr3Tfe
+mbI+ldDP/qjUvYYqcoD7U/eqjk01DlAR0xWTfXjqxSOQL9Bk1POktRWuabXagkKpOKYL8q2CgP0N
+c1NfXka43jGOWIFNguJRAZnn8w52qobOTQqlwsdDd67bWiZckE9FAyTWSfGsavzay7PXjNURblpD
+JJ88h5OafcaerwsWAUYzT5hG1Jq1rfWvnwOCdvKnqK85vUN3eeX93zZNoBPOKx7rxhZ6JqLr9rUF
+SVIA3A/XFTeHtc07W/ERna9hGOQhOCfoDTA9jsIorSxigRgAqgdamm5jasy1urc7QvTtxWlKf3ZN
+JvQaFjGYR/u1x2prNHcufMePBPI5H612MZAhB7Ba8+8V6jdxzkQPGRnG3HJrjrytFFRKkMBnuW3S
+XFwzkDkHAH41vGNLa2QKuQgzha5+PV7Lw1pNu2uXwhmvHJRG6gfQdBXSW81tcWiXFvPFLCw3B1YF
+cfWrp3SuxNhBdRSKJGdR7V5t8RfHLyxSabpk22EZWWRerew9qqeM/GdrmXT9LZWcjDzxHhfYHvXl
+s9xM52uT16mtkSPVWuCWY555qrJLLZXSyRMUkRsqQcVdsgpRgA289MjrVC/3PMc8H0qovUOh9AeG
+tevbiSzdljELopBx7V6szZgB9QK+fvhrr0N7bRaa48u8thkZ/jTPUV77CS1lHn+6K5oNqUost7Ji
+yNssGJOMJ1/CvItSvo11S5up3UQwn7vdjnpXrjp5tg0Y7pj9K8a19fsmpNHJbeZ82SGYgH8v61FV
+K8ebYaPMPEWp3fiLVZ9QvJGaTdtjjUcRqOgFVILvU4rBraG7lSCQ/PErkA/UV6jHqWmQI7W3h+zj
+uJARJMxLbs9eD0rMh8OW8y/aLe2jimEgYHeTkfToK2daC6k8p581vOp2FSoGN2RjFadloUt8wZo2
+WJR94jk131joMSTFrqNXkP8AF6/SteKxgi+WOM7s4+lcdbGJaRLVO5xtto6WKKVjbGeuOtaFvpqy
+y5NqrNjrtziuo/s6OXbvcKnpTZBHZzHjjHJFefPFLfqbKkzKsvC0beILPVFhlhmi2j5Plzgnk/ni
+vbIBizj/AN0VwWiXYvLiKJPmKn5iPSvQMBYgvoK9HA1JVIuUvQzqxUXZCwf6pR7Vj6r4UtNUmaRy
+VJGK14D+6T6VOCfX9K73TjONpGV7HBXPw2V0xFcAH/aFC/Dy4SPat0uR0r0AGnZ464rH6lRfQr2k
+jiovBdwn/LZAMdOtQzeDdQlyivCgY/M464ruTv7NmgB8cuQfwqXl9F9/vGqskcKfh9JsOL1w54yc
+Vbh8CwIiiSd2wMH5v1rsc8dc0wnimsBQXQftp9zJ03QrPSkAhQbgMbsVdkPFSMT61DK3FdChGCtF
+Gd23djIGPlJ9KsAmiimtgH5pdxooqhCgmgMeaKKAELHFNJNFFAELsRVd2NFFSyj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0006/full/!100,100/0/default.jpg</Url><Caption>29376_0006</Caption><Caption>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Caption><Caption>Exhibit</Caption><Caption>plate 053</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xIwB
+wKeqgk/KRj1FPjwVBHQjIqQCuexZF5Y9KXyh6VLilxScUFyHyl9KPKU9VFS4pHLKuVXd6jPNJRQX
+MrWNW0vQLQXOoyiKInAIQsSfoAaybPxv4e1AHbK64OB5kR56/wCFdHeWdtqlk8EyB43BBBHSvIL3
+R7bRNYSySNwULELnO4dB/Osq1R01dIa1PUtM1HTtZgaSycOqnawKYP5Grpt4/wDnmv5V5tZ6gNFk
+WSCePzONw2nB/wBnPpXpFjO13YQXDoEaRAxUHOM06FVVVtqNpoDChBBRSD7VF+5J2qUJ9BVzFMKD
+0rflQrlJoUz9wflRVgrzRUcqHcfZA/Y4M/8APNf5CrQFQWa7bOAHqI1B/Kp2dY0Z3YKqjJJOABWp
+IjMqKWZgqjkknAFc5deP/ClnO0M2u2YdTghX3Y/LNef/ABH8Q6rrJFppYnGjhiklzEDslf8Au7vS
+vN00uKIgXX7tScbz0zjOKwqVeVlxhfc+jLTxz4Wvc+Rr2nkjqHnVD+TYp9r4y8P3l7JaQ6rbechA
+w0gG7P8Adz1r5xj06CC7m2qJWQbh3ypHau38KeFE8RzSXLHbbx/I+xgZG4HbPA9zWartuyQOCS1Z
+7XI3kusyZKNgOAePrXDeN5Db6vb3kGnm4Zh5TSKD8nGQc9vvY/Os/W/E8+i3Nvp+mtIllaLiRXIY
+v1ySecjp0961Z/GumWGjnUdQwkcigLF94zL6Y/kffmlKUanuErR3Mbw5orapfRz3FoY7SCTzmeQd
+RjPHrzXcWMf9uot9OhSwK/6Nb5IyP77Y7nsOw9+nAf8AC6NEPm2cmkXdvaupTMYTIBGM4yK6/wCH
+viG31fwzHGrfNZjyWYjAYD7p59Rj8a2o0lTjYcnc6LTkkWyQSb85O3zM7tuTjOec4x1qwwrH1LxX
+p2nahFZN5kkzrvIQfcHvWjbX0F5HG8LZDg4HcY65rTni3yp6isxWXmipSOaKLAPXgYFcF408WW3k
+XWgeU7zyxFS0bDAbsP8AH2zXejpXhuuG3tPiJftPbh0dyQpPQ9zjv/8AXrOtKUY3QR3HLquu3EqL
+qIeSBVAW3sWXEYAHBX0+mafcWMV64nfQb0nPAZPl+uBWxFrdvGBHG8cOVBGEKgjn/CnPq0KRs0uo
+nr0Qkn9K8qdWT3/U1suhz9zpisjD+z54CRjcARxXOrquoaTrEaJeG1ZUK7ljCuVPqcc/jXT63qUk
++ms9nvUYBaVs5A7n24rPn0q3u9AWRZIGl3BiyINwB7g57fWs6NRqQpLobf2KJ5TbzzOzqN6zvht4
+6EY6V5x4tmlj1v7DcSyPFaxbIuMKGIzwO2eK09GMkV3LNctI7x8pvkLc45PP+eapXNlNJO11cLtN
+zKHeR1PBzwqjBJ9K7KEXCb6iS7jNC0mHVdAvZGkjF6ZkSNXYAnnkDPc10HhWfXNEt5prC5gMIJEk
+LjIbHH1z9Kr6fpF3phiurVkR5JPMG7+AYIB56H0+taZltLKKR7i48+YnJCnIH5cCtqlS2kdyl5jL
+CaSZZ7qR2Mss+92dyXVAc4/M/pXoHgvVVfVZbZUP+kDfjj5Qvc+5zXkQ1aZ5Z57eIttOF2Hken8j
+Xo3whme/a4neRj5KlNjDkEmlTpS9rzktqx6oaKU9aK7SAWvEPHtnND4onlMaSAvvTOQcemQa9tU8
+VyPizQBfTrcrCX45K9RWdX4RxtfU8v1C9e+tonS28iVRtC8c9iBzz/8AWqnN4h1qzLQpFEuOeE/+
+viuw1TRYk02YLbh5FXfhsk8cnHvXEalepuWOFJGEah2IOQPpmvHnG0lFRvcqV4vQiuH8VayQFDhC
+MjBCD9OtMuNL1Szgjhcz+dbkSHugBGfoO9dT4eubprdZrqO4CEna7LwB+VbdxBJdN+6gMrsAdxOB
+gdK3g4xdkrFWvqeY6ddypA01wGSYHKns6kY/SugF6EtVukINwBlS3z4x2rZv/DoMAFybe2iyABjG
+SeBWY/gaWzie4tpZJSo5TdwR3/SrXLJ3DlMi78QNcMqxRm4nkBYlzwuDj8elYV5fy6hMBM7RQ5wx
+jHyCtpdMu7O7EyRsYyuz5s5xjPfoP8a1df06xh+HcAigjS9RwZQrBick5PHauinZPRA4i6L4LeVP
+OEpZZFA3oeCPYivZPB2hW+h6NshjCvI2527mvEfBF/rVtqMWmxFpbdhuEWOg789q+iLNPKsokIIw
+o4NawT5ncmb0JCeaKQ9aK1IIkfipMhhg1TjkyKlB+v50rhYrXOkQXDb1wrHr71kt4StI3MkVnb7z
+/EEAroQ+OOadvrGVKDGpNGENHnVVCqgA9qyda8N3TWU1zYoyX0aFozGACx9K7TeajkBYghiO3BrL
+6vAbmzyO28Ja/qsQ+22UiSNjc80mdvP8/pXdwaBP9kWGdd5AwSe9b6I4bmRsfWrCnAA5/GqpYWEF
+ZCUmjiL3wK8z+ZbvGpIGUlQOvH6/rVST4f6legQXV/BBa5yy2sO0n8STivQ91G6t1TiPnZhaD4P0
+nw+hFnbgO33nYlmb6k1vk4FRE+5ppcgVasiXqOLc0VXMhzRSuFj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0007/full/!100,100/0/default.jpg</Url><Caption>29376_0007</Caption><Caption>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Caption><Caption>Exhibit</Caption><Caption>plate 054</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dEGP
+pUqAMoI/lSRjipgK5kjVgFp4WkjZXXchDDkZFSgVaQhoWl204ClxRYCF2jjI3sq54GT1o21wHxQe
+6t0sZ4ndY8sDtOPm4NWfh54qOsWr6fdSbrqAZUk8uv8A9asFV/eODRq6XuKaOxcpv2559KieMVcY
+VC4rZoyQyMcCluTGttJ5uSrKVwOpz2HvToxwK5nxdrf9npAICzS+cEbaMhMkE5+o/nSuoq7GQ+Br
+1ornUtFmMitbymaFZfveWx/x5/4EK7NW3Oy4+7ivLNW12S08ZWGoWUKi6I+y3EbZAIbpz3xXplrL
+iPfMQsknzFR1HAH9KcZJ7Ay3S1EJoyQASSenBp4bJxg/iKsgxvFekLrOgXNttzIF3x/7wrwPS9Um
+8P8AiW2ukJXyZgsg6ZXOCK+lmxtOelfMfil4rjxNfx2/zK90RGF+tceIjaSkjrw8rxcWfS6sJI1d
+TkMMio2plhG0WnW0b/eWJQfyqRgM11X0ObqMj4UV85+LvEt9deK7qC/ykMVwyjbxjBwM+o96+inM
+gt3MKq0u07FY4BPbJr5z1SU3usXlhqls8F0JWHz/AHlJPQnuPespq8bMa3OguLst4bs7mMHfDcI5
+LEHGPmI7HqBXuVrIksCyRhQjDIxXzrFcX1lokmlywLJbjc0cmeemMH1/+vXu+hanbSeGNPvJJo4o
+pIUwXYAA45H55opaKwSNkqGGDVW/1Kz0q3ae9uVijA6uawfEXjvStDQxJMtxdsuVjjO4D0JIrxXX
+dRvNc1uObXLyWC1LfMY03lF9lBonVs+WO44wT1lsdv4s+KsE0MtnpUjRoQVaXHzMP9kdqofDvwVP
+quox63qFqYbKNt8Ik+9M3r9K6XwN4a8CTxC70iVNTnjwWe4OXQ+6EDH5V6L0GBwKiNJuXNN3LdVJ
+csFYaahfrUxqF63bMUEfSuX8a+B7XxVaieIrBqcI/cz4+9/st6j+VdPH0qYVCegHzcLi6tZp9M1G
+NobmI7Srjof6j3qG/wD7St7RIH8yWxDF1gzlVJ6sv5frXrHizwYuu3vnPK0bIz5kHJAO3bx6fe/K
+uM1XRNW0GLZcobyxXj7RGhwPqO1YyWhcZWdzn7OKxFqsqBo3LhiJPQVj6/qaXU+2LayqclwOn410
+h0ganCkkXlTKg+4z7Tj+X6VR1FrMeTY6np0duYh+5uok27fZgOGHv1+tYRfK9eho9ShYXN54au7P
+XNOcrLHguueJF7q3sa+ldC1m18QaNbanZuGhnTcP9k9wfcHivmq8jup53tlIIVQxCYKlexz711/w
+y8VReFFuLPUXkGn3A82IgFvLcdRj3/pW9KqraszlF30PdWqFjVXStZstc0+O+sJhLA+cHuCOoI7V
+Yc81s2QLGeKmFQR9BUy0ogxsyBkOQMYwSfSvLvE2ua3ZzlY2EFirhFDDcrAdhxXqpAZSD0IxXB+J
+PCJ1C7KxPNI7AuWdshQBgAD6msq8ZNLlBHIwWtjeP9r068SzvHAY27cJuzyDj7uaZO8N5M+n6xaL
+DcdPnGM/Q9/qK2bbwvPpmtxBrJrm0ZgGdQQUIPPT6Ctrxb4ZXWJZHjg+ZMIrsWyGPTbg4xWMYyau
+0UpWPK73QxpLSfvJBCy4DKM/L/gPamaZ4fv9TRY47i2uTPuNusThslRyCO3XvWxeLfaPjS9ZhEiH
+mGTsR3GfWsu9srmyuodS0Wd7ScklTGeCfrR7Nu6kzZSSs0jsPhroHijRNake7tVhsJVZZU+6Nw+6
+wHr/AI16o9ef+AviNJrd1/Yusx+Vqij5XVcLKB7dj+ld/Iea6oxtG1zKTuxY+gqYGq8Z4FSjJ/iN
+WkSyYU4VGDQdx+6+PwqhEoAGcDqaKgJlB4YEfSnDzMcuAfpTEUtQ0PT9UV0vbdZo3xlG6Z9f1rzj
+xF4Jm8ORS3mjtJNp7czWzncYx6j1H616qCQPmbP4Ypr4YYPT0qXFMpNo8/8AA2gweeNWkhZZo12x
+seOCOa7d+tPxt4HT0xULtzSSsrDvcIycCpgaKKEITzDntThISegooqgJAeKM0UUAISaYSaKKQETM
+agkYg8UUUmNH/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0004/full/!100,100/0/default.jpg</Url><Caption>29376_0004</Caption><Caption>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Caption><Caption>Exhibit</Caption><Caption>plate 055</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hEOw
+BeDjqRU6qQo3dcc4FNhB2LnripwOKwSLKsF9aXEojiuI3cgsFB5wOtXAteL6402keLtR+zXUkEyT
+GaKPkYBGcr6jnkdK6vw18SI7+4NrqiQxFVH76MnBPqVPQdOeaUZpuxTi0rs7/bRtoWWNohKHUxkb
+twPGPXNZV1renyr5cGpxxzhgV7gn09xVNpbk3NXbTSvBxXNzazqJ1poPKEMcg2wb+QFzzIw9PQVr
+3l/baDpHn31yWWJeXb70h9h6mkpJ3sBOBKT8yKB3w3/1qjkiDdQDXMeFfG8fiPVrm2YxRnbuhiU5
+O0dya61hVAhkHMSnpkCrCioLcfuUz/dH8qkmk8m2ll/uIW/IUlsB5L8Tre3i8U2987sCIApVTjcc
+ng/hXnFvti1u0hWUx28r/OxP3F7n8K3NG0vU/iNr+tqLtY3iXzlaTON+7AHHQYz+lYuo6Zd6Jfmw
+1aBoZ4/X+IeoPcVlHXXuavTQ9SgvPFXhgqscL6jpzjck9shkRl7HA5HFNPiXRtYU/wBoW97HcNnd
+Ak7Ku4eqk5WuQ0HxbqOlhILW/wDKtx/A7FvyHSota1u78UanBB5Uclw52owRVY/UgZpuV1ZohwXR
+npeizQ6jpVwLnybC0t1Cj96TIQDnlieR7VwvjbXJ9X1VkMjusn7qyhU8AHjJ9/U1Z1DR9R8MfZLT
+VIBOlyPllRtyh+u05/nWf4XK3HiC6muLiOJrAAxPKudvPYAcnpihNRV2S1bqej/DzwRH4Y0z7Tc4
+fUrgZlbOdg/uj+tdk3WsTw1qNh9nj0u2kuZZIlZ2eWMruy2Scn3attutXGamrpgNgGI1HoBUrIJI
+2RujAg0yPpT3kSJC8jqijksxwBTWwj56We6+F/xLmneN2spTslA6PGxBBHuOPyNe2avoGh+NNIiN
+1GtxC6h4Z4zhlB7qa8v+MPiHRNTtobW0dJ7uJjulTkAY6Z7813Hwt862+Hmnm+fb94oXOMJnjrWd
+OSu49DSd9zl9T+DmkaVY3upf2petHbwPKsWFBOASAT/9asDwLoT3Xi+yaMNsi/euSQcKMH/AV6jq
+fiqxuZbzSTY3VxGMwzOiZUKRgnjJxz6Vy/8AaC+HraSy0qCKK9uY97XRlLssfUE5xg+g/Gom1KSU
+Xp1FGaSdzR+IOq21xJDZIQ6WjGaeRT9xsEBc+tcB4M8OXniKfUr5JTbxeYhSQkjJDcfy/SqcV/Pq
+lydOtc/Zy26Z3G4nHJPua9F0/V7Xw3pGnQCwnitZlDeayAb278A5Pb8M1Upx15tDI9CjhjgUYVVY
+gBmwAT9aRuTXm+p+Plt7q01OAy3OnFmilRQFbdxzk8jH4d67vTNStdW06G8s33QyDjnkHuD70Qqw
+k2olEl5cSW2nyzQpvkVcqvqa8U1qPxt4rvWhMVx5W7CoBsQCvc0xgVIMY4FRKPO99C1Ll6Hjvhz4
+MuLhLrxBcB0X5vJQ9fYmtPxb4g0/7LbyxLst7dGSG2I4foAdo7VS8eeNL+w1SfS4LlFkQjzJF6R8
+ZCrnvgjJry2a7+y3W4lpGdOWZsnP41jUu1yrYaTlqzrPDniC8h1r+0ftQ3Rws0jt8xPAAAXOOuAB
+71Z13W5JpZJdqS3cwCOGOSc9/wCVc94eheyefUZ1MUYGc44PfFW/DOn3Xi/xgZbKAOFfzJZZMiNF
+zzwOv0pwbXuoU431PYfAHhkaVpK3l2iteTgOSVGVGKTxnos92Im06BJJ4lcrGTtG5sfhzg/l712K
+LsjVeOBjgYrAuvEemG6uLGOZXvduY4yCBIR0APQ88VrVUHDkn1IRxPw9+H9/Z3Oo3viS2j2znEVs
+WDAerHHHtXoOl6Va6JYJY2YYQISVDHJGTnr+NW7e6jmjC7080KN6BgSp96VzzTUYxWgIWP7oqUVE
+lUr83F3OlhAHjjcbpphxhc/dB9TzTWw2eDeOY7SPxZqU8swZvOZgOu8Hpj/PauUty8t2gihSdzyE
+wT+ua+i/Ffw/0fxRaQJKPsstuMJNEBkL/dPqK+fdRsLnSdVuRYJLPp6yFI2kXG9RxnAqfZM0UzT8
+ULNa6LFbeYC00uWCngccDPfrXqfgHQNa8N6CFt9Ptm+1IJDIZtrjPQYx6V5v4X0XUfG/iCxt5LZ4
+7C0YPMxBAVc8j3JxivpNVCKFUYAGABVU6fKtSZyuZCajfxxHztHmXA6RyK+f615J4st4B4gk/wBJ
+ECFtwWWJlaH2Br3I1zkeiWOsSXVxqemIHaXCrJ1wOAeD39qwxNF1LJEo5bRfCFvqEEV/Dq13BeOC
+XkhLDf7gk55GM89a78goqqTkgYye9VtIjs4LaS3sIBDbQyNGqjpkHnH45q0/WtIwUVoND0qUVAhx
+UgY5+6f0raKBlDXGvmtUgsYd7SvtkY9FTv8AjXn2u+Btb1KeKJI1EIOSwcZ/WvUwaGYjoufxp21u
+IyvC+iromjRW+398wDSHvn0/Ctqq5ucdUI475pVmdhkRn8TiqETGo9ih2cZywAPPpSqxK5IwfTNI
+TSGV47dLdAkICJkkj1JJJ/U02Q81IzH0qBzzUMaHqTUgJoooAcCadmiiqAWkyaKKGAhJpCTRRSAj
+c1VlJ9aKKljR/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0005/full/!100,100/0/default.jpg</Url><Caption>29376_0005</Caption><Caption>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Caption><Caption>Exhibit</Caption><Caption>plate 058</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V4o
+XDDIB/EYpyDipAKysiiPbS7akxSYzSaQEe2l207bTsUlYCPbShaeBS4qtAI9lIUqQ0lFhkEm1Bls
+/lmmYDAkfTpVk0wjiiwFUjBoqUjmiosMsIKkApkYqWrZIyk45HcU84PWqVxceQd+77hwwP8AdP8A
+hUSdgEa4WOfax/dqM7vQ+/8AnvVrcBgd65TVtZigt5ypVnCuSrdHHII/AVGniZFuIozICwXABYbm
+9Tjv2rCNVX1Bo64OpIAIOaeSAMk4Fcm+tiW2e6iOJUlHA/iXdtI+vX/Jrjdd1q71kJKS7NNJ5dta
+hsBQehOOp7k1r7VDjG56lqOowabbiWXcxZtqJGMs59AK5i88cRyTnTra3mttQHMi3KbTEn97HfOR
+j61wsd/rOiapbpFcGZFG2P7QxdYyRyQM8Vi+IZ5Y9YsdQt5XYvvWaeThnJ5yfrzgemKfO3sXyJHq
+Gh+J4z4jvLC8uBlkR0Zm+XOTx7V2SssiBkYMrDIIOQRXzx4X0WTxj42FtNIRZwr5lxtON6g8Dj1J
+r6IhgjghSGJAkcahVUDgAdBVQT5dRTsnoMI5oqQjmiqJHJTycCmLVC6vEhl2z7VB6Eng+lDYiae9
+hCOu8EgZxgnj8K5bWNWjihYhy8Uina+c8Y5H+feszxBrZs5RLDPmMnjnODnDDPcdD+Vcvd6nJr15
+LHBILe0Rt8sgPLvjBx6D+dclWd0VGLbshNR1WJmAafZz8pbksCPT8awNNu501hJ7iTey7mdj1xjA
+UfnmrclvZWM0u+6t7SV4zs+0N8z+5Hb8cZrnrq5AuEgWUuqjLPuBLH14rGEbstpRj5nWTa2kVxGV
+YgOu1iD1P+f5VHfXotBYXZmKyCNlUAHnK4z7GuTe42yxMXBMZB5/iA/yalnjv5xBcRQ77feHRQeg
+9PbpW8aexNOWjudReTRaLpizfLJeyr8q4yE3evqQP61x19fedGqzTM3ljMjZ7npWjq08NqizySiV
+9uFj7Lx1P41j+G9Oh1fV0ivpCtmWDS46vj+EVvFK1yr2O4+Eugatd6uusxzPBYed+8JJXzgBwoA6
+9fpXvlYmi3lm9hDBYxxpCihUjVfuj+lba5xz1q73M2MI5opT1opgNXpXnXiOSTW/EWqWgLfZ9Lt4
+2ManG+Rucn1wB0r0NTxXkfifRvEaa7fXMN7MiXSqj+V8u5VzjOB71nOzQ1uctqM268a2gXy5G+6v
+RWb0I9fepbOSDRdKuLxi0k6jb5T/AHSe3681E3hjUseeJbgSA/eJJNJJpF1fgR3jO7jqw4z746Vy
+uG2ponZPucncTLcXBeaUtLIdzueSxPrTBjd80hHAXcBwQK7G68Gw20CTCMHIz83Wlh0AyIFaBQOg
+yOtUrLZmXKYGi2EepatFBKymPIBOcgDufyrt7jUdLllntYFQQW6eXGQQBx1Nc7PpE9pKWtA0cuMN
+heMelVWsJltWhTmST5WfB4z1P+fStLXKSsczqt+by4kj+Vgsp2MvZPSremTi3AzwqkHOa1dK8EmW
+aaS5ZkiB4CjLN6/Su+0rwPpMVoCulzXDEZyyNmtHJJWRVr7kHhTx7Z2JSKVJl5/hOR/+uvZNPv4d
+SsY7u3YmOQZBIxXmmneEI59RSOLRpLeLGWmkQqB+dem2tulnaR28eNqLjinHbQmSsPPWikPWirsQ
+RI9OOxvvID+FVUkzUu81IyQW9uRgwpj0xUK6VpyuXFnCGPUhBTt9OEhocUwuNfTNPf71pE3sVpPs
+liODaKMf7Ip5kNL5lTyILkf2KwkBBsUbvygpRo+lg5Fhbg/9cxUgfHQU4SGrURXEi0+yh/1VtEv0
+QVYGFGAABUIc0hkNOwXJi3saYzUzfTGY4pgKWGaKpyylXx7UVN0Ox//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0003/full/!100,100/0/default.jpg</Url><Caption>29376_0003</Caption><Caption>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Caption><Caption>Exhibit</Caption><Caption>plate 059</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2lVJb
+7q7cdc80/wAunoKfisLFkXl0FABmpgKbI2xGYgnaM4FS2BUtLq3voBPayrJGSRuX1HUVY2VgeFNS
+bUraa4a2jt1dyY9qbPNUEjftz1yCPfGe9dJShO6TEyPZQUqSlrRMCLZSbBUppMZpjIWSq5SXPzbM
+e2aulajccUAUWXmipWX5qKLIC6g4p+KYX2JurGuvFFjBerZG6gS6f7kbOMk1N7Dsblc342vJLbw5
+dQxxzBriNo1lQDCE+pzx9aSXxIYePNiZvTH+FYXiPxVdSaNIIo1U71Xb5e4S5O0Lye5I5GCPUVlO
+SsFjH0LxlhF/4SGMQ63p8LLAxYf6QNp7epBX64q5p2qyar8JLrUGuZbu8eSSZ0SQlwwkyqY6gcAY
+9PrXJ3Om2etXsOpxsVmddymRjlAF2lW9xjOcc49q5XTjrHg/U1maQf2fLIfM25cdcEjHeslK97D8
+z034f/EX/QZ7TxHfxqYVRraefEbSqc7hngHBxjvg16Jp2vWOqf8AHtKrKRlWBBDD1zXhst7p2t3U
+M2iRwzTyq3nxMwXI4wQhPBz17VVtV1HQZJnsbj7O6MTJZyDKt7gH+YqoVmtJI2lRUtYM+iY7qCWR
+oo5kaRfvKG5FNkvbWJ9r3ESt3BYcV5Zo3iOPV9M+3RILaZfkkUNyGHv37GuY1XV7iPUHKTvuwcHd
+6HkGtoz5ny2MLWPoHIIz2prDIrgPAvic3hSG4ldjMoABOQhH9Oleg44rRqwiow5oqVl5oouBwvxT
+v5LLR7ZopniZS0gKNgkgcdPrXkseqG402aKRhJcA/aludvzrKOTlu4616X8XraG8sbUPIUeJWI5G
+DnHGOvbtXjtteLFIYpXeJD8oKdOnXP8ASoteOhcXZnTvqut32HN5DAwUMBFCCCPX5s1asfE087Lp
+2sRJHKCBDMi7VlOc4Po2fz9q52w1+6skZGsIbqPdmQyA5ZOnH938K17m20zWbG5u7K7kxEqtLaTR
+/OgLDo3/ANb8a4588fi2NrQkrI05bye3gSaCRUlVi2P7x546H/8AXVtJvt1jLIluJps7bm1PXOOG
+TPfH5/hXMpb6ho0qW+tLLHEwLQSSkZHHTd0I/UVZivXs5Y7uO5RJM7Y/MO0yj2B+8PcZH5Ulq9Nj
+BpxdjC1bTWtX+36TFLBNavukJz8mc4xx09vrWjcavJfaHaXszMk++T5SeigYI+hJ/SumS9XWYoCk
+jxXKuBMiqWVmPHzD8ufqM1y3i7TJdODtHEptuqbBwD6Ee5rV+9aJpTaTuVvDd7dm3ltrVDveUuzs
+PkQEAZJ9eKl1J2guo0abzlkIQkrggmqWhavbQWFwiymGQ8vG56MOMj25PHbFOkSJ1E4uN5EgYknj
+jsK6YR11M5yV9DrPCVysFxhm2yqMJxxXq3hfV47q5uLEsxmjUOcjivBRJli3nctzj0Fd58MdXuv+
+EpFpLIHjlhKnvyBkHP4GqkSj2EjminEc0VIzzz4l6L/aFvbzLcGM4K4PQ147Hod5b35SPbNHJ8rK
+y5BBHX2xX0nqOnx6vpvkuSpIDIwOMGvM/E/hfVLVV+y2DTucgOBmMe7dz7Cs25RKSTPP9Rmt9PlE
+Mao5RcZkGQcY7f561Q0fxEkLXSSKqxzRmJsEqcZBBBHQgjitTVfCGrX7Bmt5YhnLERnj2GAKgTwV
+M+nNDb2Nx9o3hjdSKT2+6BUOUOWzKad9Dq9E1OW90z7PNd2moR7uIL1Q3T/axjPPXBPX0rO17UdT
+uNUjhl03TLd3UeW4h81iOgw2AB04wO1ZOl+F9U0+53JZyz8dGidAD+BrZRru0CteW9v5gbh1UsR7
+bTn9CO9c6UVK8R3dtTDW51nQr9LgWwypz5ikk/lmt+LxTpes33kzKiGRSJU2lVLgH5sHpxnnvVGK
+/wBTkndk0Tzo2bmSOQbx+FY994a1nV77zdP0a7ijH8e0kmt0ubci1tihr2kRw3e2CUPKjdjnI/Cs
++3uQo8u4Rgqtw46fiK3ZPAvigv5otLxJCOcoTk/XrWrp/gDxRcSfvtGlkRv4nULj866Iz5VbcLXO
+ftLmOKffujYYIB3D/Ir0X4UwSz+LxNGVEUMLGTbznIwOenetDSfhC82Hu0jtRjo3znP0BH869J8P
++GtP8M2PkWUYDNjzJMYLmnzX6BLTS5qseaKYTzRU2ZJVspC9nAwPWNT+lW1Y9yKyNKcnSrMnqYU/
+9BFXw5q9BFvdRuqvuNG44paCLBbjggGomkmU/wADD2U/40wsaN5FLQCZDNj5mjB7fKf8amDcDJGe
+9VBIacJDQMtbhSFqrbzQXNNATlvQ0xmPcioi5pjOadwHF8Giqxck5oqbjP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0052/full/!100,100/0/default.jpg</Url><Caption>29376_0052</Caption><Caption>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Caption><Caption>Exhibit</Caption><Caption>plate 060</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rhc
+4z9Kcqg/Njr6jmnIOKkArGxYzZRsHpUmKXFS0FyLYPSkYKoJbAA7mmX95Bp9o9zcOEjQZJNeGeNP
+H2qahK9vAzWtufuoGwzD1NQ7IaTZ63qPi7w/peReanbxkdi2TWbF8SfCM0nlpq8IPuCK+X7pJ7ue
+SWZzgepyTVeOzaRsfNVpID7Js9TsNQUNaXUUwIyNjA1b2V8hadJqOlXAmsryaFl5+VyBXtfw8+Jb
+alKul6yyi4/5Zyk/fp6D1PUSlQOyBtpYbvSrmARkdKjZaTQrlNl5oqVl5orOxRZiyUUnripQKit8
+/Z489doz+VTityAxWLqviSz0x/JAae4/55R8kfX0qh4u8VQaLatDHIPtDDBYEfJ/9evOBrtvcI0e
+8/vMhmzyT65rKpPl2KjG5uatrs+pvI19JEiIfkgRsgfU9zXj/iC5xqjzuxKnge1Sa7Le6ZfvtmaS
+BjlWJzWA85vGw5zWUYtvmbKeisT20iS7jsPP8WecVbNsFAIcIuOgHNQpGlugx1NaMqoYMAZ45rVo
+SMqabGMk47kU5JpVEd1C5SUMBCqfe471XMoErIy5U8EVJBFJBIUjx84+WRuwquUEz6V8DeLYtb8J
+peXkqRzW/wC7n3MBgj6+tXdJ8XWGrX89jhoLhGIRZOPMHt7+1fN9rqd7p1pNDZTOsbMGf0OK2/DW
+uyy+IrRbpI5WMqjzN23vQ+bdDSVj6PbrRTuoBx2oqSSvq2qxaLpct9MpZIx90dzXmusePtXuNNlv
+rWeC2hXOyFTiQjOM89eewrsPiBdJaeC7x3VWBwoDDIyTXiGk3FtBpEmqX9tJdtFc+XFAW2ou4Zye
+PatbMRnajc6hqINzf+e4c8EtgZNQ29i8jrHaNL5xOBtbdz7jArrb3xdc3dta+TokG+NHlTnK7QNo
+OO+3J/ECsu61rTdYjjnjt5rC/XC70PyOf5g1Mr2GmZGpm/skW21W2CSOMqSQQw/CuZaFopSyj5c1
+p6vLJPMqMW2RHjcxYknkkk/54qrD97B5FSlZaA3fcYLrB5zitO3uXmhyPuYwahn01VWOctiJuvsf
+Snx3AOEjhby8Y4HWq0a0FqVJ4S7GRc1Yth5sIDKzGM5wPSt6y0mS/jPkwt8v3mYgAZ7c027tYdLg
+kiLK13JwEXnYuOuR3OaL9B2KI3PgRxFI+mcVL4ftWbXLdoxumSQMAe+DUkQu5rQB5EjhHqan0l1t
+tWt59x8ouFZs4wfWi9k0ho+m49xiQsMEqMiii3bdbRN6oD+lFSIivtOtdVs2tLyISwsQSp6GsbW/
+BenajorWFpbwWgyGHlRAAkdMjvXQxniqOsa9Y6JbmW6kOcEiNBlj+FadNSTyy7+H+vxAstpFP9nQ
+pCscuwOOex78nv3rhb62v49TLTab9mVWHmRq2/aw9wK7nxL451nXZms9ODWVoCd3OHZfVj2HtXF/
+2XJbEy2187l+XMZOD+dYucU7XL5Xa5j/ANnT6lcuVTagOWY8YpzLp9iMK4uZugEYyB+NbR1KT+y5
+NNjgCJITuCDJPTqTySeaoXc2n6fAjrGfNA+6OQD6elTKfQLEcKPfRhZIdsAOdoGc/wCFaqWtstu5
+VYUCsCMsMgfWuVufEV7cA29um1JCPlj5ye2P/rVqWfgrxdrsqQwaXcqdmfMnBRR+JoUZvfQaaRtN
+LBbxopuQzMnJ3EAE9ucVQurm2muGkaRCxbr610el/A3X7mJf7T1O2tgp+6ilyf5VZ1X4NTaHo13q
+X9tCUwIZCgjKgqPQ561ooNdSudHGRS25dpJljaNTj58jJq5HPaXcyWqRiGN5F+YdevpUfhrwzeeI
+754NPiYqpP7xzwB657fWvR7T4PzWlzbTLqUOI3Duvlk9+cE9afKJtI9OtUEVpDGpyFjUAn2FFSY2
+gD0GKKRmRxPxVW80rT752e4gVnZdpbvikhmyoNWVkNXdNBY5mXwBYG3mWG5uC8i4zIwYZxx2rAHw
+zvwiqb6AhTkKMjP1OO3p+tej+ZSiSs3CPYd2eVX3wr1h+LTUbeHI2kqDux9e34de5rI0z4F3Ukkb
+a9q6rEvUW/JPsCRx9a9t8zijzaSSjsJ3Zz+j+BfCeh2ohtNNtj2aWX53Y+7HmuojMYXahXCjGAel
+VSVD78HNPEvtVKQrFnNQ3dtBfWz29zGskLjDI3Q03zaDL9avmHYg07SdP0iJorC1jgRjlgg6mrRc
+diKjMtRmb60XCw5m5oqu0vzUVFx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0039/full/!100,100/0/default.jpg</Url><Caption>29376_0039</Caption><Caption>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Caption><Caption>Exhibit</Caption><Caption>plate 061</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29elO
+TDruH8qci1n+IdZTQNHlv3habYQoRTjJJ9aydkVc0ttGyuEs/ifa3DIH0+Rcthirg4H5V1mm69p2
+sKxsLlZWT70eCGH4GoU4vRMLmhto20ryJHEZWYBAMk+1eRap4ovb3xLHMl7NDDEdyRRyFQRnuOhp
+SqKO4m7Hru2kK1zuleLrCSyDajfW0U5cKse4byCBj5RzXRiRXbCHd647VcWmrjTG7aQpU2KQirAq
+SOiNtYkHGelNKgqGHQjIq2RUbDigZRZTuoqVl+ailYC2gqrrVlHf6Pc28q7lZM4x3HIq4lLKWCfK
+AfY96HsI+fdXszol8ZI8tbyfeH933rT0bUEsZV1G3m2iJ1JIyQfUHHYiuv8AE/h8XcMrJCjITwFz
+uH1rzzTreTQ9Rmiu0LWVwNhOOEOeCf1/OvLkmvVENWZ61f6/aXvhe8uLO4V4jFnIblc9frivHhMZ
+9U2xtuDpyFPPBJIq/dx3GkT7bFFkhmbLRbhtI7+2CKyo4v7Lub2dU3RHaEIbJVd2SD/LNEKrmm3u
+TJ3O18JaPZXPib+1PNUyeWv7piMg4wCB9QPxr0O21q1t7qayuIpLeVHCqWGfOJzyuPpXkGn3oTzP
+JSJyjlSXP3R1HI56k11Nh4hvY8zsYFifoSg3P/tewrWNTkLizutU8TaZpEqRXU4Ds2MDnb9fSr0L
+rOom++rcqRyoHt/jXm01/pky5u1t0fuJkHB+pGDUp8T32l2yLaSxPa5wpRQdo9Bjito17v3kUj0s
+imMOK860XVtU1TW7aWS4nFsXztDY3j/D2r0fHFbwmprQZVYfNRUjDmimMlTpXn3iTx5i/ksbGYQp
+CxWSXAyxHUD0FdjrcNxcaDeRWtwYJmiO2Qfw14xaeG7C6Ejm4MzK2GJkBx+AqKsrKxDv0N2Tx6I4
+dwvGkk244AJ/lWdb6rd6jbPdC0imiBw4dsN9SOlO+w6NYhYnePd1WJcMzHsMCq8y2eoxzWhmWzm3
+Bdu8byD3+lcMn0BJt2LcfiHQYbNPNs4jMF2srKDj/wCtUT+ONDtIg0ltBGpB27lAz68VjXfhzTIL
+dGuLNBCrcmEhmP6c/wA+azU0rSbe6kjuIWQE8I8ZUEf8BGf1FOME5f8ADDcLEWqeJ5Ly4LWIWKJz
+n5IgMjrjH07n9Ks2aXutXMVqZJXnkOBk4C8jk+2M/lWls8LtGlvFpVxJNnCvCcNn2zn9a6Lwp4du
+rG7kvJI3jikBESSEFx8p644rpcUti42Rx/iDS7/Rwqi58+LrxkgnPTmrGheIFuLrbeFTA67WwMbT
+68dq6HxLayzny5Ihs2n5uvPXp+f5V5wiG21FossvOOnWqUFONmNq53gvr+wupPs84VUbkYB5POfx
+r0jwPrV1rFhc/a8b4nG0jupH+INeMRi4HluqsWP3iTnPavWvhtaSRadeXEiFfOdQv0A/+vVQiomS
+vc7JhzRSnrRV2LuQ3QZ7GdUGWMZA+uK8DvdHvINVX7PEI5yxyVbgHvXv5J8pgOuOK8d1iTb4guop
+HaLDYLEc++P8awryaSsIgY/Y1/f+TJNt6xoAQfyP51i3fhqWYG9aJwzNljIwz9c1qS3MFtbFLZRN
+KxyR157ZPapBMj2Si9vsFh/q84/CvNdVwd0wUblXT9btbGIxypcMSfv5VyPpkZq6ms6BcZdluW2H
+DPJETyfoKzWsbaTDECNc4XJ5PFOt7N7Sc3EKKkBHzs/3WHpiiOJjfVFNSNMT2cLi5tbyFGTkYjbc
+OehGOa1YvF11dW0RXT7uWQEMDFCSG/8A11zDayss8giheWOUAEIvMZzyM456A1r2DNBbs6vdFf7o
+TBUdsnPPXH8sV1RxEVuCTZp6wj3VjFdlDbseRHLgOvsRmvMrrSdV1S7dra0MYbgyyEKMeors4LiB
+7oNLGN4PG/5z+takk0ZhaaJDJ6OF4qlimvhRXKY/hjw2mnxoJ5WuHYhid3A+ley6SqJp6KibFA6V
+5Voh1W4ngb7IojEn3MEHHpnFeuQZW3UFNhx930rWhKU5OUiZKyFbrRTWPNFdJI1G4qN7W1mJMltG
+5PUlAc01WIFODmlowK6aDo6SmVdNtlc9T5YqO78L6FfLi40y3cYx93H8qvBzTg5xUOnB9EF2ZA8I
+eH4YFiXTVMYIIXLHGOner32LTI4lhNlEEHRSgqwXNJvLcHpSVKmtor7guyodI0eaMoNOi29wqY/l
+Vy3sbKLJitY04x93tTg5pd5qlCC2QXY1dPskkLrawhj1IQVKYoghXy02+mOKbvNIXOatJLZALHFD
+CMRQog/2VAp7NxUW800ucUwBjzRUBY5opAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0051/full/!100,100/0/default.jpg</Url><Caption>29376_0051</Caption><Caption>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Caption><Caption>Exhibit</Caption><Caption>plate 063</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29AcU
+/bQo4p6KQMEk+5qChu2jZUmKSloIaFpdtOooQCbaNtPFBp2GM200rUlBFOwEJWmMtSyKWGFcr7gU
+zaQuGYsfUigCqyndRUjKd3FFIC0nSn0i9KdTAKSnVBJd20M6wSXESSuMrGzgMw9h1NJiJcUCo3uY
+Yzh5UU4zywFMivra5VjbXEU5XqInDY/KkIsUtc9a69Lc6hcRGMJFAPmJ53H2pzeKLZIpXZQCnq3W
+mpIDeormJvGlnEsUgAMbHBJOMH0pl74nTzVMMoEbAFSDyaHJFJM6gimkcVjW/ijTXgQyzFGztIYd
+Pc1sRSx3EYkicMh6EU9wImHNFPYc0VBViVeFz2qvdTsqoIXXduBYZH3c9ald1jgd2+6oya8+1XxH
+pUQlmRVm8scKvOfQUTnyoSVzsbrxLpdmJPOuAPLALEDj8+lec+MPH/hzVEFqmjvqLD7ssh8sKfZh
+z/KuQ1p9Z1tjJclYYs5SAdFHv6msX+zxApBClz1OODWEqt9ClC2pPdxWD6l9rlhkkieMfuZbluue
+zYyRjtSy3n9nywX+gwtY3KMMvDIzIwPY7v1Bqlc6TuUSsvyD/a/pWWyPbKWhkEa5x8pxURd3oy+Z
+rc9Estfa/eSSAM1xjEhRgdp78f8A1sVTv9ZEYKN5mV4OOpb6VyOkyrG7TNbXEx3Da8dx5XPucEn8
+K6lLG2/tWz1BLO4McYLGG4l80B+Np9x14PoM1ra25MUmVrbVDcwSrljsXJRxhh/9alTVpX0nyckM
+hKqQecdf61Jq1vcaldWt3LaR2dw6kPJE2xGIPOB2JFZccMFqX32s0j/3o32A/hjn8apWd7lOKWx0
+dpq//EvjEsRmYD5tzdfy5r2LwnfQ6h4fglhj8vaNrLuzyPrXgMGt6fbsPtWn3Bz/ALf/AOqvcPAO
+p6PqWhsdJVUEZAlXaQQ2O+a1Rm0zpmHNFDdaKkBskYmtpI26OpB/GvD9c8C6hbXEnlPtjDl0ZVJY
+f0r3FDxWR4h028v7XFk6CTvuqZptaDg0nqeAtpmqLujNzuAPJYbaqHStR3kpdJn/AH816Ze+BvEc
+il4p13ema5aTwR4ve62OLnyx/EozXK1PqjZ8nQ5aew1gIInlQxsem7Jqu+jIqbpJmLAEkFcV3C+E
+fE0UgH2C4kUfxOST/hVPVPD+ryTGI6dOsgHRULnH4DFYTqVIWDkizlbPU/s5XcimKP7qjtzXQW/i
+VpjhYUVB0DcmsaHQtQuL/wCyTabPAS20Obdhn8AK7Sy+Fl2YC83nbSMgJHtP5Hmt/dnqC00Moaz5
+ifNFjnjoaz7u784feUHHQGu0t/hQ8qNn7RH6ZI/woi+EWoKCxmRyAcK/H8q0jC21x8yPMZEaW4xl
+mI71738KrGO18LvKo+aaTJP0FYegfDG4iumbUrW1iiP9x9x/WvTLCwt9MsktbZNsa9BW0LvdWM6k
+k1ZEzdaKa3WiqMyON+KlDnsB+dU1c4p4kNUSXA3HNLuqr5hpfMOKQFndSMxHRQar+YaXzDSAd5mW
+4gU+uakSSUkZjVV7/Pz/ACqLeaUOapAWd1JuqDzDQXOaYErMe2PxNMLHHOPwqMuaaZDigBWbmiq7
+Oc0Uhn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0018/full/!100,100/0/default.jpg</Url><Caption>29376_0018</Caption><Caption>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Caption><Caption>Exhibit</Caption><Caption>plate 064</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2mOMb
+R9KmVKaiBowDnGOxxUyrhQOeOOaxS0NGASnBKcBTsqGC5G48gZqrCuN2Uu2n4pcUWC5FspClTYpp
+FOwXIStROnNSyRFmyJGX2GKawpDEjHA+lTAVHGPlH0qUUIGKBWEoe48cFwH8u2s9uc/LuZs/ngVv
+YrG0DM11qt2TnfdGNf8AdVQP55oe6QLZm5RRSk4GTVECUhpsU0c6b42DLnGacaBjDUL9anNQv1pM
+aCMfKPpUoqJOgqUVKBik4UnrgVxlh4gj0g6Xpzo0k1/cOxKjOAXI/wA/Q1188git5HPRVJrzae5t
+rXxVoocn9wivJt5Kja7Yx1PL1E58skVFXR6ezqiF3YKoGSSeBWJqWtW9x4eubqwnWUZMYZfXdtP8
+jWL4311V0y3soCfMvDnZ/EVBHy49SxA/OuevhaaToFp4aWWVtXaZZGKsQGkY4IyOw3Y/CidTR2FG
+Ox13gUzT6VcXc7FnlnYDnoo6f1rqDVHRdJg0TS4rG3JKpklmPLMeST+NXzVwVopMUnd3GGomHNSm
+oW60NghksiwwM7HaFHWsRvFVjazslxeW8ZVC5Ejhfl65qz4kljh8P3bSlcbOAxxk18/XurRy3bwG
+2/dMQu5cMQM9jisJzaehSVz1/U/GcVzps72k6SwSRSBSEI5AzgZ68d/Y1i3Wr2sPxEn1IbdttZJH
+CW6B2IUH9TXELc6HPBHE93c2UqAqv7sEc9f51FJpt4ICLQyagJ/lLjIGPfOKxlN3uy0rI7uTVLbU
+fiJBLPNCIbYBUbdlSVGQwHfJYn8BWkiaVqXjq0uoHQpBJtDsfvbVPT33tmvPLXQtQisBDPbRo6vu
+iJkyfoevH8qim0m8n/dQ30Qc/N5LSDr3xS9qn16hY+hItUs57hoYbmJ2QZYK4OP84NMGqRS3Rt4s
+lvUjj8K+fVOq2TqWuFUQ9P3uBx25rcsPGGt6WvnsRKrvhV++Se+P/rVp9ZI5D3I1A55rhtF+Jlve
+usd/bNb5bb5mDtz+NduWV1DKcqRkGtVUUloKzRzXj4Rnw07S3K28auCzkZ/ADvXhN7eaat0PsKyS
+jcA0sxCjr1A7fjX0brejwa5pctlOoIblSexrxvVPAd7HdSM1qI7WPIVduS+O/tWNSOt2VFmTLqFt
+DItumlr55+cSnhWHUYPfj9c1pyvrFzbAwytGSR80Z6Duc/8A1zWdplu9ndSws0jJGvyxuCVQ8due
+2abLqmsyXEiwwFucjeMAVi4XlojVJWu2acVy9qC1zLCHB5JUFmPf5s4x7cmqWqeIrSdEi8hXaIho
+hGNgQj/ZHNZ7adfzlpr1sM/TYMc/jXS6bpj2VosgsLUEr/rDFuf65Pejks7tjuraIxI5Jr+VF3ZT
+IASP7zevNT6zc6naqEVVW0YbFRojtU8YOexz3rfttNhZo7mdJZZAOHIAI/KtC8sptSKo9vPIhTG1
+0yB+HrSXLfYl36nn1zcajcWvlSoVdioYEdSDkMO4PWvoDw+07eHrA3H+u8ld3HfFefW/g/UbieEG
+0k8gN8zHAOPxr0+GEW1tHCvRFCiumknbYzkWFNP+VhggEe4qJTUgauhEMhfS7CUkvZwEtyTsHNKN
+NsEXi0gAH+wKn3U7dTsgKp0/TmILWkBIORmMVJ9ns8bPJjweMbakZFbqKcNqjCgD6U7INRgtbdcb
+YIxjphRxTyAOwoJppNFkA1nX1qBzUrGq8hyaTGgDHNSAmiipQDgTTgTRRVALuOKAxoooAaWNIWNF
+FAEbMc1BIxFFFID/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0046/full/!100,100/0/default.jpg</Url><Caption>29376_0046</Caption><Caption>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Caption><Caption>Exhibit</Caption><Caption>plate 065</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YDAy
+elcX4zl8Q291bX2mPHFZW3zyyvINp7FSvfr+tdshDKGHIIyKV4kljaORFdGGGVhkEVlKN0XGXK7t
+XPO9B+JYujp9rqNoRcXM5hMsYwh+bapA9yfwxXoDTxKxUyKG9M81iatbafb6po8jW0CrBMVUkBRH
+lTjH4j8Kx/EnmafqLXtuqeVIuRcod5ic9mX+6fas3zRXcb5W9NDprvWrGyiaW4uY4o1OCztj+dVL
+fxfol5eW9raXizyzttURnODjPPp0rDtrE69p7tqlrb+bgbZYyCJBjqM8j6VwGqeFba4e+bSZX8+x
+wzqOMHPY/hUxqO+qJaPdpG2IxB5AJxUf2mEcGRd2OQDyK8b8O/EiW1t103Wt5VDtM68Mw/2u5r1X
+StUsdUtUOmzxCLHJTGfwFbom5dN3bBlVp41ZzhQzYLH2qbbWHrfheLWb7TZnupI4rObzWjHPmEEE
+ZP1Fbg2QxktJ8o5LMeg+tNeZTtpYyta1ZNJS1JAZp50hC9+TjNX2KKcMwB9Ca8/8SeMdJi8WWRjl
+ErWaks6gkBjxt9OhPP0rt9K1KHWLFbuIDY3SpWrGyxweQeKKeRiigQtkMWUAPOI1/lUZ1WyVJ2a5
+iXyG2ybmA2ntnPrUsAMVlGMZZYxx9BXi/ifUGW7fUHi320rYlXrxnrjjkVUnYErnZeOv7WW0tLnR
+5d9xEjXSqvPmFACeO4welYeh/FyO/C22oaAxmIwWtmDBvX5Wxj8zW/pN3ZTjw5a6BfQ3QjjlZmkO
+SqkDO5R0OT0pNV+HaHVP7a0yeGC+yTLG0e2GQfQfdPvzUO9nbcHuY82vTjeNKsWsgzjZBIQ3JJ5x
+0UewqtqenX1rY3F7dara2txKuHS3jO5yT05OP0rkvFHjCwuLmGOygc3VtL88iSARsB1A7nt2qhqP
+i5dRWBSjptO4qTkk+lc0VK92NtFKawaW6KBi5BwDjrWlpl5e6DchbKR3nc8xKePxqK0ncR3d8ykL
+CpPPqe1ang+zaW5N3OVLSDJB611J6EW1L2oeN/F1lH5slzAqgZ2CPP6msXUfiRq+tWNvp6+YN7fv
+jGcF/YU/xorXepiGJfLjRMux6VkaJFHp0cuoyD+ErCTjk9Cad7rUtLU3tJtdR8TeJZNG0+OOxjYe
+ZNPjeVUAAnP5ACvbPD/h218OacLW3lnmPV5JnLFj/IfhXJfCO50ltFljhwuqNIz3BcfMwzxg91Ax
++NejkU0rA2QkDNFOI5opCGT+d9jk+zBTPsOwMcDOOK8E8Q6ndaffTWOp2MkM80jPJvAwwJJ+UjjH
+0r6BXpWV4g8Nab4m09rTUYdw/gkXh4z6g02rivY8PsrK50q4j1jQ7owXCDcY93yuM5K+4PpXqOhe
+PdL8TWz6ZeM2najKhjaGRsbiRjKN3/nXnWt6ZqHged7YSPdQJ84kZCAUPb3x3+tVN+k+IEWS5jaA
+hSwZU5bHpxzzWPO4svluemp8LfDtxoaWF7Yp5iE7Z4TtkH/Ah1/EYrgPF3wsj8NJDfaVK88G7bKZ
+zlk9CMcGtzwRrfiG3njgkuxPpucEXp+eMc4wRz278V0uofadZ+1efPayWyAGOONCSvPdj3x2AodS
+NtCOXU8i1OWwbRrC2sb2Kc3EoZwoYFcDvke9d5pWnww6ZGzgYTDZ9MVwXiXSYdHgi+xR7fLnYrk9
+c84HtW3Y+I4J/DrmWeRbnGPLzjB/woumlYaXczPE0yanrCWNqdu9suw7Ad6ZYWlr4g8S2ukwsq2y
+ARKxP5nHeuead4hcXCv+8uSdp7hc1J4KuHg8V2b8gmZV/WtoxuNux75a/DjStNSKTTnlhu4skTsx
+bLe46fhW/pcmqbXh1SGISJ92aFsrIPXB5B9q06Q1VibjCOaKD1oqQBelKzqmNzAZ4GTTFPFOOGGC
+AR70wIb6AXVlLGFR2ZTtDDIz2/WvPPEHw9Ouo+oaPcfY7hB5ccDoAi7cgqMDKjP+cYr0VraFjnZt
+PcoSpP5VmXBfRJ2vA0kllK3+kKeTEem8e3HP5+tRJJ7jTa2PDZtQ1fw1cfYtctZ7WXoJQeG9ww4N
+all4jn+1xyrqT3FseJIjww+le132n6frFmYL22gurdxnbIoYH3H+NeU+J/hBFZiXUtD1Q2kSfM9v
+PkqB3w39D+dYypdUFyv4outFfTEJmMsmS0YX5ixPr3H415vc3KCXy4zhnILAdh6fWuivLWx0Cyml
+vS8j3Z/duQN+F54HYf8A1q5PT4ra6uWaSQp/c55HuaVPRFM05CimQSx7ZQAuw/wAdqk8J2zz+IYD
+HGWKygkD61sG00W/tIjcx3C3IUh5Y3JEgHQnOevHNZ2mXOp+FbyNtOKyTyjJDp1XJwfUduhrpjNW
+sS4u59EaNPJbyy6VcszSQjdC7HJeI9PxHQ/hWsa8h0rx5qGr3NsZdKuor6EkK9v+9Vx3Ug8j8zXr
+MMvnQJJsZNyg7XGCPYimmDQ89aKaetFICJWqQNVCO4JH3f1qZZMnpRcC2GoYK6FWAKkYIPeoFk46
+U4Px0pNiItOsl060FrG5aJGPlg/wqTkL+HSk1PT49UszbSuyxlgWC98dvzqYkNwRTSinpxU+QHl2
+vfCW613xRZXNzqIk01GHmRgbSqDnaPr61U8Y/BmzmuFuPD6zWwZfmjQ71DeuGIOPxr11YlBz1qRV
+VPujFNJWsgPn6TwJr/hqxE0Wl3mqTkcZ27Y/fYCSa2vDHw71u/Q6pqwWKWfkRyEhlH0HT6V7RupN
+1PlRXMzM0fQbTSYxsjUy93xzWqTTCcnpTSeKei0EKTzRUTMc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0041/full/!100,100/0/default.jpg</Url><Caption>29376_0041</Caption><Caption>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Caption><Caption>Exhibit</Caption><Caption>plate 066</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IWA
+G4j6VJspUHFSAVjYu5EwVVLNgAd6p2uq6fe3MlvbXMcskfDBDnFcB8XdfvreK10LTZTDLcKZZpAc
+EJ0C57ZOfyrK+Cui3q3eoX13IdlufIRc9WPU/l/OpcRXPYtg9KXYPQU/FRXNxDZ20lxcSLHDGpZ3
+Y4AApJIBxQen6UmweleV6p8T9Y1C4ePwxpKvbKcC6ujtD+4HpUOhfE7Wj4gg0vWbOHM5Co8PT/69
+NNbDsz1nyx6Cq95dWmnwNPdzRwxDqzkAU6/v4dO0ue/uDtihjMjfQCvlfxd4v1jxvrDASS/Zmk22
+9rHk59OO5rWMOYTdj6Hi8deGJ5zDHqkBbOK2URJlEkVwXQnII2kEenSvmtfhN4zgsRfrpgzjcYvN
+HmY+mf0ro/hj41vbLV/7I1EyBc7dkhIKn0xTdNW0DmPcWTnpRUuQwDDoRkUVhYoGvbew0oXl5MsM
+EUQeSRzgKMdayNI8feHNbvWtbC/3sDgM8bRqxzjALAZPI/OrepWMWo+GxaXC7onjRmB77cN/Svn7
+xlLaPqrz2IWBZAJHWNSBuwOfboDj+tbJJks7v4o2Utv4y0+/kTfaT2/lMxGQjKc/1rQ+FmqC3mvN
+JuPkkMgkXd1O4ZH/ALMPwFcd/wAJr4ggSxtNeuTJbWy4kgAKy3G6PK+Y4IJ5ZflBBIU5ya57+172
+DXZdStHe3SWRkhWQl8Ju3KuWJPGAfqKynOMdxqLex9SYryj4sapNealp3hiByscv+kXIB+8oOFB9
+sg/kK1fCvxV0/VHjsdZVNPviQiuW/dSN7H+E+x/OuO8bMz/FG6D5ytuixnOOMZ4/HNRKXu3QJa2Z
+WvrptMhlWFMJbxhQgOMtj/8AVXp3hPwVZ6bbwX97Es+qOgZ5W52E/wAK+gH6145rKt9medjuAn+c
+54wGx/Svo+2O+2jYd1FFKKKk2cj8U1l/4Vxq4h6+WA3+7uGa8V+C66fD448y5CM4iIgL9FY9T9e1
+fSWpafBqmmXNhcruguI2icexGK+Q9XsdQ8D+K57KUskttKdkgGNy9mHsRg12Q1TRk+59hYrhPE/g
+W1vdZg1e0iEd0GyzqMZ4q94A8Wp4q0RJyQZV4f611rKCOajYoowKRBGG+8FANFWSozRWZRyvjiG8
+uvDVvYWlylpHdyJDPcP/AMs4yPw6nA/TvXiHjFba01W5sEuFuktCIfNXjzXHXA9uh9wa+lruJ5rC
+aOIL5hQhNwBGccV5Hf8AgDQ9K0zSVlEx1W+nMkktzkkKqszJtzgfwj1NXdJXZFiC00/7dFp2o6oY
+X1NYAryy7WYnt6AEdO/51n+KdAkvIY/s8Em8HCuOAuepqbU/EMD2csYZEVMgIh447D2rlfBs97L4
+tCwEvasxMqOfl2dz9eleTWozu6zlt9x106qS5Lbmp4i8LoulLKq7ikYG7HXArCg1xria1e8kke6t
+gIWd2yWQfdPvgV6pr09nFphFy22NwdvFeK6zAlvdyvburRsm8Mp6HNLBzclyyCskndHWapc+f4fu
+QgJMjOfl7cgk/r+tfQ3h+Yz+HtPmJyXt0bP1Ar5itJmuNERVXe037tEHVicD+Y6Cvo651GHwf4FN
+9eDMen2YLKONxAACj6nA/GvSpK2hzSZtXV3bWUJmu7iKCIdXlcKo/E14z8ZLvwdruixXcOs2E2p2
+sgUC3lV3eMnBXj0Jz+frXmtz4i1Hxbey6trt2ZMEmOL+CMf3VHYfz71l6kqyN5EcKpLJ8zNjoK6o
+xsyLnb/B3XTo/in+zGfNvdrhc9d3bFfSB6V81/BrRo9T8bieeeMfYYi6pnlz04+ma+kvMRnZFdSy
+43KDyPTNTU3GiMjmilbrRWJQGRI42d2CooySTwBXlHxK8X6NdJZR6fcPJqVlcCeIqvyMuMMpJPcH
+07V13jiwXUPD+3yDNIrgoucc144/h1oZJjfxrA7AiNUJ4GP1I7VMqijoxqNyvf2mnXqSXcFwqiUZ
+8h/ldG9geuKv+A47eCHUJcobuMoAgbny8nd+Z/kKx/7F0yyKziea+lDcgMMA+jd6t3er3V3Gww0X
+lhf3YmIDDPIx7DNclZ+0g4R2ZrD3JczO516wi1PSol37gE4Ze/vXl/iSyFjbWUewEt8jerAHP+Fb
+lx4t+z2sUNvJbxtGMM3lDd78/wCelcvqeuQahJ5lxcSTuo+UZwAPYdKww1GpCXkXUnGS8y1p+qx2
+ep2Doke6B1aCKQEqWB+Xgc4zz71seMPiNr/iLSLrRLpIJ7N0WW5NrbsGjVWDcnJ28gdazfB8+hXH
+iywgvIPLheTLTMSMYGRjuOcCqPiK11bw9rOqabp6CO21LeN0LeYssRJIAY/XB7816tJa6nNJnOyX
+cAQQQB40YDJDE1owy3Wpn7KsYL/89Ox9/aqdlocoUtdssSZ5yea0LZ3t4rqKyYFZmDA90A7Z7VtK
+ore6KMH1L2mWX9lTpc3F5cW7gHYYZMOOMHkdM8/hXq/wd1mzk1LUdOt4SrSRicyM2S+045/76rxF
+p0jk/eN57DsM4r2H4GMlxe6tP9mWNo4kVWA6Ak5H6D8qxbbd2aWSVj2djzRTT1opEFS9jM9hLGqb
+22kqucZPYZrzDWfBvirXZTGsUFrA3DF5gcg9Rxk/lXpkdyrIDhsEZqRZlHQGolBS1Y02jyi0+C96
+JB5+rxQxjHEKsTkdOpA4zWzD8GtMhjCrqd4CM8qEHX6g16D9oHoaPtA9DU+zgNzkzymX4F20900w
+1MwBvvfu/NJH44AP4VpW3wN8Nov+kXupTnviRUH5Bf616L9oHoaaGi7JjPoKcbLQlts4KL4P6baX
+jSWMiwxYwoOWc/Vif5YqSX4dXKJIbaS2M7f8tHJznHY4OBXcgxjPy5/AVIkiIDtTbk5OBQ4RerGp
+NHikPwW1u/1EtqV7bRQbuWjYsxHsK9Es/hb4RtdPjtJNMFxt6ySyNuY+pwQK6nzxnoaDOPQ1qrBd
+nKy/CrwTLydERT/szSD/ANmrW0Dwto/haKePSLYwLOwZ8uWyR06/WtIzAn+L86Z5wx0P407iJGbm
+iqct0EfGD0oqRn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0019/full/!100,100/0/default.jpg</Url><Caption>29376_0019</Caption><Caption>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Caption><Caption>Exhibit</Caption><Caption>plate 068</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3VY1/
+uL+VPCKP4R+VKBT8VIxmKSnAEDk596U0hDAadmkxSimAZoyaDQBTAKQ5p+KYyMScOR+VAxDmmMDU
+uKQikBWIOaKkK80UWQFgUuKBS0wEIpMU40lSxDaKWigQmKWloqkMKSloxTASginUhFIZERzRTyKK
+QDhTqaKdTEY194js7GZopGXK9fm/+tVA+N9M2htwx/vY/pXLeMY9Qi1d5luVjhzwHdQp/OuDufEU
+9vdOtuEmY8NySmPQZrz6mIrRk1ZGiinse0p4usJDhVc/7vI/MVm6n8SNJ07T57lQbhouBHG4JZuw
+9v6V4bdLqN9KZZJJAxOQsZ2gflUSaVNFEQskuV+8objJ6/pSji7fE0Dp2PZfD3xXttZvrmxuNLlt
+rmDBwkokUg4/iwOeayvEPxsXSNVazttEMix5EklxP5eT/sjac/WvJpdNktlYwrJt3AuFJHI9vxqG
+SA6gT9pDvsGE8znArojiE9VsChc+g/D/AMSbPX9MF3FYyxuG2PEZASrcHr3HI5rWh8VedMEGnyKC
+epkXivni0sLiZxIsyRAcAR/Lj8BXQ6fLeWsgi+2tMrnDKQT+R6/rSlXd9GUqeh9Do25A2MZFKao6
+LE0Gj2yOSW2AnJJ/nV+upO6uZDCOaKU0UgEFOqMGng0wOJ8T+DJtYunuImDyMeDK3Cj2Fc0fhlqE
+E3mqEmb0DAV63z60CuSrhYVOrRaqSR4reeA/EISQC3Z89FjZR+uaoQ+CvEhKedp0pePpskwGX0PP
+Ne8nkcHBqLEwP3lIrmWXRW0n+BTqt7o8YsfBurzTNDLo0iRt1Z2G0frmoJ/hzr0lw7R6fsHr5q81
+7egmz8zDFSqCBhmyfXFaRwEU7qbF7XyPI9G+H+tRxgXNvBFk/wB4Z/GtS3+H+pfbxJLPAkKtkADJ
+r0mkwf71X9Qp3u238x+3kMgi8iBIsk7RjJp9HakNdtrKxkFFNJ5opARq3FPDVWVuKkDUATZozUW6
+l3UASZpc1HmlzU3QiTNLmo80uapMB+aTNNzSE0xjyaaTTS1MLUAOJoqPdRSA/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0044/full/!100,100/0/default.jpg</Url><Caption>29376_0044</Caption><Caption>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Caption><Caption>Exhibit</Caption><Caption>plate 069</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3S1G2
+2iA6BBj8qnqrpribTbWUdHhRvzUVbxUjGnNJzTsHJ5GO3FIRQISjNBooAWloFFABk0nNLRzjjrTs
+Mac1GwNSAP8AxbfwoIosBWIOaKlK80VIFXQB/wAU9pv/AF6xf+gCtPFZ2gqV8P6ap6i1iH/jorRq
+hCUhp1Vb2+trCAy3EoRe3qfpUyairsNyYiiuH1Xxvvt57e0ikidgVWVSCy57gdM1yXhvxrfaH4hS
+z1nVnfT532g3z7mXPRg/btweK54YulOXLFlunJK7PZaUVQvtY0/T4g9xdRJn7o3DJrhdW8Z6hDdC
+5ttV09bSKQMYSnzSLnlScnB69K1lXpxdmxKEnselUleV6n8V5n0yG70y0CBnKnzPmzg4OK1fB3jW
+/wBX12TT9SktY9kBbC8EvuAA6+mTirVSLdkS9HY9AFIaI5ElXdG6uvTKnIpxFUMiI5opxxmikBX0
+kY0iyB6iBB/46Ku1XshtsoB6Rr/KrFMRzXinXJ9Lh22zRo5GS7jOPpXkPiXxM6/vbq9aaRueDwPo
+K6P4hasi6jKjy42H7uCa8wW1XUbm7mvmeNIxvVVH3l/GvLxHvTbnsjohaMbl+x1S6uYpntraVkcg
+GViABnocVmX9udRusO9vLcfdXzGYAH0JOADxXQjWI7DSZBJGkLkBIXEWVdeo+oqvdPbx2LzrJGs0
+hBVFbOz3GemcGuWE2pXUSXVZUstLlmhlgbV7m4nwqQojARq2cYLMc49Peob3TB5amzvJBGi7JFnd
+SWfvtxxirlne2FncXF2zsIux8xRjockHJPzcgDH1reN34d1XRENh5n2vdud5kIRF9EycdhyM11wl
+K92tCeeXc5a0CW2nR2Ydm3yDBY4wTzuAzxkdPzq1Ckulw3E0gcTtIdoVvm2nufSnWsLSzzmZW8vd
+lHYjZ1x1B64X8s1f8k2expZYZklYHbGyttJ6dPp0/Ot1O7sZW6nqfwnuzdeFpdz7mW4bIJJxkD1r
+uzXA/Ce2Efh+7nG3EtywBXoQO4/Ou/Ndi2BbEZxmihutFIoSJdkSr/dAFSVEp4p4NAHjXj+wf/hI
+5ZpLDzrcsGcl9vye3vXAXlnd3C7IDNHZZzHHnJwe27qASa+nL2xtNQhMN5bRzxkYKuuaqw+H9GhK
+mLTbZCowuIxwPSuWpQlJ6MG7nzBFpxtIZZfJZlQgYUZO7nb+v4Vs6d4dtrwq17amSYgFmd9zADn8
+Ca+jYdL063GIbG3jH+zGBRJa2O7D20Yz6JjNQsPU6PUcXFbnznrukWttZbIIY2Ocso/Wq8cc+pWM
+xVRArJtRc52Bf8a+h00HQ97sNPjYt94NGWH5GpIfC+hQszR6Xagt1/dg1UaE0rNjqOM0fPjR20CR
+tFsMMgMku4kFfYe+R06nNNSCbyVJwJps7ovXnOK+hpPDOhy/6zSbRuc8xA81ag02wtuYLKCM+qxA
+VqqOmpnZdDA+HulXOk+F1iu41jkllaUIOMAgYyO3SuqNGaQmtxkcmd34UVDO+1wM9qKQxytTw1V0
+JxTwTTuBPuozUQOaWkA/NLwetR0oPNFxEgwOgxTs1FmlBoAlzSZpmaQnmmMfmmlqaTTSaAKl5Ltm
+A/2aKz9WdlulAP8AAP5migD/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0021/full/!100,100/0/default.jpg</Url><Caption>29376_0021</Caption><Caption>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Caption><Caption>Exhibit</Caption><Caption>plate 070</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2eVvK
+iLliAPSsi816SAHy4lOBnk1o6pKsentJuUAkYJPHNeca5r9vaq5MyMysEZc8gnpXJJdi7mmnxAvE
+k/e2KbCeuSv4dakh+JMTzGOW1EQ7MX4/HivLtRv2N8JZZRMVO5YVPX2HpWFe3U13ALq6llgZJSss
+aMy7QVyox6e9TKyBXZ7n/wAJvcDJH2Vh2wD/AI0+Lx/Gn/H1DGgHV/MwP1rwePTb4xs8TTwqihmZ
+Zj/LPXmorCW4u9Wjtr68uJI2GMs+7ZzxjPfjrURa7j5WfSmm+MNJ1NS0dwAM43g7l/MVvxSRzIHi
+kV19VOa+ZtPcaf4gmtIJTHFIGXCk4Dr0P5CvQ/CHilE1qJLid4oQNkiMf4iMD9a2haSuJ3Tses7T
+600qfWoTqdiFDG5jAPAOamiuIJ/9TNHJxn5WBrTlQXEKn1qGQSg/LtI9zVrFMIpOI7lT58cnB74o
+qYrzRWdh3OQ8cLK/gi3CNhv3RJzjtXiV9BLI0hkLMX+Ykc817Z41Eg8EWpU4dUj64/uj1rxp7C5n
+kLebgH0pymovUhxbKEJEMTtIiudwXL9P0qKZGuIYyUKneEPH3x6c8d+9b8Olrbx7rmZjDIRknA2E
+dG/z61E+ky3lrcXEVlMVB3RSRjIb1LAc1zOd5XRslaFi/Hf2lx4bW3jgjiZWeMuj4R2U8HrjkD+V
+czahrfXIpJoX2oclNuD7CrBt/O0ttOYPbyrIZFBXg+oPpVmygv7DRLnzpTMJoQlvFwcMSOfbAzWS
+5Yp6lXd7WMyaO607XzcXURKFGmRM9SeP6k1uWd7HeT5iO109eCR2qnqtvcLoloAUdoQVeSQFRgnO
+0euDmsWK+QKp5Q+o7fpXbSqRlHc55RaZ67pviSKS3KXbLHKhxgjhh6irza/bW86XEF95cg4+5mvK
+dPuibcRGTewJIIPP61sJeXSlT5Ub4AGGXn8xWyXZgj12Px3bmJd6qzY5K5wfwqaHxhb3DoA6oCcH
+PWvPLW4a4t90trIjD24/CtCw3NLHsgQLkY3A/wD1qhzV7F8p6uCGUMOhGaKIFxbxggA7BwPpRQI5
+zxjZrdeEwmAGUIVOOnFeWppl06kRFZGxwPuge9ez+IoxJo0q8ADBrzKG+igvhAqKVXqfUVlVSY4m
+Dfi0061bz5lEwz+6JJJOO3p9a5Hz5L6JTAGgljbJaOQ8+3tXU+I4Y7jUY5EaM70ySvXqetYM0Mdm
+0eZFjDDlcEsffFc8IRjr1Kdy/pqPueZ7ySR9wdizk7/qe9XnZb+EyzTlQrbgkY2hSO3v+NcvGl4i
+P5UU0kQO+MnAxz35qrZwXGqXJS6uJBubAWMcAE46UnCN+ZglLax0GpCOUx/aGmML/wCq3gkNjjj8
+asWGnabfjyvKWd40w6CP5gvWrfh/SzZ6yvhrUv3tm6edaSD+BmGcjuOc/jVKSO+0LUb+1U+ZMScb
+h+RJ9uPWr2Vkxpa6k0nhvT2tEuLTzIpHUOoLbgO+K0rHxDdXASzeKBpUGM7AC+P61x+j6hdaXObK
+4LSW0h2qDyVYntV6ZLiO6W8ihkTawYEr3961u1o2KyZ3DS3Eg+eIIMfw5ot4sTRsxlKhgOH3f1rH
+tvFSCH/SLZ92OqkYNW9P16OS5gZrVh84IORUq63QM9si5hjI6bR/KiliIaGNh0Kg/pRXQQYHjbzT
+4an8osDkZx6V5Hbq8EuY2Zn/AI9wyFNe3awM6RdcZxGWx9Oa8dGt2cNyoxyzZO5a567aeg0RX4SV
+kuZkASOMg8HG0c5Jrhra5n1TVJZY7d5QThUUcBR0FehX2t6fJaSwtbtNFKpVtp/Os2z8QaRYjZZa
+e2QuOE2gfp1rl9rJRa5dS1ve5XktdVNnlLZYD3I64/Gq2lRQWlrE10XjgJJdYYi8hO7kE9FrpYvE
+Vo2zz45I9ww3oPwqvqEml3dtJHBM8byjErBNu8e9c8aj2ktDTmd7la5kfWdZi1a0kNtbWyiJFC5b
+C8gfX1+ta4u7HWVa9Zwt4ABKoODwP/1Vj2dtFDKEsr5EcEAfvM80mq2F/et5jpGZEX5JI0w5+pHX
+6fWt41VJ2EkvmZ2o2UNzL5iJL8pB+Yc8EfmT9BW7pmmu9hGHtpIpMfeM+7P/AAHJqxpElosbeXZt
+cXKKAwY8/wD1uh/Krc11KF8xtLUgdFBHy+1OpVbfKkOKsMNpKEWFrWORSOfk4P59Kjs9CjkvYgLK
+MMWHKyAf1p1xqpERD2Mm08kBiRU+grDq+t28KC6TDbiB0455pQu5KwSSPWoV2QRqRjCgfpRS9OB2
+or0jAZw4KkAg8EGuN1z4fWmoPJLahEZsnaxIwfYiurV+KlDcd6Ukpbgro8b1D4ZayuDZxYx280MP
+yqg/gXxBDCcW16sgI3BEVh9Rg17pvIpRIcVk6a7sd/I8CPhLxhAoENvO24knfF/+v0q5Z+H/ABfP
+DN9r0tXUdIjEFLE/XAxXuPmGkYlxySPocUlBdSX5HgieHNdVsTeEZww/igbb/I1estLvImBmstTt
+iOSjwmTP44xXtiod2TI59s1KrYGKHRjIak0eTW638cMnl2MweV8tttwp+pJJz+VV7jTddWZzBpt7
+O8hyRIvyD9K9i3mjeaI4aK3ZftH2PIrLwb4s1CT99ss4j/z0YDH4KK9G0Dw3baFb/KfMuWA3ynv9
+PatcsSKjLH3raNOMdiXJsUtyaKgZjmii4rH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0035/full/!100,100/0/default.jpg</Url><Caption>29376_0035</Caption><Caption>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Caption><Caption>Exhibit</Caption><Caption>plate 071</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3gEgd
+z9KUMSM4I+tKBSGpsAu6k3H1rxjxVqmotqN9dzXUwMMuyK2UMBGATlt3boPQ1oeHfE+q3Go+c2oT
+XUWBCYTh8OXQAkD/AGd3Pqa5vbxvY09m7XPWN1G400CnYrexlcXcaN1Jik3Lu27hu9M81SQXF3UE
+mjFFOw7jWO1STnA9qi81WIUFsnp8pFTUlJodyA5zRUhFFTYZOKjaSNQSzqB6k0/cFTcxwAMkmuA1
+fV7e6uJVtbhJApIJjbOPyolLlBRuYfxZktI7y1YkiRoCy+X/AMtGzxn1rD8FeJv7JhE19oRmJfcL
+iOTaQB0+XGKr+KvKuhazTT5lhLoRnJCnvj8DV21vrA6JHLBKpH3ePXPSuKo7SckjpiuaCiz17SfE
+Gna1AslpONx6xP8AK4/CtSvE0S2lxIJOSc7s9K0LbV7y2tJo9PvJlljG4FnLDP0NXHFfzIylQ7M9
+crj/ABRMIdRgmWaOCSF1KO+Rlj6kdevTpVnQ/FRvdNgublUPmxqwMfHPRsj6g1yV7dS6r4kurqOT
+dbwzLJCWUHaQq9M+4redRcuhnGOtj0qwnnuIN08Pltxg9m/DqKtVxVt4wvVjaKeGFpAflk6Aj3FR
+X/ibWFiKmEQLIPlnUBhj2960hNNA4tHc4oxXntr4s1OL5HmSXnALAZxXS6HrNzqNy0cwiChcjapB
+z+dXck2yOaKcRzRUFBLjyH3AEbTnNfPuqQ21nqU09iDFL5hOIwSPoR0r6CkG6J19QRXzvqu621O8
+yrkB2AwQc8/WufEO1jSkr3GaZd6a8st1qNpHNO0rHczn5eeABUjnSb68a3SZ9OtnHmDAyN+R+lYp
+jjklKQSMG6lUXH6nmk+ySu6gBVQA/M7Drx/hXK6mupo4tbHSf8Ivq32cvp2q29xFjIKjk/TBNR6B
+qDQW07zrIVz5buw+63v6VkWf9qWV0Us0uR23xLjcfqeMVuaM2t2kd1ItpCUnbMq3L5aQ8/3enU0n
+UpvfQlOa8yxY3Is7Ce3glYkyEoCfuK3JH5k/nVvT78WsEjMgkkKkKM8ZAJH8qxr+6t7WSO4ayltJ
+d2ZFSXzI3Xv15Bqe11jRnnmi3EGMFzlDjHT+tar3tmRdp3N4a5bywhWtik23cVI3DJxnmr8mofat
+KS0PyspdwO+AM9PxrmZLzR1uDG97AsqkhgSAQe/ardpJaRTyPFcRywFc5D7tvYjPvmtYpxZXMpKz
+FSOQuByynoQpH611/g57qPWHhkTMRQ4YHNc/CNMjRZfNxE3QnnFdBoGu6Fb6lDbW8jNcTNsXj/69
+dEZJmTTO8NFFFUIO1eMeJdCeDVbnyIl2tKWy9eyg1zHizT5ZIhPbxM7fxBFyawxEHKGhdOVnqeTP
+ZXEcbLHG7OerBeB+Aqn9nnWYx+RIHwM7sjj15robhrgyss8ptk6bVXLfmen5UkK2qFrhbSRzjaZX
+cl39gSc/lXj1I30udSZmaal3Hv8ALO/J2lVAO38atJdyQN5ZeUSHqOoq3JqGnw2ztDbC2YrkvcqV
+yfTca58eJohv8vTJXKnCPGNysfY4H8jUKjd3E5Mmumtpd3mSDew4ZqrW/hiSVMtI6REDJBByBz2p
+zMdTJudS86EpIDHa25VWxjqWI/Tir8l7YRFEh0zUPOk+6ss4GfpgGuiKnFWTFZHJaxpNpaXWy3Es
+rHqQ6k59arLcLBY/ZoQwmeTcxz0A6Dj6murk0C91W5R0s4tOjyQ0ks6t+QABqpfaTp2mx/ZoQbiY
+thp2XAJ77VHJHvmuyEnbVg7Gbb63eR2i2rbGwxYmRSce1dP4CY6n41sEMb4RjIzDGPlBP5VTsbC1
+4jtdPlmnI5bYxJ+mRnFeqeAfCR0aF768h23kvQMOUX09q1pScpbGdRJI7eikorpMCMNTs+2agDU8
+NQBBcaVp94cz2cbn1I5rPbwfozk74Hb2aRjj6c1s7qdms5Qi90O7RyWofDXw/qLq8y3I2Y2Ks3yr
++BGPzqH/AIVzpEZwbq+wRj5GRePqFrs80bqn2cOwc0u5x1r8PvDttuIjvHyc5eY/0rSg8E6FGd62
+sgbGMtK2cfnW+MDkCnZqvZw7BzS7mUPDGjBAhsUYDpvJP8zU8Gh6Vbf6nT7ZPcRiru6jNWoxWyC7
+GRwQQ/6uFE/3VAqTNJmmlqoQpNFRluaKQH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0016/full/!100,100/0/default.jpg</Url><Caption>29376_0016</Caption><Caption>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Caption><Caption>Exhibit</Caption><Caption>plate 073</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3hadQ
+BTsVNhjc0ZNLtwSck5pDSsITNANJilxVAOBpaQUvWgApDS4prpuH3iv0oGIaYRTwm3PzE59aCKAK
+5BzRUhFFKwE4paBS0wEpDTjTTSEJimu4QZJAzwM+tOPSo4pI7qJuOMlWVh0PcUXAhtmKqZJpCS5C
++wIGOPxq5Vby1WOSFuY9vA7470tpN51srMwLAlGPuDiknrZiLFFRLKXnZFwUVRk++Tx+lPVg2T0G
+cD3qxi4pCKfSEUhkRFFPxRSAcKdTRTqYhrOoOCwB+tJx6ivG/GXifWrLxHdxxmbyUkwgVtoxVCDx
+prUgUppdwwPDM91x+oNYuvBOzZfs52vY90quytE7yIQVbqpP8q+ddR13xXeSKWv761LMdkdsWVUA
+9SvWqNhqfixNWivr69ub94GxDE8pbaf7zew/nS9tC17k8kr2se4+IvE0OhhJ5LlUQ5UCTnBx0Pft
+XD2nxRghv5YyrIDJn6cZJA98CuF8WDXdU23+oB2kLbQsIzjr1P8AX3rCTTpRHuEEkdwsfmDfzmsf
+eqe8paDcZR0se2WvxCgkujFaTAvODtDgn5u+Men867DT9Wa6ePIzjgk9fqB2/wA+tfL1vNqFpIrr
+DNGyZ2lRg89ea6rSfGutWKq3zgE9Dnn3pxm47srkk+h9NDkcUVj+FtTbWPD1rfMfmkXkc8Gtk12J
+3V0RsyM0UtFIABp1Rg08GgDgvE3ho3epSzy7jBIQcKfSuPRZ9OV4GiVnDsBIxB4JOOAP/rcV7Y2G
+GCuR7ioWsbR8FrWEkHPKCuOeFu7pmqqu1jx46sIXZCqEnniMLj86kQtdxq7WhGTwGOM/lXqs2h6X
+OweSwgZhyDsFSLaWUWMWka/8AFZvBtvRjVU8ouA6QbUtYgBywOffNc2LHUJ5WliRgJACiBNwA9+M
+ivfBb2jn/j1Q/wDABUkNvbqMpbIn/AAK0WE01YvbM8Mh0O/uIttxlVyeCn681rab4EkuJg3kll9S
+MCvYfIiznykz67RTs44CmqWEXVjdd9Cno+nJpWmRWiAAIOg6Zq7RnikNdSSSsjHfUQ0U04opgMDU
+8NVdWpwY0gJ80u6ocml3GgRLuoyCMGodxpQxpASqABwMU7NRZNLmmBJmkzTM0ZpjH5ppNNyaaTQA
+paioiaKQH//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0037/full/!100,100/0/default.jpg</Url><Caption>29376_0037</Caption><Caption>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Caption><Caption>Exhibit</Caption><Caption>plate 074</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Nc4p
+TmlUUoWpsMjyaXJpxQlgcnHpRigQmTS5NGKXFMBQTS80gp1ACU00/FMdCwGGK/SgYhzTCDTwhXOW
+Jz60EUrAVWBzRUpXmipsMnUU8CkXpTqoQ00mKdimE4ZR60bCCihSGXIpwFCYABSigUtMApMU6kpg
+NxSEU7FBFIZXfg0U9hzRUjJF6U4U1elPFMRkazriaQoLW8snuozXI3HxMt/MVI4kDbufMbbit/xX
+fW1lCGnYqTwDXmWuz2bxF5jEq5wGdeT+Qrjq1ZqXKjWEItXZ11r48uAFYwxSQ5JPljLYxkdD61ot
+47WNFdrJyjdHB4NeIpqJS7ZbF0WNQRmYEr9RkcVTvba7eW1a7vDMiA7CsmQOc8elZU60k7TdipUr
+6x1Poi18Z2Uo/wBIjeDPILdMVp23iLRbwZt9WsZDu24W4UnPpjPWvnFPEuoRxGIvHdxxqUw5+YD+
+tQpvu5C1s8ELEfNAykEY/E1vHEpfEJUG9j6norwrTPGuuWlokTtJcqihNyS5PHHQitG0+Ilwr7D5
+6uOCGbn8ulbRrwezE6E1uj2TFIawPCesT6zpzTzq4IbALLit81pe+xnsRt1ooJ5opAKh4p+agQ8C
+pM0COC8feG9R1q6glt1mliQYKROFI/PFcHN4PnO7ztD1NWX7pDghvyJr3gse2KM+uK554fmlzXaN
+Y1bK1j5+Hh3V48pbeH7ojOT5mcH9aqt4F1+VwU0qSFeeA5IGfbmvovPsKaSwz8qkfWoWEV73G672
+sfO0Xw38RM4b7Oygf59Ksv8AD7W0dJGgkfbgbVSvoBZJGOBGB9c1Kpfd8yqB7Gr+rLuCrvseGJ4L
+1+F02RSlV6qTxXR6d4Qmu1VLmx8ojk5HBr1LikJ9MUfVYdSvrEzM0TR4tGtDFGWJY5bc2ea0zRk9
+6QmulRSVkYNtu7GHrRSE80UgI0bgU/NUbWUyWsTnqyKT+VWA9CYrE+aM1DvNLvNO4EtKKh30u+lc
+CcUuag307fTuBLmkzUe+gvTAeTTS1ML49aYXouA8tzRUBkGe9FSM/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0033/full/!100,100/0/default.jpg</Url><Caption>29376_0033</Caption><Caption>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Caption><Caption>Exhibit</Caption><Caption>plate 075</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YZoU
+MByxb608CjFSA2kJNOxSEUWATJpQTRio55ktoWlkOFUZJo0QElLzWB4evLm/uZ5pnbHlp8hHCkkn
++X8q6HFKMlJXQPQbSYrIk1Hf4itrJHHKOxA9sVs4ppphsRkVB5TjGZnPPcDn9KtEU0imMrleaKmK
+0VIEwpaWiqENIpMU6jFADcVUvYJJIJUj2vvUgxucfke1XKZLAkwG4sMdCrFT+YpNXA43+3JNMtJh
+GFjuoGTfDKPlcDII3DIB9KWP4kaZd3UCW2VtyWMssoI4HZV6tk9+lXPHF9a+HPBOpTx2qMXjKLGo
+xvZuMn165NfNMuq30WxtiEJguiJhQOO/rmsknH3UUrPVntcnjGy03Xv7TuyIomyicgk5IySBzXf2
+3iXRLu2S4h1W0MbjIJmUfoTXytdk7EE5kk+QkFmyzHPr/npU1iLSSIoWxvYFRg7s1pDRDaufWEF3
+bXalra4imA6mNw2PyqWvmbQdZu9E8S2rabcGINIqSbz8jKSMhvavoCx8VaVqd0tvZTmdycEopwPx
+qtyWrGxiinYopAPHSua1jxfa6VO0LB3cHGFTPP1yK6RxmNh1yPXFeR+KNBvJr9nfZFCv3SZN2P0z
+UTnyK4WudFJ4+ZR8lrJu/usgA/PdU58dgAf6HKSRk/Jjn0615deW8VtJD9pPnZGGUn34OT9DVeS6
+hMEXkzfMvDeW2Bn8653iJWukVyHqI+JllbzOl7ayxjPy4HJ/OtC08d21/F5trp16yZwDtXn8mrwm
+S5mSMyCQumdoClj/APWqKLWry3cNBOI3xgbhn+lONaXYhx7Htfia60zxFaRW2qaTqoSKQSL5YXrj
+HPze9ZOp6loB0u5sovDkkTy27W4Z9i4XJORyec89Otecvr2uXkQSR5JEHpEcUJNegiRtMjkU9C8T
+L+u4Voq0Q5ZHLadYXuqakLOORjKgZiHyQfyroP8AhFb61kSSWSNNhBwqH+vNWYLmy0+/bUWsI5JI
+0WIxlsLkjOe/uK0n8aR3IKDT4VTHAMjHn8qp1EXZmJo2lXE2uTRhV3xKzor/AMXevTPhtPftfukj
+RpbjI8tVVTn+dcnHqMYaG/jgQSjKECQ8g++K6bwjr32O4tbNLRJd7Aec9wAeT6YoVRXHKOh6yRRS
+0VoQB+6ee1eP+MjdG5kKOzqpP3mJJ9q9e4Iwa4rxdoE1xtNlE2G+9tHSubEqXJeJcLX1PEL64dtU
+WMwykiHOF7nn/Go7gRPCJYCFWLGfm5PrxXU3vhSSe5f7Tu84DCqASVFRR+BboqQVWOLdv+Trn8Tj
+9K5Y142S6mjgzmbi5EkF0umRs0kzKxKHtjPT65qgjQrp5mngV7rorKT09SPXNeh23gu+kto/tc0S
+eiHBKj0JHBqvqPgOcRbY1TGM4jQLu9s8YpqvG9iXBnH2/iK/021wk7Tvxu3fMEJPTn8K1LDWX1je
+Zkw6Ae+OvY8DpWhZeCNSKF5rKP8AeY+Viz4x+NW7XwSG1F98qwqoyY0HU+5/OqqeytdaMIqXUzJI
+oARAxLDbuYFwMn6gVUg0uGaTCoxOf4c4/M13lvoVrFHt8pGPGcDOfxNRf2O4kdbSNwewAP8A+qsl
+Wi+ppY52PT5pFKRQGNAfk8zg/lW34c8OH+1bVpZ38xWDAR+ta1joGpeUXdQ0p4C5/nxXWeGvDUlr
+It3en96OVReADXTTUpPQmdkjrB0FFBorsMBgal3L0JFQKxp6sc0AI9paytveCNm9SozTJNMspRh7
+dCPTFTBqXdWbhB7od2Uv7E0/IP2deOlPbTbIMGdR7bm4/KrOaU8jBqVSp/yoOaXchW2s16BfzqL+
+xtLlZpfssLM/3nA5P41aVFToKeDV+zh2FdlMaJpynItU6Yx2pw0jT1YMLWMEcgireaQmmqcFskO7
+AKkYwAAKNwPQ0maaWNWIUtRUROTRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0022/full/!100,100/0/default.jpg</Url><Caption>29376_0022</Caption><Caption>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Caption><Caption>Exhibit</Caption><Caption>plate 076</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RVx2
+H5U5eR90j6inAUGpGJikOadmkNAgBNKCabS4NFgHZopozSjrTsAtIRTqSgCNjtGTn8BUe8McDPry
+CKnIppFAysQc0U92VGwxxRSAtCmsQqlmIAAySe1P7VzmrXksKXKqcxujKwPbIobsBeste06/n8mC
+YtJuKgbTzj3xitIivKtA8eWWixy2TafM6pM6idNpBGeOpB7V0ll4+sru+jhVJgspwGdQAD+dZKtH
+qynB9DsKoXGprbXMsDoQ6QtOp7Mo6/jmmw6vC5yzKVPIIIOPY4rhfFU8uoeIILZb6aGOTMUUiAYy
+2PlYZGVJFU6iSJSuelQSpcQJNGco6hlPqD0qXFUtKN79gjXUIoY7hflIhJKkDoRnp9Ky9T8a6PpW
+pnT53le4UDcIoywXPqavmSV2JJt2RU1zxO2k6nNYtHKVkVMTFMJAWO3czenf6g11SMrorKwZSMgj
+oa8xt9XGv+Pobm0kuFs5BGkkDkASLtbBK/Uf416ciLGioihVUYAAwAKIu+pUlbQKCKcaMVTEY2pS
+MlyoVcjZ/U0VJqTFbhRj+D+popAa3avN/ElzeQX8vlLIVPZSD+lej/wmvFPE2t3UWtzxFmjw5G1E
+DGom7IaVyrLJFCsUn2bEwJfbgEAZ9Pfmr3iIymTT4bWWb97EJHSM4wSBgDH4n8awZ9Q3TtGZpdxV
+TnYueBz/AFqOHVhd30KzXDxcLh2GMbenP+etck46aGsZO+psjRteEBMf21MjqHI/WqF5HfwGC0mk
+ckSK6PKcsuGyQT+tSL4g1VoUjm1I7GGQZA3P4jrU9xd6ibhNstrK4UeW7y4YAgdP1rJQd1qDqLsd
+lB4rk8oYlOccBZBn8qxUubESX9xdxCS6vJ3MLEfMrAYH61zkyzzxEXSqcHdxMDgn3qvdQiOLCHGH
+GCZBwCM9j611t8yszKHuu51OjS7L+ymhgjW9ijJc9DtPIHoeCv5iuxXXtSXlwmfQ4x+gryeS5Nnd
++dDJIkmzZ+6fsD0/Sri+JtUMIEJnJ7lguaqF4xsipavU9QGuXrP8y4HfaOP5V0dnOLi2SQHORXkm
+n65qrzxlwp453xj+lenaBcS3On75QA2ccDFWpNuzJaJrxEaYFhzt/rRVmSJXbJoqhDyflNeYa5d2
+iXsouViLOx2gLyfwr00ciuN1jRngvWuorV5dxziOIN+YrCuna6Lha5ws9hZjNxsEasNoJHOO+B1q
+KPTLSaQE2+/0MpJ/QV0lydTg3SPbzBP7rRYA/DNZrahczuBCwjGOrNgfpXDKrbc15ShLp80QaKIW
+MUZIOPLJz7nJpt5p95eTbYrmJIgqgskeMnAzV0Weuyy7hewvGf4ViLj891adhoV+YcOXdv7xjIpQ
+quWxLikYEHh2BVYT3MsueuPlzV2Hw/bS+axiBLuGw+cDGf8AGultNJmjO2S1cMfTOKtyaWyHc0ZV
+QP7p5rZTkldhZHEr4fN5K6x2SoFLfO44HJqSDwfGpB82RmHUDArsI7SYjcrO6HtyMVWnEtsyqttO
+Wc4+QZI/IUOo3sUkU7DQ4BModX9OWP8ASvQNMs4bK12QxhAeTgViaZobu/nXMtwSf4CxAFdJHEsK
+BEzgepzXTRUrXZlNocRk0U09aK3IGK1ODe1VYnJRT6jNShjQBKQjDDKCPcVF9jtM5+zQ59dgpdxp
+c0ml1AVYoUHyxoPoKXzEHBXH4UmaXNFkIcJVOSFJ/CnjaQDjr61GDgU4GmApjjbqin8KAqjoAPwp
+M0Zo0GOJxTS1NJppY07gBbmioyTmilcD/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0047/full/!100,100/0/default.jpg</Url><Caption>29376_0047</Caption><Caption>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Caption><Caption>Exhibit</Caption><Caption>plate 077</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2RI81
+IsWR90j61Ii81Jg1Iyv5JzSmOp6aeaQEHl89acI6k20AHNAiPZTtlSbacFo0Ah8uk8oVYxSEUDKx
+gqq64/5ZSfkP8a0sUxxxQBnGHmirhWigCwo5p+KVBzTiM0NgREVWuLyC1uLeGZtrXDFIyehYDOPy
+z+VN1LU49NaFXilczEgMqZVcD+I9q4bxjJeS3kC3N4q2xZWSNMrtb3Oc+tY1KvKiowud7b3cF20g
+gkV/LbYxXoCO1YviHxdZeH5BC0M11cld3kwAEqPVieBXL6NfeIbO0ktLS30+KP8AgkZmcj37AnNO
+stO+yTTzX8pnuJwWllYZyaxliHbTcpU1fUuWnxAv9R/489AYD+9LPx+gouPFviKNv+PKyjHvuNYc
+F7/ZOoEL8luzYIk45PpVnUNatT5kSN5skh+RR1HFY+3qM2VKPY0h4y1+2j86fSbe4i7+TIVP4ZzW
+nonxA0fWbxbErcWl63AhnTGT7EZBrP0xJP7DSN0LSj5SpBH86x5NIMXi7S76NMOkjHaP4gF5renW
+lflYpU42uj1LFNYcU23mM1pDMy7DIisVPYkZxUuVPAIz6V1M5yseKKew5opiJwcAmuau/FcdncmC
+SaFX5IBRv6da6ORPMgdAxXcpGR1FeRaha6tp15Nlo54wx2+Z94D61lUk47FqNzvbfxPHIm6SWBlI
+yu04P5E1TufEs03ywwWhB4zK+7+VecXNteXMqzQRxI/TA3kD9cVXFpr8MhYXETZHII4/nXM60h+y
+Z11w9yJ/Pke2BB+VkQKF+mKoyTXgkxC0hidg8zSMCcA5OK5a/S+s9DmMk6i5lkBCs+3ag9OepP8A
+KsCNtWkCmOJx6FiwH6mpi+bVhytaI7SUS6xci4RFZFYlCW7g4zV5G1lJVD3cMO7oW2H9RXIfZtR/
+s2OXaFnhJDjJw6nv9QT+tUPtV+EVZbZyobIYyd63hy2sKUZt3O5j8W/2fc+S5aTkhpgP6d6dqXiu
++SYQSoijPyvGwJH9RXMmTT7BoZ9QZvOI3CIYYj0zz+lWotT8PynzJ3nkdjnk7QP0rN8rd7GqckrG
+3eeJLy3ntoYZmkR0zjdkseuT+f6V0fhHxPLqOrpbeXI27OWLDAAGelcvc2WkXMcLvhDJCBGTJhiv
+rXaeCtA0+1uDfQIRIF2q28kH14rSNSLaj1Ikup2bdaKVutFdBmPzwRmuS1W0Mkr8lutdWDXHeLdS
+k06VTHCSjdwueazraK5UGZv2KWRgrHA9qnewVEAVeneqFvq8k2GkUj8OSa0mvYwqxvExdhkj0Hua
+8+U0bGY2jW4ufMEcTysPvP8AMatDSF2qfJRVH3zwAB61D/amnrMd7KrL0AJyTVmSH+0IZBFdPEMc
+svP86zVRNgZmtQWNrpwZmZDneUTAeQdMZIOOo96k0XT9H1CykmtrJAmMBpWyx/E5IrmbzQI77UHN
+1rlw2ONuwZrd0vwTFJCI7TUbsJjsRj+VbRqRk7REvMFtvD7Sy25jgjuF678ZPbr3p3/CGWkuJCEK
+k5GDWpbfD7T7WYTXAlncc5kfAzXTRaYfJVYwqKowFHatrSK5kcDf+FptSmgjlMawwpsRE64z613P
+hTQYNFtGWNAGbvk1PHYGOTLkGtaFNkWOa1pp9TOctBx60UGitzIj3c0OI5Rh4wwHqM1CGNSAmjRg
+At7Xg+REMc/dFKYLds5hjOevyik60dqVo9g1K6aPpkblxZQ7mOSdgzUqWdjb/ctUUeycU7Joxu4P
+Ipezh2FdkJ0/Snl8w2MLP6mKr8SxRqBGioPQLiq4VQchRmng1ShFbILsnbYwwyg/UUYUDAAA9qi3
+UFuadkO45lQHO0Z+lI0g9DTC1RsxosFxxfmiqzMQaKAP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0042/full/!100,100/0/default.jpg</Url><Caption>29376_0042</Caption><Caption>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Caption><Caption>Exhibit</Caption><Caption>plate 078</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vDBc
+gFj6U8KSASMe1PVakrLQogKkUmKlYZpNoFPQRHtpcGnmgU7IQgpTS4pQtHKh3G4pCtMuLqG2eJHY
+CSVtsad2PtU+OKLILkDJwcDJ9KgPmFgDCQPXcOKukUxlpWGUmU5oqwVGaKiyGWUp2KF6UMyr1IH1
+q0JiYoIqJru3T70qD8ai/tG3Y4Rt30oZJORSgVWbUIgPumkGoIeduB9aOYCxPPDawPNO4SNBlmPa
+ueXxNc6lIY9HsWlX/ntLwv5Vk3183ijW/saMV0y3b52X+M9zj9B26muytZLG1t1igZI416DpU3cn
+psPRFHT9GlW+GpalP9ovApWPHCxA9QB/WtC9vbbT7V7m6lWKJOrGlXULJ32LdQlvQOM1znilkuNY
+0C2d18iS5ZnGRyQBgfqat+6tBrVmpY6/ZahOIYhNG7DKiWMpuHtmtMjiuY8Z4SPRpbdgJ01CMIVP
+Yg5H0xXUYyKAIsUU/FFQMeW2RlsZwM1xWoarNc3DeTdw7ckeWQQ4P0JrtHZVhZm+6Bk4ryHWbjSb
+zUJHivim1/4lIKn2pSlZbglct6jeahbbZD5hU9SVzj6gdBWXL4p1GEhY2QN2Cjr+dWY7zzYRDc6p
+mMHJbbliPSqtxd6VboxifOMksYjxXP7dlOJDdeK9UghLz6nHFjtwTWHfeP8AUJIRHb3s+6Q7SzKF
+AHfmsyR/7T1FrmfJiztiU9l/xqQW1vdwyQx7A2SAQCQPqfX6UvatMORdTsNJgvdPs1MNzMHf5mZT
+hW/PtVk3+pXLGGSSZlzzk9fyrL0q81PSdNjt1dLhl4VZF6D69cVXu/FWsAPHE1u0hyCIojhPfJqo
+Vr6ITgT6jrllZSGMLJNcxnlYxyh+vY1l3fim61GewiSS9WeO5RovPO4DPHWnaTbQ2cuLhCWbli/f
+PerGoQWczmSOGVWjwV2dCfbvVqu726GnIjprqXWrmW1ecxSi3mEo4I5Axz+ddx4b1S7vnZLiBEKj
+qjZFeH3Wpa7dNsubyfHTap2D9K9I+Fdq0X2iWZpzIwwN5yMVspXM2j0kiilPWikIhuMfY5QckbTw
+K8i1GwMcrC3hSNQT0Gc/j3r1q5i+0WksO4rvUrlTgivMptGuLOeSFpJZYyTjcSxrnxK0NKeuhycx
+ugSqDnPJFRfY76+eSN0zbIM88bz7nsBXZQaTIkRK2xT6LTWtJCmWil8tT0fP8q4ZVOVbGnJqcVcW
+UMUAt4C7SSgruIK8YwSPatzSvDTC2RYiE4wDmkuoIzcA/YZnbswzkVds1mEiJDdtCzc7W61m6mmr
+Hya3L6aS0ChEjklcDlmIwartYJ5XlHTFGDk7SQCfwrSt0vIm3PdGRR3q4l/CG2tIuT6NWkY+YW7H
+L3GmXN5KGWAjyxgYGP8AGobjQNTJXZvHHau8ik3DKDj3FBa4LYSJW59DW0YruHqee2+l3TShJYy2
+3rk16p4StkttOwgI56GqMcDySgSQxg9jiulsoVggAAxXVRi07syqNWJyeaKaetFbmZEjZFGyJvvR
+g/hVa3lLxI3qoNWA9MRIIoSP9WuPpUUlhaS/fhU08PS7uKlqPVBqRf2fZIMi3T8BVVtK0oyb2txv
+9ec1e3Uu6p5Kb6DuyqLDS9pUQLz6Z5pkOhaTHMHS0+f1bcRV8NgUoeq5IdguwWytlGBCgH0pwt4R
+0jX8qTzKDJTSQXYrRxdDGv5UmQBgDApC9RtIaYCluaKgLnNFK4H/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0032/full/!100,100/0/default.jpg</Url><Caption>29376_0032</Caption><Caption>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Caption><Caption>Exhibit</Caption><Caption>plate 079</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tE4x
+T9lOVak28VFhkGygpUyqTnIx+NBWjQCHbTgtPC0oFPQQ0LS7KdTgKLDItlIYxU2KawbPG3HvQBAY
+hUbRVa2nHOM0xhQBnvF81FWWXmikBaUVIBTIs+WueuBmpRTAYeKYc1KwphFIRHThzUF3dQWNs9xd
+SrFCnV2PAqnpGv6brbTLYXIkeAgSIVKsv4GjmWwGrThxTRS596YDuKCKjMqguCfujJp6urEgHpQM
+QimMOKmIpjDigCqy80VKRzRSAmA4pwFNXpT6AEaq13cxWdrLczuFiiUsxPoK4bXvEeoWWr3MT58p
+ThNny8VyviHxIbjRpbaN5lZ8Bgckbe461zSxCvZItU2zqdZ1NfEFqoGUi3B4yp5BHeuXsmfw94ug
+vo7xIBM4ScynEciHqCR0I6j6Vz+k66YI3tppVeMD5WXtUOtX0WoAH7SWSPBKY6+nNckZzU9TocI8
+uh7ff+K7C0sorq2DXqSMVHkEHGOvU1Uj8YaZecRO4kYcxsu1h/n2rxXwvrq6fNJ5sjNaqSGhB6jH
+DfUdK6ZxdX5hv7JdsbP8u4A+WPXg11SqyvYwVNHdL4h/0obn3Iyn5vXB6H3rX8P6l9sV2diMHGT3
+ryUarfiaZJtPUzIxztyoPvz2rR0jxY1vG0MlrKpzkGMjiohOpzXkPkZ7UORmmtVDQrn7XpEM2X+b
++91q+1dqdzNkRHNFKetFIBUOak7VAhqTdTEcnrukrLdF1QMSc4PasOXw/HdAxPGrMT90LXo5Ck8q
+D9aFjjU5EaA+wrlnh7u9zVVbKx4/f/DZ5W326mJ/VTisS5+GWqBPmmyD97Jr33j0FMYc5CKRSWHa
+6h7XyPCbL4am33CcyvnqFOAfauqsfDF7DAsVsrQxjsTXpY+Y/wCqX8alQeqqPpQ8M5byBVbbI8vu
+fCWrXLMjOxQ/xEk5otfAM0ZCuGZT3r1PikOfatI0EgdVlbTrUWdhFbj+AYqdulLk01jxW6RmyInm
+ikPWimIYjVJuqkkhqYOanmHYsbqN1QbzS7jihSQrE26lDCq+404MafMBYzTg1V9xpQxouBPuo3VD
+uNJuNO4EpamsajLGmsxxRcdgLc0VCWOaKnmCx//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0045/full/!100,100/0/default.jpg</Url><Caption>29376_0045</Caption><Caption>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Caption><Caption>Exhibit</Caption><Caption>plate 080</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21QFX
+J6VLtoUYFPAqAGbaNtS4o20tAIdtLinlaMU0kIbijbT8UuKdkBHtpCtS4pCKLIZCVqu0kYz83T2q
+4RTCKWgFPG7BHQjIoqcrzRU2Aq6u8iwwohIDvtYDqatQSJaxJE7tnA+9zVLX50tbOKdwpVJBndXL
+P4oM7usUbF07sepPasqk1DUaO2kv0jnKtkIE3bsd6sGeNYvNkdUTGcscYrz7/hMntVaWeCNli+Y5
+4249/wA64rxpr+seMNDuLu0Vo9PQqqxocEjrz6njOOgFQqy3Go32O91n4veFtKuGt45Zr6ZTgi1Q
+FQf94kD8s1z0/wAdbVWAg0KdgTj95MoP6A14/YxKkLeYhbPB2HBHvmtzT9NtkhkNxIsUiKChbLCT
+Of8APFKVZor2Z6fa/G6weF3uNGukZQPlSRW/nitPSvjD4a1GdYbj7TYOxwDcKNv5qTj8cV5Pe2BW
+MSnaokjGVxg8Viy24L4C7gG+b0IqoV2xunY+rba7t7yBZ7aaOWJuQ6NkGiaUxxb1AYfWvnHRPEd1
+4N1QKk7CxufknTsv+0B6iu7vNTvjDG0E8ioQHTDfe9M1p7W6uZyjyuzPS4boyQvKwbaBnGOaljlW
+aPeh4ryePXdWtnQx3LtFIcvHt4Pfit3w54quLm6eO+8sQoo2sp28+h5pxkK53RHNFO4YAjoRmirA
+yPFto114enCfeTDDmvK7W8VLzZgiQsDI5HRfqa9ovrc3dhLAG2lxjNedT+GoknfcxZuQc5HesK8E
+wR594p1BTJPZRTgu6FiXbHHp+P8AStXwuzN4Ms0QqXF0S0f8TDkZP4Go9W8BXd94sWcKn9nyKrO+
+cbdoAx+NdNZaXHZyyCMxxhT94nnHTj8Qa56rUYcq1uaQvc5zWfBtuJTKVRVY8qF6EnqD2+hpPDOn
+2z6NPFqNwEQXDCEHJbaMdPxzW3qAZr1LWKVneYgZLDA4z/LJ+oqzZ6T5K4RRgDaMc4Fc0Oa1pM1q
+TWjijnvE2mLJbILYSSkj5W2kEj05rntLsQ0skVwgjijXczMOM/XpXcMkl1qrQI/7iFMYPTd2/QH8
+6oWFkyavcaZID5cmZI0cZH+0v8j+da07/CU2kub7zm9fgtNVgzbsmZCNpxgAZ5P0/nV/Rby7NvDp
+bxkT26Z83O4sucAj14rXvvCd2B5djKIoGOXiK5J9MH09qz7PQNT0rX7MzTgbnKGTYcOp/wDr10U3
+y+6yJ2mroty28yRjdLj5dpXBJP68VUtbaTdF8sZYyKcsQAQD0NdbcabOcgbWPqUp2iaO76jCs8Sl
+FOfu4z+FdCt0OayPSIf9RHwB8g4HTpRUm0KAAMADAoqyhSf3Zx6VyWor5s23aCCcHJ611YORg1lX
++ji45Q4PrWdaLcdBxavqc01jbkgOjx46/NwTWdc28sV5IkaRMjgBXkz8oHoB1710Y0q7j+Vi7AHg
+5qKazlTKtCJPdkz/AFrzJqSeqN1boc1d2EdrLBduwk/hkKjZxg9PzP5VBZA3V6TYWzeWnLyyHAHf
+8a6CXTHmieNoiY2Ugjpz7VFb2EtlCtusQCHIILZJrNX7Ddmcm0eoQXVxFaTtAHlLvIY8g8DpzWjN
+HLDpQv2eSaa3lR2kcDOARnp7ZFaR0u5hvSVgxETxt5xU8sM00L20cO6NgQx25rVSegLe4+8kWKIT
+NPCEOCrM23IrF1G5kFkVcptkbKMWI59Rnk/hVi10V7e+Es8aSmMExoEHHuM07UNITU50kuYp2lVc
+IQWBUZ9jitYvoxWtqhjeIxH5CXKr5kx2pg4LkdcAgV03h64jubpSjMCD911INcZP4ONzd27mW9le
+A5hDSY8vOMkcZPQV6VoVg9nbASD5gMZPU1009ZKxlJKxqnrRTSeaK6DMjVqkD47GqiPxUgemmBaD
+ZoIVuoB/CoBJSiQ1LAlKp/dH5VGRH3i/Sk30bzQrACiA9IM/8BFSRxQgfLCE/AVH5lODmqtEBzW8
+DMGaFCw6HFBghP8AyzT8qTzKTzKegAIYkbcsS59QKcW9sUwvTS5o0AC3NFQs/NFTdAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0049/full/!100,100/0/default.jpg</Url><Caption>29376_0049</Caption><Caption>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Caption><Caption>Exhibit</Caption><Caption>plate 082</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29E+X
+pT1UkcjBpyDin4qBEe2jGKkxSEUWQEeKMU/FLtosgGAUuKdtpcU7IQwrTdlS4oxTsO5Ay4GcE+wq
+HJLAeU4z3OOP1q5imMtKwFNkOaKmK80VNhllBxT6aOFOKz5Lu4WQ4HTtgVaRLdjSxQRWadQuB/yw
+J+lQvqVxuwqlfqpNJi5jXoxWUuqShcFAzeuCKkXUzj7gzSTFzI0sVm3Gv6XaXwsp7yOOc4+Unpns
+T2qP+2WQ4kgGPVWFedeJdPl/tGWTS7oSpJlng/ijJ9B+NTUm4K6KhaTseri4gO3E0eWGVG4cj2qS
+vCvsMUZk+0xuZiC7swyxz3P61TtPF2reHZY7ixupJLJW+a3lJKEZ5AB6fhUwrqTtY0dOyPoA00is
++x12x1CzhuYpU2yoHALDIBGavRzJL90g/Q1u0Z3GEc0U4jmioKFlJFu5XOdpxjrXLvqF0lxhpAyp
+nI/vV1EjiOB3boASa5Ke5jeVmCAL2JOc/hQ3ZEsWfUTIBtldRkNtIIrO+0zrMJYp3aXk5IPQ9qzN
+cvZo4GaMScHIyoAGK5K68YX7Wa2VqREzjmQclR7elYyqIFBs7i68Sy29wsEcvmSZ/ebpNoT/AOvT
+J/FgghhuZLo/vFISJXJLHOM47/WuEh042+nSztBv83jezc5Pf3rYtNPis7F766IVlXO9uoHbrWCq
+NtlyglZHUWXiYmykuLlZHJfCpJlePUA1m3uv+H7hh9rWRcNuA27wD+Fctp/i2xa/ex1VQ1nK2IZZ
+ODGT/Q1b8T+Cpkha70q4faOShO7j2zmqV29RpWRLeN4cnczNqFy8jcg7mTH8qy7670Z4hbmYPBG+
+8fekZj+PauLnN9aA7zubPO4DFS2/n3s7IjAEY6fStVFdx3Oo0PxJeQ6mkUE0zwZwkbjccfTsK9s8
+OC7ZRJcBdrDsuMV4B4cWXT9WjklHyBuT1xX0folxHc6ekkZUr6rWsW72IkluXiOaKG60UwI7mJJ7
+SWKT7jKQecV59qusQaMreTA7bR1PevQmG+IqehFcb4j05JrSWIQjOMHis6iugW55hqnia81hmjjU
+QxofmzyT+FYtqs1tdTySxYlC71DjgjHFdZoPg2/F75lzGPIAPLdSc9vauql8PwyIk0kcr+WeIcYB
+I6ZHp3rllZKyNeaxz+m+d9gj1LWiQsfMUIwMD6eprldb1qbULqR5SfKT7kK9AP8AGu61Dwxf6o6y
+XO5EH3YkPA/xquPAwaJg8Z3HpgcgVClZk2OG0rw/Hq9hNdTqu9RnB7V6J4AvDfeHzb3T7/Ldo0bq
+cDpn3/8ArVUh8EzxufLDxq6FWCkgEe/bNO0bwff6Dd/aLCR/JLZkgbIDe/19615k0FjG8Z6CYblb
+yCPdEeJlUcj3rEstJFs32lDvhOCSBytezTxxTQq8ibWxkqwrlotCWLWrgW6E20yhioHyg+1XGWlg
+Zi3WnQPcebDhk2hiysOOOprrPhtezTXl5BFuezRRl8ELvz2z149K5mLwp5OvFfsdxJBMrEGMkMnq
+p9q9Y0Swh06yWCCLy4wBwRg5q6VxSNE9aKax5orYkYjU4qjfeUGqaXA9DUonz2NK6AmEMX9wCg20
+B6xLUfnjHQ0ef7Gk1ECQww7ceWOOwpuyLB/ctx9KZ5/1pRNS5Y9gHbYiOIXPsMf405IYmHMRX/ep
+vne1L5uarlj2DUcbWA9UB+tKttAo+WNR9BTRJml8zmnaIairFFGSUiAJ9BTi3FRl6aXqgBn+aioW
+bJoqQP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0043/full/!100,100/0/default.jpg</Url><Caption>29376_0043</Caption><Caption>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Caption><Caption>Exhibit</Caption><Caption>plate 083</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xFwv
+TNSKuVyRg+lOjWnkcVnYoiwAaXaKdik6UrIVyI8UopSM0YqkkK44AUMMU0LT8Zp2C4zFLtFPxQRR
+YZAyPu+ULj3NNEb4O8L7YqcijGRSaHcpPH81FWGXmio0GWE5UEdKU1FZk/YoSevlrn8qbLeQwqzS
+OqqoySxwBVIlkxoxVG11iyvVY21zDLtODtcHFcb4u+ILWUsmm6Oqvdr8sk55SM+g9T+lTOSirsEm
+3ZHa3+oWWmW5nvbmOCPOMucZPoPWo9N1aw1eNpLC5SZVOGA4K/UHmvG7KC41i7W61S5lvJBwu984
+PsO1egeHtD0/S7lbu3uXEh4dTJkY9Kzp1ed6IJR5dzpdVu5rGxaaCDzpOgXOB0rgbT4h6raaif7V
+0/dZE4LwxsrJ+fWu8vNZtrS2lkPz7FztU5J9q4HxLryzWFwktqqSYypQZB5HB9Dg1dSbgrhBKR6R
+YXttqVjFeWkgkhlXcrCpyK8l+HPiE2GoSaZO+La5XzYQx+6/cD6j+VeoDUYG6NWlOXPG45Lldizi
+jHFVvt0ROKsxusgypqmhIjYc0U5hzRWRYxCF09WbjEYJ/KvM9W1aC9E1vtuPvg5UdcHPfivTJ/8A
+jykB/u9K8u1UPbyuxs3kAJxsbANZ1anLoCVzI1HW5LG9S5hgMbeQ4wT19Dx74qr4Ws4bpzJcyBjn
+cdx5JNRazFc6nboY7UQyR5Aw+7ep6ik0CA2qyC6Ji8wbArDBJ9vU1yTlzJamkdDXu0s7W4WaIeW+
+S0cqZGOSO3WrkGtxMmxYGfndne3XrVF31aUeTDZrHCBhfMQk4qzb2eqKqfu4Oe6qeK53VcXZENNs
+nkvXmyY7NgWHJ+Yn9aLeyEyM92smzlmWToTjiqrHUFuTEbmQAckLHmn6lqLwadEJJzJmTG7btx6Z
+rRVnNWHCNmc1qzva3cbg7ZEcN8vbnpXWSLaXErMXmRdoKmOTB9888Vw97MtxdKo5LMCST26mt5bw
+Xl2l1NHtgXiOMAE49T711U5tRKnFXOggQt5f2OaVSOS8zFh1/wA813eg3EM6t5Rk91YHiuDt7y3k
+AALIPXH+Fd74d8trYtHLvH1zWtObbtciSNVutFK3WitCSOYotq5c4UDkmvLvE2qW1pG0kx3AMSih
+sEjPOPWvU8BkKnuMV4z44+G2r3d5Jd6cxlDMSUJ459PSsasOa1yomefFem3TpFAjA/w9vzroraW3
+uYcS2qysBwQORXB6f4C8RLIplsSqhuuev9a9Q0vQtSRS0sGwYHQDJrlnBJ+6aq1izAWFopLMpUAK
+rZYn/GsltRsopmjvZCZWbaEY9/p+NaGs2OtyQmK0tnGFwNhxn8a4qfwd4umDGGxEWTks8g61m6Ll
+5CbR04liDmRZY41z+FU7+wv7uxbe3mQnkBVXn65HH4VW0vw/4h0mMy3lgs4UZIUkn8K6u2W2u7YJ
+tmQ5+aMg/kaz5Z02I4PSfDMd27NcQpGyt1+Y8duCcV19j4b05V83/XsOrMM8/TtSS6ZfDUV+xW7g
+c5YrxitJdO1W3jWQh5VJ+ZU4IroXPJbAPt9Pt24WJB6ZTp+VdLpkJhhIMap/u96p2VvKwGUdR71s
+IpRMHrXTQg1qyJMRutFNY80VuSRI9Sh/aqUbkgVMGNVdCLIIPYU4EVW3ml3mpdgLBbjgZpvm4PKE
+VFvNG80tAJhLn+A0qEHPybfy5qEORTt5qlYCfIpN1QbzRvNUImLe1MLVGXNMLnFAwZvmoqFmOaKV
+xn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0048/full/!100,100/0/default.jpg</Url><Caption>29376_0048</Caption><Caption>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Caption><Caption>Exhibit</Caption><Caption>plate 084</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD22NOK
+kCgjjBp0a8VIFA6CoGQlKNlT4ppFAEO2nBKftp2KLIRHt4xijYKkxTgKYEPlimmOrBFIRQMrMgAy
+cAe9REITgMCfrVwgHqM0xkHUAUhlFo/moqwy80UrICxGOKkxTU6U+mIMUmKdQSMgdzSuA3GKTFOr
+O1bWrPRola5f945wkS8s30H9aOZJXYWuaAFOxUNndR3trHcRbgjjIDDBH1qene4hMUmKdTA6sSAw
+JHbNMYmKaRUmKQigCsw5opzDmipuMlTpStKifeYD61HlhCxXG7HGa4rUNb1BJjG1tlwT8y5AFTUq
+KCuwSudx9oi/56L+dMeeFhxKgYcjmuLtrrUZ8NKqCPGcDOfzqhrGryafCzj5AflRU5Z2PYZrknjY
+rZFqkzt5ddsoVbfISV67QTXnd7qtrqXjS5muVfyE8qNFbg7MAnH1JNVEvLq6cLfWl+m4ZXDBg35G
+ormzjyJYVZSRnk4PFc9TFOWjiUoOLuelJ4j02KyVYJlLKAoRnywqnF4tSNt11hIVyWc8DFcVaeF1
+vR9pkuApP3mJyQatanFY2lmqiIXUyD/WSMcnHQcV1RryfQlQu9Tq7X4gaJeXiWqNNHJJ/q/NjKB/
+oTWhHqitDGFgclDjcMc4OK8b1O5lvI1e6WCNkOU8tQojH4d61fDniC/kuHto5ri4TCiPOWA65Ocf
+StVVlbUp010PUJtWuB/qrcf8COTRY6hcTzhJigB42hSDXJX02qiNZRGwdOd4OMVseF9QuLyYrcoQ
+R0yo/mDTjUbdiHE6dhzRSt1orQQ0coRmueu7RBMRtyCe/NdCnSqV3bkHeiFj2AGaxxEFOOvQqDsz
+JkiPk7FwBWDNp8kjnz1Uc5X5AQPoa6eG0nuWLS70A/hGRmnnT3MpJU7ccHNcns1L3rGnNY4q4067
+kiZDezbGHIDk8e2c4qjYW1rbu9rb/u/KxvY85Ndpe6ZLLEywfKfde9c6ng26uGlaS4njyeiEAN79
+KajbQLmXqGo2sR8sSMz5xtTliapS2c77POBt42bH7xhn8s119n4OtrRVL2zySjOX5Jb61MPCSXJ3
+3dsAsZyijkn8e1VylKSRx9lplvc3H7q3kkgjJBkdQoc+o9q7C3+y2FrllVffHT6ULpuoXDmG3j8i
+MAY3A5FPfwnOiFmaS4nPO5m4/KlGXNHmivwG2urM671uF22puYKOSFya2fC7Wr3BljbEjdcgjNVb
+bwldxStJtiUv15zXS6Zpps0zIEL+qirowk582vzIm420L7Hmimt1ortMRkbcVJuqkjmpRIaLiLIY
+GnZFVfMNL5hpNoCzx6UzeB/Aai3mjeaSsIlEoJwEP5VIr5JBUj61XDkU4OavQCxkUZqAOaN5ouMl
+LU0tUZc00uaLhYRm+aiomY5opXCx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0015/full/!100,100/0/default.jpg</Url><Caption>29376_0015</Caption><Caption>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Caption><Caption>Exhibit</Caption><Caption>plate 085</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21Fwt
+KqkjJXB9KlVeKUis7DIStJj2qUijFIVyHHtRipdvNBwOpApITZHjFV5L21iOHnRT7motWnaK2OwZ
+yOtefXksklxKZ5EUAjYrdTj2rKpV5HZIa1PQk1OwkJCXULHPIDCrWxWGcAivIdOaCTWWlkbbhd2w
+fxHPeuqfxJNDCuz5Yl4DF8DAqViFs0Ukzs/LT+6PyqBowetsf/Hf8awdG8XQ3kskU5GRjaw/iPoP
+WupBDAY6V0LlkroVyk1rHn7i/lRVwrzRS5UO5YBwMmoftMZmSMZJcEggcf55qRzthY5AwOprm7rx
+XpljO0bS7yp4VO/45qtkJnTYoxWFY+LdNvzGAzxmQ4AYd/wrSvdUsrCxlvLm4RIIhlmzn8PrSuiS
+S8n+y27S7GfHYV5R4m8d2ouxAbqV5ASGitwCVPpkkDNZ3iT4gan4o82x06M2Vl1V/MVZJOO5YjAP
+oOa5W10tIIlk+Rivys+8NknocA55yTjnge9c1R8z30LUe53Nh8TrfTIjbX2l30sO0EMXViM9Dg/U
+d6qyeItN8QSb7ORluWyUh24dR2znr+Fc9PaqJkTzUEYzyUy6qenOT09cduKg1/TbFX2W7xpIAed3
+zcKOOOCRzwP0pW5kkPlR2KW8GmWqTzMJbtz8zDgAE9DzWfqthdzMslxcIkTKCEHGB6Y/KuO0nW5o
+LmGW8jW6UcI7dc9Qc9629S1stHiJirvySw9ulEabjLTUTLukvHYamjtI8kaH5SQMD9a7vS/Ft1c6
+vb2zIRBK3GQNwHvXmVrds9sn7tXYDOc5P+FdR4Kmmm8U2ysgEZXOSMDOD0rpje5J6/iin4xRQWVd
+Xm+zaNdzc/JEx4+leM2SxX8csxBjlWQdTnIIr17xJJLH4bvGhTe+zAFeA2Ut/aXQ3MrQbuUSQAkf
+Wpm7IXK2dik0Gm232p5H2Id20JyfauW1jVm1Z0e5nfyZn3xxZ+VV4AAJ46lScjofpS6rqTm1ihj2
+xCSZEZS53sDnkYBGB7muf1K2VIbWZmkCQ2gjA34IkzyT146cVgnfcrlsXdMeI+ZLcv8AIck7MKdo
+J4GTj8KqreXct3LNZS7bJ3CqJ5QM4HPVsZ/GqNx5WlxOst8JY1zHGIiw83198c1VGrLLMEEHmJ92
+ML8uPpQluxNnU2jzRE3gMKi2UK5hCkKvOThTz16nrzSahK97aG4eG1d4sBcGNWAPIKrlivPoQaqw
+20jWxzBLa5XO93GB75qHTJLl78wxXBYhdoML7Rj6AYpp3eg1e2pqabY2Wp6e9koWC+kIkSR0yST9
+4LyADVSQ6g1zbWdxps8c0gbZEynLAZByD0zg0jQeXrDRRANHENrbD1bj6dPYVea6uyjCWe4bK4Cl
+yNv1NbJolvWzKOn3xgxFLbtC0seR5qcgZx+fFd34FuIzrUCu2QDhdwzg+3pXJx2szWEomuLYJIow
+suWYEHggjp3/ADrpfhyI/wC3o8sMqeW6hvQCneNxHtRHNFKetFUUc/4089vCF+trII5WUAM3TqK+
+fH0HVbiYsbyPJ/u5NfTVzClzZyQyAFWXBBrze+0SK2uZPLHy57DgVMnZCdzzrT9C1K0uopWvMgNy
+pHDD0IzV7U7G5nuoraGP5FXLSEngg/L9c4/WtuWymeXIZiueMf4VVc3TkLHHKRnrnAP6VzTs3cFO
+SOJ1HStYaWNGtonSDIjA688nOaqrfzW7NDLpzLJHjLIvI49uK7O6OqRuD5BC+rpu/pWZM1/IGkh8
+vLcMUg5OPfFVGzIc2ZT+J7LYg+xpI+Pm84Hg+3/6q2NP8TaZLAMO9vKvTa3Bz19/T8qwr20uJIXW
+ePJYYDGMcVkDRJMbhHKGA+8vQfhWipxsNVD0bR9P0C7JmYrLcSNveUkE8noAenFdStv4XP8ArkdC
+OivkZ/WvGo9F1FYTJbyB+5CHDAfSkt9SvYZNjTyErxhm/pTcPM0TPa49E8LXDCQROy5/ikIH6Gut
+8NaZomnzEadYxwuedwGT+ZrxjQvEWouotpWiKZyPlB5/pXsHhQXW4M+CnfFRGVpco2tLnXHrRTSe
+aK2JI0ORiq11ptvdj5xhvWkSbipFk+v50aNBYx38LxbgU2HHqKil8MFzyqEfU10HnfWlE3tWbhFi
+OYbwl8u1VH/fRqhJ4Ic52RjHpvIrtvOprfOc7mH0NSqcRNHB/wDCCXDOP3MeB/ebP9KJvAuoYzbw
+WIbv5mSP0rvFXA+Z3P41N5mBjmtFCIcp4zqfwt8SX7sTParG3OyNyB/KoNM+DOqQXBkn+xMAPlWV
+iwz+Ar20SUpeq5EVdnlWnfC3WYJZTLqVjawyMCYrWNjx9TjFem6dZJp1lHbqdxUYLHqamLZ9aYWw
+c801CKd0Dk2OZuaKgZjminYVz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0031/full/!100,100/0/default.jpg</Url><Caption>29376_0031</Caption><Caption>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Caption><Caption>Exhibit</Caption><Caption>plate 086</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tI/l
+qRYyB8xBP0xT0HFSYqBkW32pNtTYppFKyAjK0u2nYpwFLlQXGbaNvtUmKUCjlQXItg9KaYxVjFIR
+TsO5WMVVmhnyPmiIzz8h/wAa0CKYy0WQGc8XzdKKssvzUUrIZaQcVJUFu2bWN27oCfyqK41O0t1y
+9xGv1bFUQy5UckiRKWdgqjkknFc1d+NbRTttA0yg4abZ8n0H94/TiuM1aW/1yQnUpyI/4LdeFUf1
+NY1K0YlRg2eqxXVtPnybiKTHXY4P8qmBz+FeHJp0Fqyyqzwvk7ZImKsgAyTn/PWtbwj8Qby21Uaf
+rU3n2kq/urgr86Y6BsdR+tTCtzA42PXAKdisGTxRpwCtHcxuTgKAepPrV5NasfJMj3UYUAsSDwBW
+6ZN0aGKTFZ1rr2n3kQkjmKg5wHUqcDvg1ZGoWjdLiP8A76qhkxFNI4oWeF/uyIfoadkEcEGkxlZl
++Y0U9h81FSMqzs40RmWMu/kghAcZOK82nkvZJmAtEjZjzlwWH5V6dMzrp7FEDME4XOK4TUplh3ST
+FI2P3gHBx7VnVk4oFFPcpaZeadYhhJBl/u7pJATkdgg6Vmanq009yyW1oVQ9JHHrznFVbrWLGJ2a
+BJZeDuYLk/rWBe+JriPKWkG0dcvXE1Uk9IjlMsTNeXUixyXARVOMDgE5/Wrj+GJ101Ls3JaYnMSA
+chckZOKNOSDXNKWeEqJ42UXCNlWBPPy+ua00e80hpHgtpZlEexPOmB2/hihXTtIUU2rlDTLDUY59
+pl8wAZww+n9BWvDeymfyBaGeFCrSBGzwDnHp29axJfEup2jBpLDZ6MGyP0FdbaQpcWQmvGjVmT5s
+ADfx1PvTjOa3KjFMlJjkiF1MVjklOBEeuPf86SOYKMK5z6bv8aqJpVtdwSsIh5aAbTjsfSuK1uK5
+s+bWeTy1P3N5IFbRnKT0dhygjvpNfhsiBcTuEJxuU5A+uK67w9qNrdoBDd+aWXcoLZyPb8q8OXbJ
+bxyZbdIuW55JyRivQvhvZ+XqMkykMvl4JB4H0rojJ7Mlx6npDfeopW60VQhqgeQVJ4xivOvEA0qO
+Z90gLf7Kk16Kh+Q/SuQ1mzjjZ3WD5T1AUYqKnNy+6OJ5+/2ZwUSBpIyf4gBVK50yO5dSlq4xxjPA
+/Suha2VJwywsVXnHOD7VYhujJGY3RUx0GcV51WrWhrYahfdmFoKLaPNa26SSSb95CRkgY4x610fl
+3t7Nzay+VxlduCR3rDv5L0ll3ssec4QnDfXFVLNr+znE9k5SXGCz8ce1YKtCUrt6lLTQ1NUltdO1
+WW0umKR7PMDrgkUyK/sWRYreKW6L5YF7jBP4AVCVe4Jl1J0mkPLMTjJ9KqiziedriImObOAVIGK6
+lyW0ZWp2FjrWl2WmmO4haCc5DBdzjH41yd0trfXbrHcxKspOxjkBfrkDFWYYLszKsl7HJGeSsi5/
+WtNbO3iQ7YlYnqQOtDrqDV19w1ExG0y10uwgtt0F/dM3PlZwoyTy3413ngTTxayyyqJFDLjYTkCs
+i2s/OQrHHg9OFrs/D9ibSE7l+bHWuilVdSV0rESVkbDdaKax5oroMyONqJYYZ1xIoYe9V4mJVfcV
+KD7CncRG+lWkg5jH5VTHhnTt5by+TzyAa0t5xilDmolGEt0O7MyTw3ZONpGB6AVXbwlZEkqwH1rb
+3mggEEYA+lcn1LD3vylc8u5gSeELSQffUH1PNKngqwzvyPTgVuooGcjOfWpVO0YAAHtWkcJRWyFz
+MwV8HWaE4YY9CtTx+GLZFCs5YfStjeaN5q1h6S6BzMqwaVa2+No6VbyoGFx+FNLGmM5FbRUYqyQt
+WDNzRUJc5opXHY//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0030/full/!100,100/0/default.jpg</Url><Caption>29376_0030</Caption><Caption>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Caption><Caption>Exhibit</Caption><Caption>plate 088</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOPi
+nKpOcrj096kQcU4cnFYWLIylRTSx26b5GCj3qziuD8eX08d/bWkTEL5RkwO5zisa8vZwci6UOeai
+drEyTRh0IKnvUgWuZ8C3rXmjushJaN9pzXVgCijLngpE1I8knEi2Uu2pMUpFbpEXIdtJtqVyqKSx
+AA7ms86h5UipcIIt7EKSwwfb607IpEzCTnEWfT5qTYSuWXB9KsAhhkEGkIpNBcovFlulFWWUZoqL
+DJWYpC7gZKgnFc/L4tsEnliMhzEvzY/i+n5GujH3D9K8iu9B+0Xd7cLIyEzyrjGcAOQAMf4VUpKK
+1FY6OT4jW0Mrr5DuuAUP+NYHiXXodaktruKIrJbZWQHj5Tj+VcrPofkicsJmlU8bn2/57VktNfW0
+7FNgj+6A4z7ZBrnc41bwL5Z07SPSfCmux6TezK3zQXAyuD/EK7uy8RWV5bNIG2uoBZT2zXz5aauL
+SQW825UY5Abnb7it2O285lkN9Iv8TBj8uPUH6VlSk6PuS26FVf3nvx+Z6RdePYobkrHH5qo4VgnP
+H1rSsPGdneSrC0bJMeNvXmvLbO50+JzEtz5TlSnnLz+orqtIfSopxe/ame6K7Q8hJUKPT0zXTGo2
+9jHl0O2u9QDzIigBM9+pNc14p1wadBvklU8ZVT1Nc1r3iqzsbu5ltLvZcTDBdTkr/u1xY1WW+uFv
+9VlaZEOEDdZW7cVdurLSOxsPFt6jAvKyuQWUE8AelejeHdZbWbISsqhhwcGvGEnmu5Eso8ea/wA0
+xXoB6fhXpHgVWiu5YVKiFY8AA9TnkmqTBnaMOaKe3Wiiwhy8x5bjjmvNPEOvaRZXU8WZ3JYk+Wp2
+lh3616USBCxYZGOa8m8TTW/2t4Yvkd3wIwgJJPPcVlVeiBGMfEOmXdyq2yFH/jzCvP1O6qHiO6tJ
+tJiaKPbcAEYA64PGKlk02WeNrU2zKH5J24zV/TtHFtepLdR/6JBFuJI6MMY/rXHe0k0aqzi0ZFv4
+XR9KivtbmELNgpDnDe2T2+lVdQm0yB42muHaKPhLdT8pA9areOPErTzrbQuWCnp6VzWlhtRnYT7n
+Crnk9PSulXerMdnY6STVZLqLda2cEULcDdzmo31W9MAgacRL0G1e/wBarNH5car5vl9jGDjHpz9K
+v6TZTXW+3ZVkXPGec1qrJXY9Wc9cWjxXHnyPJIQc/MuRSm7nkuUuZmJjjOY0U8Fv6V0WuW/lGaEx
+HYRkEVg2QVbceeu4M5BB747/AFq1JNXDXY7Tws0f2JpmkVrmVuVDDdj6V6H4J0u4h1B7uVmZdpAB
+G3HPpXhBuxBOyeaFaMmvUvhX4yubvWv7EuJBMroWRxyVwOhzzU8rvcLnsB60UrdaKoBrMBCxPTBr
+ybxFDbalqEgWJ2kOAVjY846Ej1r1Z18yBk/vDFeca1bazZGaGx8hdxPKr81ZVdkOJjSy6xcz25uZ
+ksIYEEandvdlHcKOAfc1leJvFqwaabO1JmC/I0jNuOff3qC50PWriQ/a7593XYq8fjTYfBpkkUSE
+sxUBiq4yfU1g5RHY82l3TXDMNzM3Umt+0A0nS7Z4oS9xcShip4yAen+fWuyn0bQtJu0iaNpcKC0h
+Ubc+grMuprOO8WcW05VTnBHA96Upt6BFJbkWv2MI0tbqNBmUjHPfjNY81xqNvbLd6arwNNw44yOa
+6K71nSrq1WO43bQ25VCnrWYdX09P9XBK3++hx/OinUnZKxq4Qu3cyYbrUX5lY+c5O/GeR6ntmnu3
+nzDzCFCfewMACrH2ya9m8u2s53dv4VXH+Nbmn+BdY1QAXCLbQ/ewO59/WulSS3MrNs5G5hhkf7Qj
+bjI2SvcV6d8GtOg/tqe7V8TRxEFR3Bqza/C21EQ3yyF8de35V6N4X8O2Wg2Oy3hAkb70hHLU4Svo
+ElY3GPNFMY/NRVEjI24qGayt5yWZAHP8VMilyAfWplcelLRrUCgPDlkPur+fNSrodsqEKME96uiT
+ilElQ4w7BdmPJ4R0yWUSSRbmHTNRXPg7R7lDHIo54Izit7zKXzMjkVPJDsF2crB8PfDtudwgQv8A
+3mOf61aHgbRSgxbxlfpmugDhegxTvMq1CHYLsx7fwpplr/qreJP91AK0E0y3QAAEY9OKseZSeZVq
+MV0C7FWKKPAAAp24Y4xUZkphkqroQM3zUVCz80VFyrH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0026/full/!100,100/0/default.jpg</Url><Caption>29376_0026</Caption><Caption>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Caption><Caption>Exhibit</Caption><Caption>plate 089</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xI+K
+f5dSKtLtbPbFY2RRFso2VMQFGSarPeQocbs/SlZAO2U7ZVY6jAKj/ti3Bwf50Kwrl/ZRs9qqrqkD
+VML6Bv4qqyC4/Z7U0x+1L9qg/wCei5+tSKyv90g07IZXMdRtH7VZaIkk72HsMUMvFFkBmtEN3Sir
+TKM0VPKh3LiiiWVYU3N0pyisDxBqHkOIh6c0xC3uqbshTxWHqF5dpaNJaRJLJnAV3K5/HBqg18ZZ
+VUsEDMFBbpzxV/7NPG63D2rSiLIVlO4N9RUslsw21vVftiQPpOyPhpJjcAKq5wcccn24rUWRHOUb
+KnkHsa5vxhapqFsSYGjlXkfJjPtXI6L4mvdNVrCd12r/AKrfjKn0p2vsiU9T1kXSRIGkkCgetUbj
+xCFbbEcD1NcTLrUki7pJMtVCO/e7u1hEyBmP8TAU9ldlpX2PQodVDtnzfmPvWxaa0YmXL5rgUtDG
+VCSSM7AkEj5Tip4b5lbaxww6j0pU6sKnwluDjuev2OoRXqfIcMOoq0wrzvQNUMd4nzHmvReqg1bQ
+isw5op7DmipAnWuB8a3q2d8xYPyvGBmu+XpXD+N7P7RMjY6LgZpSdlcErs88bW4nl2+TJI2cqhXg
+kcjuO4rc0ab7Tfwag1/OuoLbKklk42o2M4ZQevJJyCetYcuntBcJMiZKNnA71Z1fSLbWoIZLTUBZ
+3SDOfuMPriiE1LRkVItO5i63pUtpDdfabu6lSeQyCN5MlSTnr9a5rRdB1LVtXVrO0knfPLHoB7sa
+6Wz0rWrjXrbS9XvVubV2ws0bBjgDOD06161bxJZiGz0+CKHCZJxhUUdz61c58uhlCN3c82HgDXBC
+0krW8aquSGkzx+Ao0DTI3FxazQJ5sU4LsU5HGQM+tdbf+MbzS9SVY9Pae0RwJZHQq7gjJZRwAMHv
+1pkU0TxzXwBAnYy4PU55A/LFeVmOKdKmlHdux6GGpc0tSmZraLUlglYDfhQCMDI4x+R/Suc1+9tY
+NTRYZczKMS4HGe34461pakEvLkOcAdfSq2paAl9ptxdLEUMSeYJNp59ifengI9eyNMSkvmN0TVle
++hXeclh0Fe8J/ql+grwPwhot1eXybEG2Nxliele+qMRqPQV6XNc5JKxERzRSt1ooEPU8VheIIlmU
+bhnFbSnisPXtUsbDAu5fLz0yhOfyFRUfujjucnLZLn7g+prMu9Hiuv3ZBGc8p1rZfxJoRY5vUUe8
+bf4VBJ4i0ADMWpRCTsWRsD9K4JN9DcwtO0yOSIYh2TwtsY45DDv/ACP411NnqFxb7BPHvKjG9RyR
+7isG21TSo57mdtdh3SvvCJCwGcAYJI5HHtWmviPQ3QZvYxnsQeP0pKpJMTimax1PRZYRDfQNtwVC
+zxEgD0B54/Gq11q3huOM7xCqDjIUgCoBrmi7eL6Ij0IP+FU7698M6ggW4vYht6YB/wAK154y+KKf
+yJUWtmKmqeFeZ4bV7s54WNSVz75NM1S51PxDALaGFbWz7ooxnHr/AICltp/DMVys66iruAAMk445
+5AHNbEer6O3KXkWT14P+FaqdlaKsVbqw8JaIumEAElicsTxXd9q5zTdQsZZlWKdWY9gDXQ54ralq
+jOpuNbrRTSeaKsgYj1W1DS7HVECXtusoHTJIx+VKjmpgxpaMDDfwN4cl+/p35TP/AI0wfD3wuOmn
+H/v/ACf/ABVdBuOKXcaTjHsF2c9/wr/wz2sXH0nk/wDiqY/gDw4nIspse1zJ/jXR7jTtxpckewXZ
+zi+BdAY8WtwB/wBfcn+NTf8ACB+H8Y8i4/8AAmT/ABre3GnBjiq5I9gu+5z48BeH16QT/wDgTJ/j
+Th4J0ND8sEw/7eZP8a3txo3Gnyx7BzMzrPQNOsJRJBFIGHQtM7fzNaRPFMLUwsaaSWwtWDNzRUJJ
+zRSuM//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0029/full/!100,100/0/default.jpg</Url><Caption>29376_0029</Caption><Caption>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Caption><Caption>Exhibit</Caption><Caption>plate 090</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FUwK
+cFBGR+oqTFGKiwyIikINS4qnPqNtA2zfvf8AupyaNEImwaUCq8dzJLyIgo9zzVtOeoxQmgAClxTs
+UuKdguM200pU2KCKdhlSQKgy3A+lM2K4JHPbpVwimlaVgKBgGen6UVc20VHKhk/UZHSiorIlrC3Y
+9TEpP5CpjVkmNqmoET/Y4mw2MuR29qbBaxxrv4yRyayplaPWLl3yWZz27VsQHzbdh3xxWb1Yx8cp
+z6irqSArk8YrEtZ9yjnp2q4spdwg/wD10kxM00ffyOlSCqMkhj2qOPWrcLCRAwOa0TAkxQaWg1YD
+KQin4pMUmMixRT8UUgI7H/kH2+evlLn8hVT+2bFpmiFzGsinBVzip3do9JLqPmEOQPwr591fX9Tt
+dQlLQ7RvPzMuR+dAmezaiyy30ckbqd4wSpz0q3C/2eGSR+NoJ+tcR4B1OfV9MaSZVBjlIBXvxXb3
+wIgjjDIGfJAc43EdBWbGULWxcoJPN2bhllx0ras7YIvmHlj0zXP+HYdSRbiPU1AleXhkk3KV9vSt
+bUdQSy2w78TSAiJfUjqfwyKlWEV9VvUhkWHeTJJxhf4fc1Lp+oiBPKm+V1OMGuc8SXkXh7RH1CR8
+zuQsZxnLH/8AVXOeFfH73mpiLU3ifI+SYgKVPoa0SvqF7Ox66lyWAIQ84x9DU+7jmucuNWuLbTbq
+eO33CCFnRt3J4PGPwFeaj4qeIFkOEtXUHoUxn9a0iribseyz3KxdfUZPpU4IYAjoa8XX4p6ncFhJ
+pdsT/vNzXdeCvEl3r4nE9vHFHEBjaSSSaclZAnqdbRS0VBREyAWZQn+DGfwrxvX7CMXUqpMZQSSy
+Ov8AKvZSoeMoehGDXFat4UR53n5Knkisql7XRUbdTkfDesjw9atCtqJIXff8pwRW5P8AECG4QxNp
+bSDBA34xWVcaOTcMsaSFB/s4FV30icv8sTH6DpWTqMfKdT4Z1uzWwCPNHbyLIxKPwOTnj2o8QBbm
+8g1KC+hMkAKKhGRz178ViR6PE0KC4Z1kz93AJNTpo1qiEswVh1LVCrdxOJmXXi65kh8iazt5ozxh
+gT/PIrgb6e0ttRZYYtk0kgAhj6Lk11PiOykV47eylQux3SbOSo7Vl2XhyaTWxOYi5QBz9ela05Nt
+Ckkk2X4PE2r22ly6eJC0TDZuIGdv93nPFc87mEkNEGYn+Fea6yTSnkk2eU4B/ucEVUfRWj3v5RyD
+1I5rsTRzKTe5iwh2AJUo3TBHNet/C5CLC8Zgc7wM4xXD2ug3U54gkBPIC5/UV6r4Q02XTNMZJU2s
+7Z+tEnoXC9zoqKTNFZGpEGp27IwRmq6MSKkBp7gONvA/3oUP/ARTRZ2oziCMZ9FpwNLmpaQERsLQ
+tu8hN3rjmqs+jadPky2mfoetX80A0uVAZg8O6Rs2rp6gD04NTW2g6dbMzxwYZ8ZJOav5pwNUopCK
+x0uyP/Lun1xzS/2bZd7aI/Vc1YzSE1QWQxYYUOUhUH2UU8mkJphNAxS1FQuxDdaKVwP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0013/full/!100,100/0/default.jpg</Url><Caption>29376_0013</Caption><Caption>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Caption><Caption>Exhibit</Caption><Caption>plate 091</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7Lg
+cAZpRbnaNwAPfFQ65eyWFj5kRUMTjJ7Vwt34n1aFDNDdLIQPuADB/Cs7A3Y9B8gUnkiua8J+NYNb
+BtbzbBfJxtPAf6e9deMGlyiuVTCKBF7Va21ynjTxBLpdkbKxfbf3ETMrgZ8tBwW+vPFFkhasXUfF
+2haZrMGkXFyWvZnCeXFGX2E9N2Oma6EW4z0rD8KeErfRLNZZx59/J+8llk+Ztx6nJ5J966jaKtDK
+n2cY6Un2Zf7o/KrmKMU7DuZ72nHyKufeo/sQOdyJ+ArUxSFalxRVzIOmQk58pP8AvkUVq7aKnlQX
+MvxLbfadMIzjB656V5+2leYjLuXrweleka8dujXD+Xv2rnbnFeVLrtjI8kZEkMwBIWQkZ/GlUlYl
+xuUrnRJbecziNgVORIr81uaXrN05EMoaYg7SyuQwrmrbW7x7t45vLaEnIJbbtFbVsjXM3mQRtHJ0
+OTzXPKpoTy9jubfVLu3tfmYMijhpOTj3NcjrYudQuJ9SvI0h3KqQiQjcAAcBV/3iDzTU1H7ZDDZO
+J2aWTZF5R2+YRklg3YDHJ9x3Nc946vY9L3fZoIRcx7GkmZiXZ+Rxnk42oc1UG2rtmijbQ9RHjW03
+7Fs7k47/AC/41oWviWyuXCsk0Oe8ijH6GvlxFlkt2mmuXe8zuZy5yuf5V6B4I1zUrTUrfSNXcyw3
+S7rWZzkg9dpPfocVvGdyXCSVz3SK+tZ/9XPG3tuqcsoGSQK5J4lUAgL071jXs0kbnyzMcf3Gxir5
+xI9G3qejD86AQehBry+31bW4XzG8hQHpNgj/ABrr/D2p3mozMZlREVeQvc0XuM6DFFOooGVtRjEm
+nTIQTle1eC+LNOeO/R4SMEdD1BzX0DLzCwPcV51q2lW7XjSKEJHqucVlVdtS4HmcenXV5AHhWdST
+iRBwPfBrodKR45fIu7uUExlCgKAhcfxHt+ea2JoPKtpQm8Aqc+WuW6dh61yFv4W1C8l3TGaOMOzR
+xhvujPBb1OO5rkt1bL0vY3f7MvLeCVrW7Mq/MFjDY2L3Axg//rqne6emtW7XE8U0ihcordQTjk+u
+BnjityE3dtZG2uRJK4wIj57RKuMDkpye5Oc1RvIRFplxcl5lVVDLMZiu5u20BgeOvzZyKuHvJWZL
+dmzi7Sxmg0eY3UcS+Y2IGAwZB9KuXVlcQ+GtN1DIJs3VsBsnaG5OKrRwP/ZsWtmJpJbR90iPnBQ5
+4A6DnHT1rX8JX1zqum3mksI7fT7qQsHlOSi5y2OlaxQ2zV1HV9Lt8C3LtIygx7H4Y/hVWx8RzG/j
+juIY5LUnDsI8kf41yGt2T6JdKbaV5LSUZhmGQHA4yK2NF0yQQxXDyEs4D7AMe9NRstyOXsdofEnh
+pZfLlVkIOObc/nXo+hQ2qWiy2mwxyKGDIBgivEbzSrvUbiKO2s5C4J3MSBnNenfDvTdX02ymjv5I
+TbjiJEbcVx1yauFwasdrRRRWhJHK22FjjOB0ri7iCR7qRyMgn7ortTypFYl5b+W5OBzzkCsqquio
+vUwxAkCgso54AFK+cZZUjjx3pk95FHISgMrj8hSLdJdQYMsQlY4AzmuKSNSnKIrm3kGSqOCNxGCB
++NecauBp+orYSmdIS+5EbJSVcADDdsY6H869AvbS6BMhBKj+L/61Yt5ZxajH9nuYRJESDjJBBHQi
+iE3F7EuNypBpjalpc0cEg8qSNkK9Mn/HIq9onhb7DZwxSkMVQBsdCe9auk6bb2dsUiDhSxYgZJya
+30ULEAqqR7mrU+w7HM6xpVtrFg9ncxH92AI2UcjtxWNpaXeizW+nXaxvvB+zygZ3BccH0OCK7CRP
+KmZiu8E/wgDFLFYxXE6v5fI6HHIzWqlfRjsJZSkuCsYD+uK7TSYkiswEQLkknHqaw7XTHRgVjbHu
+K6W3Xy4gMYNbU0ZyZLRTc0VoQRhqDsYYZcj3FQRMSgPtUoNIBsllbSptaFcewxVOTw7pUzKZLRWK
+nIySa0N1LmoaT3QylDpOn2rOI7b7/J6kf/Wpp0jTRljagZ5JxV/dS5zS5Y9halNNPsQDtgOPanCz
+s/LK/Zm2kYI2mrYOBwKXNUox7BdlVNKsVUBbdQPfrU8drbxDCRIPwp+6k3VaSHccSB0FNLZpC1NL
+UCFLUVWkkIbFFK4z/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0023/full/!100,100/0/default.jpg</Url><Caption>29376_0023</Caption><Caption>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Caption><Caption>Exhibit</Caption><Caption>plate 092</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJSj
+5h0I+oqULSlagZCVNJg0XdxBZWsl1cyrFDEpZ3boAK5K2+IdpqE7rpmkapewJ964ig+T8yaTaQjr
+MGlwajsby31G1W4tn3I3qMFT3BHY1Q1vxPovh6POo30cb4yIgdzt9FHNO8bXCzvY1MGjbXn3/C4t
+D8/Z9h1Dy/7/AJY/lnNdZofirRPES/8AEtvo5JAMtC3yyD/gJ5pRnGWzKcJLdGrtpCtT7aTbVkld
+lCqSTgDvUOUc7VZSfQGrpFMKD0pWGUjFzRVvaKKVkBZFISB1OKUVx3ibxfZ6TcG2a9WN84YKcsB6
+ADvQ2ktQOqmaF4ysoR4mGCDz+lME1vbxKEj2x9PkXAFeVP40tPPZolnmBHJ2Y2ntg9c1VPi3WJ2J
+tLG6B3AqTJj6jHvXNLERW4WZ3muGXSpvO024EH247XGzIDD+Ieh7Vy+q+FNMtoFvnaWW6dwZZZpC
+xf1rD1vxTqcVhby3dssMgmxEpfPbv0rDu/FOt6iAVj84pkbViJjHbrkZrkm3UlpsbwfLG56zYaVo
+scITybfJHtk1z3iHw1b2M8eqaQ32e8hO9HQ9D6e4rmdK8Xa+k0cL6XbGJhtYD5c1uaXr7azDcbgv
+koDjJ549apxjGN09hwm5M9E8L+IofEWlLOoCXEeEni/uN/ge1bTEKCWIAHUmvALnxRd+FNU+3aaq
+SFomSSJgdr4PHTv/AI102h/E+LxASJIVgmUZ8hicn3HrXdSq81PmZnUhyysj1XzYz0YU4YI4rjl8
+RAqCz+XkfxrkD8q6HRp/tNoXEqSDONy1opKWxFrF0iikkfa2PaigCfoK8A8V6npUuv3UiuwbzWBA
+jJJ56175M4jgkc9FUk1816vcWR1Gd1kAkLt8yg8g561jXeiQ4pdS1Z6vpyuv+kRALzgqcn9K6W28
+X+H3tQ0l0qSA4CyKR0rzvfZpG+wkkkZbb+lS6dbWE10guAzQkNklTtBI4ye1eZUows22zS66Hcpr
+Vh4juJbITxNbpjeMcH8f8KsGPSoB5SyKyRAARh8D24rziPTIpL64S11COCNGGG3E7h1xx6VEbFjd
+bW1DzQW+8CazWHV7KegXv0PVUt4UiztWM9gOa5PwjaST3+tWkFzh1nysZ4Z1GQcVTsA9upaDU9rD
+AEbNnP0z0qYaKs9000zmMMd5kt+JN3PfPetaKUeaDe5S0d0V/ENktk9wZJt0qnBXOdg64+tYfh6R
+P7bjumJWK3JbI4LH0qeTR72PcR867iSrPktn1qnhrW6EMkYQkBiMEZ4GOlehTso8qZFSTvdnqKav
+bTxZfJcjJ74Neg+CZEl0iQohUeZ1xjPArwiPEDjBMLAEbCxwx9fWvYPhXNcS6Dd+fJvAn+T2G0cU
+6UeVkN3Ozn++OO1FSSAFufSitxC3C+Zayp/eQj9K+Zdbs3tdQmVsArIQCeD1r6czkYrynx54JuXd
+7qwiaVHJJUckE+1ZVk7XQjyULGG+c9f7pqRWWOVdhZSRgEirTaXdabJ5VzbSpz1KHFDQMWPkpvAH
+WvLqVPe5WOxClvaTOytkSEfKx4w30ot4sH7RkAR/Lz1Y46U8Wq8k/vDnBXOcVbit47Z0Vk2jOeTk
+DNZudhWLNlpwEMtxtDS7WOAM7RgnIHetS10g24SSW/MqtuIMqlMptyCo65zn2qjazOt04t5GV9oC
+umcCkvtT1e0IjMzSE/xcAL9OM1vSqXVmXFpIk1VXgFvMG2GXrEByf8KxFme5uQ0igso6kY6Hj8qt
+vdm18y8aQTTyfLGp5Cj1zVaCCW4fcF3McnCrnJ966Kc0xSbbJNkQcv5aBm6ncWIHtXtHwvjCeHJS
+oIVpieR14FeX6LoOpatOFh06QDoXxtA+te3eGdJbRdDitHChwSzbemTXRT5m9RGq65NFKTRW4hgN
+O3e1QqaeDQAS21vcLtmgikHo6Aj9ar/2RpmAP7PtcDkDyV4/SrOTijJpOKe6AovoOkOctploT1/1
+K/4VFJ4d0WQKJNGs3A6ZiU4/StPNGaSpw7Bcz4tC0iEfudItE+kSj+lOPh/R593naTZkng5iU5/S
+tDNLmj2cewXZkf8ACI+HvlH9j2mFOQPLGAfpV6LSdOt8eTY20eOPliA/pVrNJmmoxWyC4iosYwka
+qPbilJ4pCaaTxVABbBoqGRiGopAf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0027/full/!100,100/0/default.jpg</Url><Caption>29376_0027</Caption><Caption>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Caption><Caption>Exhibit</Caption><Caption>plate 093</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3ERYH
+AGaeE4GQM96exCLk1CbqL++v51Fh3HlaTFQG6jzjzAaq3GoKqkAdP4ial2RNzRxRiueXW2t5Mk+Z
+H3Gen0qdfE1oTgowPpTViedG3Risk67G2PLhdqtQ6h5nJjA/GqHzFzFBWoxdQ45OKlV1cZU5FOxV
+yGRXA+RQx9zimhHIO5QPoc1axSEUrDKRhyaKtbaKVgC8LC2JTg1y9xfLbN++uY1574rpNWQvpc4B
+wducg4ryS+sYyzfNL5jMOWOcCpnPlRLOpPiS3GcShz/CAvX3qlPrwZsvA/J78j+dcfFbmKd4WcsU
+IKYPVT7/AKVsf6SdOdYEVrjG1Pr7Vzub7itc3VvUuEAEkak9FK4z+dQyE7/mjXcOR1FcxHqt3Nbm
+G8hVSpKM6nJ4AySP8Pyq7bSzwwFEcyLgkZOcfSlCoKULPU6myvxED56ABR6j/JrROr2YjO0sHHVc
+ciuBku1Kb3MkRToACetWrLUbRVA3SSZH3tpNdMZ3Fotjon1a+SfzFVWhJ4U9R+NXIvEAUjejIfY1
+hNqUbxbIztX1INPF1bMgDMjevFXzFI6qHVd5z5uR6Hg1tW0yzx7gc1wkM9krDbNt9ua7DRJoprVv
+LOcHBOKOZMpF/FFOxRQMqaxJ5WjXcnXbETXj1hrf2q8uRNEoWIDbnnmvZr9Fl064R/utGQfyr57Y
+R2mszB2ZYgxBUZw1YVtNRN2H65qb3N1FPp8e1lJygTkD3ptjrGs32pwxWiDyom3SMRgN7ZpYlg8u
+e5huAs5bCx4ySOcdfpXQ6YmnWHh2B4kVbgYkaUHHI9T6VxzlZbbmlKN/eZk6tBqtvLcXE0Uce4gj
+y1DhBzk5x1zisZNYuYEMlzcnyyec4XNW7zXby/vpIxFPKM7fvgrj+VSjTdNuLZ7q9LszIFihVuVO
+P15qYy+y9hOPPIsweJEv4c2zjapCu8ibQCenJrZ0++SZv3kcDOh2nb1B9Mis7S9LaztkkWFQk0Si
+SFxn5lHX696n0+5sLTYNQm8qUMTGuwZI9Scf4VUVGPwlOCSNzFu6szQkfSQ1LFb2bpt8uVT7tUVr
+cW9y7GKRMdhnrWlbusQZoQpcAMck4INaKfZkJElrpcRTeqygDuTXYaTFHHa4j6Z71hadqklzIIpI
+gnr3rp7cARcAAe1dFJ36lSSQ/FFLRW5BDdrvs5lAzlCMV41eaOlvdSEWzySEnvXtDZKEDqRXKS6L
+qEtyzABVJ68VzYiLdrK5UbdTzq30qad/khSJRweeas31m8FoYZYmkiIxjaAuPQ8Zrsr6wewDtiSS
+QLwAvGa55U1LUJo4WVVJfIQMM4rzasXsjReRycVqQ4jiQpEOgA/w5qci6jjV542jRWwm/nP0716H
+eWFzY6cREs3mMP8AllHls/U9K5AaJf3eqJcXBkc54inAJH48Cs/ZSTsLl7GTZxXMc5FvJ5WecjIz
+9c1WvLcXE+94ITIOCUcLn8q6G4iNvOVurh5ZA+0pwAP0FPuY7SJ4ZYrONpdrMcITyBxk9OtVTnLm
+sS9DEtLR0UfJJGD+Nbljd3mnHakkhHXGwkYrS0aC9v7bfLbHYeceQVJ/H/61aE3h2RIPtNslzFIO
+qIM/pXYo3V7FKxX03xVYXNwkU7eTJnGQOp989K9GtiDApHpXJaLo0d63mX2nRAjjzNuCa66KJIIh
+HGMKOgrrop2uRKw/NFNorYkjR8qD6jNODH0H51UtHLWkJPUxqf0qwDRcCTg9QDTRFErbhGgPqFFJ
+mlpaAOOD1AqJkUfMYIz7/wCRT80UaAVzZW0hLtZW5Y92A5/Snx6bYqdwsrdWPXCD/Cps04Gjlj2E
+OWOONdqIqgdgMUvFNzSZ5qhiknsBSZPekJppNAC5oqPNFK4H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0024/full/!100,100/0/default.jpg</Url><Caption>29376_0024</Caption><Caption>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Caption><Caption>Exhibit</Caption><Caption>plate 094</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7NH
+/wA81/75pREikAIBn0WrQFLtqbAV/K9h+VHl1OVpCKVgINlKFqTFG2mkIZtpdtSbaAMGmBFsoKVN
+ikxTAqFgCRh8j/YNDR8Va200rSGUmgBPSirRWikIsgUuKBS0wEppFPpDSAYfWlApcVBcXH2W0lm8
+tnKLkIgyW9AKVxEV5qlhpzIt5eQQM5wiyOAW+g71m3mttLdiz06PzLjvkgBfc/5/CvN9ai1LUdeF
+1qNuiTySKI4VblcAbV56dyfTnpxXbWk1npGjOscge5cbpXT+JumB7DoK5/bN3vojVwjG3VnQWk7x
+WRkuJxMyjLFVAAPpV/GRmuWtLxFWKFmDM7CQqGGDjn8ADXRxSCQBjJn2HSt6c1JaENE2KaRUmKaR
+WjEVpZVjbB9M0Vi67O8V6iq2B5YP6mipA6YVT1DU7XTIw9y+0HpxmrYrnPE9tBctGJi3yqelEpWV
+xlxfEli6hk3sp5yBQ3iOy3YAc888frXKxhEAVHYKBjhR/jWRNd3LSlmuBCmcKioN+B7iuOri1AuN
+Ns7u68T6fEvLMfYp1rmPEniWxit4bmzujD5WXURfLvY8Yx0P+fSsW61DSbZ080y3ErYxGZCxP4Z4
+rD8RXmm3sAa0hZHh+cRuOBj+X61zyxMpFqi1qXobueW4e+vJjnBAVedoPP457mntqjxYWW1m8ksC
+sgx0J4OM5q9oU+kX2nRtDNErMBuBb5lPpg1rnRtMMDeYxkU8EvJxj0rPWT1LjGKWurMG31ARyCYu
+Nx4GGHAHb2rorX4i6VahInWU/wB5gO/sKypNDtYUJgIWM8gAcVy+p2scd4ZGjBUcMemfTFdNF8vw
+kSjc9V0/x5oeoXcVtHcuJpThQyEDPpXTHpXjXhgWqa7akWByJB1GMH16V7MelddKpzozlHlZz2tx
+b71DjP7sfzNFbE0Ecr7mXJxiirsSWRWdrN1aWdv5t0+xfpmr4NVNTsVv7UxkA/UU5XtoCtfU4uXX
+tNm3rbNz03FgMfhXOSWdtNM8s2pKCxO1VcV1cvhKDcS9puJqKPwbBn5YSnv1rzqsJzd5HRFxirI5
+SbS4Li3DT30AIA2tuBbHbpXOXOmhCRDKswB7OwOPpmvWD4VslTDQkn1xWdc+DrSQ7lzGT6c1kqMo
+sHUurHl1hZwvdGMReVL164NdDPYST6eiXN267T93zufrXVJ4DglKyM7bh3KircfgtY5AQpYdzjmr
+9nJ9AU0jkC17HZ+XaXalQMAshYj8TVGPw7f6o/8ApN+5Udo1xXqI8OoEwFfNWLTQ2gbIDYPpW0KM
+gc0YfhbQltp4mZWkaM/fdjmvQT0qna2SwfNzu+tWz0rrp01BWSMJycnqRnrRQetFUIjSTcoYdCM1
+IGqjYOWsLZj1MSn9BVsGmBMGPcUZqLdS54pWAfkE1GzbRny84oBpc0WENWYt92In8amViRkjB9KZ
+mjNMCXNITUeaTfzTAkLH0/WmlqjL89KYZPakMeTzRUBmwen60Urgf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0040/full/!100,100/0/default.jpg</Url><Caption>29376_0040</Caption><Caption>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Caption><Caption>Exhibit</Caption><Caption>plate 095</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3DYwx
+tXPrzT9lSgUuKkZDsNBU1LijFS0IhK470balIB6gUYpWFc5bxnqPiHTNKibw3pQ1C9llCbW+7GuD
+8xGR9OtcPN8QvG/hra/ijwxGLY9ZrY8D8QzD+Vew7aZNHE0LCZUaPHzBxkY96fKUnY4Cw+LnhS9i
+DS3Utq+OVliJx+IzV6L4k+EppRGmrx5Jx80bgfqKwde0jwK8kkh0KIvuwDbv5QY/ReK5K/0bwjcQ
+zJa6dcwPgiOaGcsAffPBrH2qva6NEont9rc219CJrWeOaM9GQ5FKUlz/AKoY/wB6vA/AeuXvh3xQ
+tjLKzQM+xlzwQe+K+h1KsMggj2rSEuZBOPKUjb5NFXSoop2IJSdozgn6VUnu5V+4qgf7VSX15BZQ
+b55RGCcAmsNdTs9SlaO3vI2ZRnAP+NaqxEmR3mqX8Eu+KUN/sY4q3Z6/LIuLq0MTf3s8Gsy8vLbT
+mPnXKBgMncR/KqL+JLGZvluYemPmJH9KtpPoZXaOyj1K3kH3sVMLmA8+an/fVeZf8JLo8m4f2nFu
+T7/BH5cc1BdeMtEs4ldbrzc/wqrEn88VnLlXUFKfY9VN1bqMmZP++q5PxZ4mSxiMUc8aKw+ZmIwR
+3rzu98YavrH+j6RaG2hP/LZxlse3YVlv4bJKz6hPJPK3VnfOK5qtWNrJnVTpTestCC41G0u5W33q
+eWhJVXOCTU8F7F5DszRrEBkMPX1NWtP8N2V3cNGUGwA5OKxtf0GPTnDwDIB7iuVcuxv7HzJ/D1r/
+AGl4lN+4228R8wswx8q967Dwd4muZNfWE3E3kTSsSu3cCT/KuUvL1v7Ji06wQRiRFaZweXbGcfQV
+b8GWU0XiK0DSBZFkUkbgDg11QpytzGVSSvyroe/Yop2KK3MznfG0U0mh5gVDIrggt2FeTRymJ2Aj
+Y3GclyQcH6V6z401COw0cGQA72wM15lbXtpc3OI9obqc9zRKbSsibIx703HmS+ZIZHUFmJ+ao302
+P/Rjvlubi4OBFFgfqaXzZrK4ulviGjuM+UYSdx55wuM+2falshcR6nZXMVuy25YyggdAMjFc9SpL
+qbwpxTLN/wCGLa2tA80Xlynqu/d+tU49FtVvI8rlcitnVdVhvm8lc+Y3HTpXPyXk9nI3m8rGRz6j
+OOPeuROTdjZ2PQ7eyjjtkEaKox+Vc7rU5EvkI2T6g1PZXt7eIimVbaHH+tmYKMfU1KieH7Njcalr
+NlnqF80Mx/AE0QpyuDmkP8OuYLWXzR+9OPmPpz/hWd4rObfIGas6l4htzHE2nWbHT2T5rkjBx1BA
+9AetYmoai9xCAVWSFhlJFOVb6EVTi07lxdzmdT1L7KY4Od6xqfpnnH5YrQ8L6j9q8WaUqfITOqkn
+kYzWH4ghZZmvkUtC4AcY/wBWQMYPtxwa2vhxdaa2t28UlnLcag9yi2/zYRF7k9yRXpw1gmjhndTd
+z6fHSigdKKkDzH4z6mdP0Sz/ANGaRHkbLg4C8cV4b/aM01w0duGZSCDhvvHH8q+l/G1tHc6XH5wJ
+iVssAMk15Dfrb6dDJcRWqqVU7UA5J65PtVcyXTUnlucrb3c9j5pgIFyQCfw/h56Ctaz+IDaQhtW0
++OZJPnw0vCn2OM1wk99d3ckqxElnfJb1NXbLQNQnKNMsjLuyT0OKznCmtZ7le0ltE7/R9ck8SXr3
+NzawW0FtyCg5P+8e/WuS8UeIJdUv/Ksi6W0TYDjjd710o04Jo7afp8UkRlP7xjzx/jVNPCkNrGjT
+uPbLck/yrijKKm5Jehc23FRTOJd5pn+dJZiO7MTWrp+jXF1E0hjliAbAxHnj1/WvUdAs9Ps0BuYl
+O0cFwMf/AF66G51fRIIA2EPH4Guj6xJqy0M1BXuzzeK6httDWyjS8kkWJoyrRZ3E55GOnWs7QdO1
+qzkVsC2hYYKShdrfUHqa9DTU7GYk20Ict3UDj8ayr+C5uJFkeLZsztKvk4znB68VKm1dW3NN2vIw
+9e1W0t7WaOK3QSH5QQODxg/hnmqnw1tg3jTTmKnPnA56YpbjSybkySRNK7NnOM4/oK9A+HXhc/2m
+moP8qxHIX3xW9KKhG3cVSTlK56/RSZoqiCje2kN/atbzZ2N1wcVyd54EDk/Z2gcc7RMDxkYPr2Jr
+sVNPFNrqNOx5zB8JbG2JaAxK56tt/lWhH8PEiX5Zo93qVruAadmocU3cLnIr4Eh2jN0Q3fC9arXP
+w9guWXfehNp6hckfT0rt80YDDkCs3Ti3qF7HDyfDm0kj2nUWx2OP/r1WX4TWbTb5tRldQPlXZ/Pm
+vQQiqMBRTs8U40oLZBdnIw+Aba3i8uO6YD2QClHgK1yS97MxPsBXW5ozWihFbILs5iHwRpkTAyO8
+g9GOAa37a1t7OLyrdFRR2FTk0wnimAuaKjzRQB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0001/full/!100,100/0/default.jpg</Url><Caption>29376_0001</Caption><Caption>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Caption><Caption>Exhibit</Caption><Caption>plate 096</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Hyyo
+yAT7U8JxUoAA5qpc6pYWkLTT3kEcanBYuODUWAm20bajjvrOaHzo7qF4v76uCKes0b4KyKQehBzm
+pshXArxSbTVPVZHtxb3A3COOZRKQeNh4OfoSD+FLqOtadpRQXlysbN0HU49fpS0W4Et1cR2cDTzO
+qRrjLMcYqFtSs0sxdtcp5B6PnrXHeK75Yopmn1OKSzl5CD526dh0H4157qXiWd3ighaQWSY+Xpgd
+PpUe0fNZILnvkTJPEskbBkYZBHeq81/ZQTiCW7hSVuiM4BNc34d161vPDssNvcqsoj2R7perY7el
+cDeWv2a8kvNRczXO7g7j2NU6iSQ0e0MBg4+YjsOtRgbzjY4+oryPwzr99D4kXdPK0TsA4kc4b0r1
+21v4byRkiydvU1aaY7jTb5PeirhUUUrDEvtws5Cpwcda8R8SRs1/MFEnlnO8uMDPbFe0a1OLXRrq
+c9ETNfPupeKVF1KsrkoRkEpgf41NSLbuhI2tGmS00/bPPIzyqdqqeAB61oaJ4viaaKxtIpmEBJO4
+devv71xOlahNfXRuUIVGUh1Y8cdMCk0nUJrLVmm+ykRsecHkc1i5WuJxPcYtettWs/s0v7tJo2jK
+uQG3du9c/ruoaXqGjwtfKjXka+XJyeq8Hp78/jXIpqsrREiNFJJPXmqzagsd0kt7Duifg7SWKsOh
+x3B/oKlVefRicWR6tfx3Fklss+xQAoIOT9BWBcwXEEXnwl5EjI3cZ3duKt6hJCbr7RARLhshSCNo
+/HvUL6jMqu0duA5xyzDmmk1sCT6jbEXen3CzI37tnVihHIPXHv6Vq69qxnDY3MzE/KhwB+dc42rX
+AkifaUkjOd2QR9MVZlv/ALZLE8sRA43FVwD16fpWqi7pspLoa3hieZtQy20RvgMCwJr2jwujedIc
+ttA46YNeHWd5b2WoLcWNrLJKB0kPy5+leufDq71K98+S8VEjAwFVe9aq1x2sju8UU6imBn+IRnw/
+eDsYzmvlvX4pZrtgijYDgEHJNfTXjBgvha9ySAUH8xXz1HZteantUjYDudicACs5y5WOKvoHhiy1
+HT5Bei1eSIfIUI4IOOKNZ0m5iWe+VbmzUMGNvIWAweRgk+xrutPuYoReWeFeBSrqSOvyHOD9VFcq
+3iF9eguxfD7VHaAiJXJwCSOeOvOMZOeTXMpuTbZrKKSsc9Bf6jNcSLERGqEgkDOB+NaMJt5jiW6u
+JZT28w/0qlcpdwXKabIsUfnfMgjHy9SP6GussH02PREgl8u3v7fl3dcFgR2+tS0riVkc29sBdsDL
+OkUf+sR5d2Bj61qxroF5D5UV+lvcr08wHBNS38SRW7BJBMynez4++T7/AJVzVxo8ImtLm9WSOCRO
+Z0BKhsnqR0rVRT6gpeRZ1rRL2zC3G4NH/E8Yyg9CKxib1EEhLNGTwytkfpWrq8+peHdSjsra8kls
+5lDRlgGBFOWO+t7Z76VIp7ZhiRQMHH4Vqm0lcOVN6FWw1KWB+GI+vNe4fC6/N1a3CnG7gnnr+FeC
+uI1ZnhnUoDkLIO31r2H4K3kdyt6gLF0xg4wK2SXQzdz1aZ9j49qKScLvGfSikSZHjP5vCt4uQMqA
+M/WvBZCbfRmkbIHnkyso5KqM4r3/AMS2Zv8AQriEZJxkAd68D1ZLsRPpcNu/7wlWO35VGeTnPPFc
+9d6pGtKyuzmrTXdYF28lrM6WrOWEDAMu3056cHHFaH9oHQrmS6hSQQTLvfYqkDPYZHHcVq2mkvEy
+Lbxkt0PFWNbtIViMFw2xHi6FSd/Pb0NYe1UpaIq3dnEajr8t7qRmjtUTLDaoJJGPQ11F3Ytr2hLd
+LcCG9iQEb2xvHpx3rF0jR/LBd43Jydo28kdq6izsL7yWENu2xxhlYdR+NTOtFStHoSlfcxdPmA0m
+T7RLIqRExssnOSRyAaZo2utL58MrM9ptYxqeoPrV3V9EvZ0gtXJS26sh6g5yT+OetX7Dwii229Vy
+OhC/41arQa7hZpnOWscmpTQrPN+7tHZFXGcc+tbsumRPGEQt3zjPQ1tabpCWkuFs8qzEsxf5snv0
+rqIIdNVRA8aRk8AP1JqXW5paOxSWh5onheFFJik3E8lSf8a9U+FVoLRbpWhKv03Y7U9NCgVsi3ib
+PA+QfzrrNAsDaRMxXbu6Cuim5N6smWxqTq7OCvTFFOc/NRXQZCZDDB5BrOk0LSpXZ2tYt7dWxzVx
+T0qQGk0nuh7Gevh3TkGFhUA9gMVSufBunXMgc7h+RrfzSg1lKlCW6HzMxY/CWkxqAIAfepRoNjGN
+i7EX0wK1s0hAYYNJUaa6C5mYp8NaVJIHk2uewJFW08P2EabEiVV9ABWgoC8AU7PFXGlBbIOZmZ/w
+j9mM4Xr7UkXh6xiff5alvXaK1M0ZqvZx7D5mV1srdMYUcVONqrhcY9qCaYTVJJbCI5JNrY9qKrXT
+ESjH92igD//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0034/full/!100,100/0/default.jpg</Url><Caption>29376_0034</Caption><Caption>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Caption><Caption>Exhibit</Caption><Caption>plate 097</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2KAbQ
+BtJ+lXlXiq8C4q4orNLQoAtP20oFDukalnYKvqTimAm32o2io57u2tYfNnmjjj/vM2BXKQeLbnVf
+EkVvpsanTVbYZWGTMe5X0A9aTkluNRbOv2j0ppUelS4oIqiSm0kQz836UjIM1ZIqJhzSGRRLzVnc
+EQsegqGMc1Y/gP0piKF1rljZ2ouZJl8rdtJB6V5b438S6jrHiOHSLGYwWONzsp+Zu34D/PSsLV9R
+lnvdSBlaSKO42hWPBbPOPof51ajtX+1rMzhTcv5jH0jQAKv4kGuSVRy0N1FLUtasbbR1DXN3PdMs
+XlpBvO09OP0/Ku/8DaNdQ2g1XUoliuZ0xDbr0gj9Pqepri/A+kxeJvGV5qk+ZbOwYLEr8gvzj8Op
+r2WtKUPtMmcuglIa4H4jeLbrTNPu7DSX23yQCbeuCQocBgPcA5rD0vxDd/8ACYT6hc6pONJh0pbh
+AxJR+PmJ465zW9zM9YIqJsZrlvAXjm38b6bcTJF5NxbybJI854PQj611D4zQwGJ1ov5/sumXU4/5
+Zws/5AmhOtV9bG7w/qK4620n/oJpdBHhuhKl5eLBcqVkMgkfd3+bcT7/AFrX8UXFpCymFiWC7EVe
+SeemK5PRzIYvMDATrkqxz0Bzgn6c10nhmz+2NLqV0wcgHYD/AAj/ABrz5+4zeL5hfBt7ruk6bcw6
+e0UEcj+ZJJJHuKn3PSrt7488VWMnlC8hmL8BvIHy+/FX4Pn06dVTavmHfj1IHNYen2C3fiAxXMix
+wxDexLfeX2rONefNa5pyxtqdP4S8IS6lc22sapI7SxTPP83O8uACD7ZGa7bxBoemajoN1aXcKpbF
+Mv5Y2kKDu7fSrmlT2s2mxPatmHGAcY6VYumRbWUyDcgQ7hjORivSh8Jyt6nk3w88U6PfeNrrS9B0
+tbSwFrjfgBpChGCQPqeteqv1rxf4f6hpmo/Fm7k0rSmsIFtJAyucMzbhzjtXs0pwRVXEhoZU5Y0l
+00ctlNG3KuhU49CKz9WmEFqJWkkQKc5TFc//AG4/kmRJpQhB+8orO6tqS5a2PIbe0mM72ybTF5nz
+AnBwMgiuha7hhltxax/Z7QDbM235R+NU4EW2vrmbzTFvISOTAIDZ6nPbv1FW4jFbW97bTubgeWZF
+KgYYknB4Jrzpy5pXOmOiKVz4klvtbGn6XJJFaQA/MoOJH9W9q5668aXVprZAWNTEWiDMMt6EkdK7
+bQdGg02wOQGkc5kfH8XUj8K4XxB4etotTe4Visjku8QO7B7n2roioN2aI5maQ8XNb3aMxnmnQh0D
+yYVT1yAOK958J+JF8RaAt1IFWZRiRB/Ovmu3jhinae5XdIf4QcYroPDPj280vXIYrVo0tGcLMhHy
+kd61jK2iIep23hfxHZ638YLmOxsEt4Le1li8zZh5W3KST+XFeqyHkVzWlaXolprEur2loI7q4X5n
+DDGDzXSSHODWl9BI5bxpM0OnoQVHP8QyP5GvOH1ktHJDIUdSDtXZxn9K9R8T6c2oWSpkhQeQO9eR
+apYL9vS005SctsLjnJ7n6CuOafOWkXo7e5ktd8IwCxban8agYxzn1qppGmahHPLFd2piEvCEEYAF
+dbaRrpdhFCHEjqDg5+WsfU/EFxPut7dkIB/1y8c+g96FFNDbZcmuVgj+zWocueNwXlfwrhvELrbT
+MWkDSEYxuztHoff1rWOvW2naW8bzI107EZAyQPr3ridRu/tk5ydxJzyK0jB38iTPuJyx2qT8xyTj
+rWhoOlSXdwGUERA5ZzWhpHhq4vyJnQrABnJ/irpE0ZrePC7kX+6honUUdEOx1/hi6t0uILdJX2ph
+RuQZP416axG1cdMV5L4Xtliv4yyORkdVNervwqgdMU6bbiwtqRXVr9ttnh3lN3GRXN3XhaS1hZrW
+MPKFxu7ke1dZGasqciuh01LUm9jxHVU1G1mMLwk7h5YJU5J46Cs+706awtmjeCSW5K4Xy1JVfb6+
+9e/MiN95VP1FNMUYGViTI6cUvZoLnynd6Jqs0iytaSkn7qhDgVq+G/AmoapqiRvC64w0rMOFFfSp
+C94V9uKegx92JVz17VXKx3OHtfB8NtZxwLHkIMZPennwkMAJGgPqc13BppNZ/V4j52c9pWgrZEsw
+AJPIB4rVkxkCp2JqtMfmHNacqirCWrFgJxVpTxRRVR2Ex+aTNFFMQoNLmiikAhJqPcc0UUwGN0qn
+MTuooqZDR//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0017/full/!100,100/0/default.jpg</Url><Caption>29376_0017</Caption><Caption>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Caption><Caption>Exhibit</Caption><Caption>plate 098</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tYQo
+zzTxGGUEZwfUVMBS4pWEQeVTTFVkisjxHqyaFoN3qLFcxJ8gboznhR+dS9NQM/XPEul6DLHDeSOZ
+5BlIol3MR6+1SaJruneIEkaxlYvFjzI3Xay56cV5PYW1x4hkuLya7Ml/kSbpOmf7vsMcV1HgnRNR
+svFAvfKkFrcQMjnsD1HT3FclPEOdSy2NZU1GOu56R5XFAgqwFpwWuyxiVTBSG3q5ijbTsMoNAApJ
+zx6c1F5Ks2MPz6qRWntpCopWAyzZAnvRWgV5oqbICcUp6U0uEjLk/KBk1lyeIbGN9hkG7uAelXdC
+Zq15T8ZL9yNL0tWwjuZnGeuOB/M1d1fxVqNv4xgntbwHS1jAkhGDuOeQfQ45BrjviZq8Gr+JbCSB
+gUSDaRuzg7if8Kwq1E4uKeppCLum9ibwcrQ3cysDhiDmvVNBhSG6kFtGwgKASM5wd/Xp9DXm3hq6
+g8iR2A3RNjr6V3mm+IrUF5/NjE1yFd4y4+U4xiuHDNObbNa+h1mOacBWG+o3UgzG6L9OcCmW+qzf
+aWjmY7B0cetempq9jlN+lrNN1csf3LxsMd+tRrrG1tkiZfp8taLULmrTTVIakCu4wt+dTwXcdzwm
+QfQikVceetFKetFSMpX2DoUm7vEM8+wrxm9tkM0pM79T9017LrAJ0K4Cjny+K8Lu5giyTMQAhJPB
+6CuPFN3SRpTKTWvk3CtFKwI5+bqaTU9LF6I7mNwkwPzA8A0WuoJqZ3wHgcfMuOnf9afe3Is7bLAs
+2flXIO4/0rhbmpW6m3QtWluLa2lWKYmSQgnZg4Peo7zTkkkUrPNNtUbixGT+QrEhTUb9i3m+UrH7
+qHbW/pXhR5ZlkuZ5GTH9/rRrF3ciWmyW31SazjCRXMitj7nmZFdNpfiu3KIt4WWXb1Ukg1yX9lwQ
+63tAURoN2W4AI6U6C6t4Lh5Fhku7g/KFjTCJzkZPetqc5JaNkOCvqd1/wkVkJRh539z0/wAac3iX
+Tov3qzSDrgAHP5GuNnjcWzXF7IkK8naDiufGuz3l8YdMtkcRKcyyk4x9K6KdSq9xOET00+NJSCUj
+kKds4Fa/hbVby/1XDxgRcknPtXkEPiV7e+EGpW4jxjmMkD8q9g8F3EE7K0Me3jrWkXVcld6CcYpa
+HbEc0UtFdBmVrqJZtPkib7rJg/lXjuq+G1M52MUjBI45Jr2UjfCV9RiuavtLySQAV69KzqQUlqVF
+2Z5YPDscCl42ZFXn5ep/Ksi6kR9QFiRvXIUNjJ3eor1K4sFWIjb0rEbSQqh44QpByOK4KkHc3UlY
+4PU7iO1nSFGxsYFyPatFfFd29rHbWts3mZBDEY57VtR+Emkunl8xkDnO0L0/Gt638PRRwJGkYZkA
+wzdSaiMFZXQpyu9znbKCXWczX1qsLKRkKCMkd8Gt2DT44IyY169SeTViW0NtKiO6jPJOc1fjhBgB
+jGcjOK2jFLYVzivEenf2jZtGgb5fwqj4NtoPD3mNfWjTbicsuOK7WS1iu1fbJvZThgvUGq6+HzMw
+LK230Faq9rD0OA1/S21zxBJd2sDw2x/vDk16r4AspbeNNytgD+IYxxTrHQlUhRGMemK6zTrX7Mo+
+UD2ArWClfUibVrI0M0UmaK2MiGNvlFOwrdVqCMkKKlBoAR7S3kHzRioX0q1c5Kc1aBNKDUtIZROk
+W20hQVPqKrnRrcqEZ5s4xmtfNHWs3CL3QXaMM+HdOeVHYSsyjGWOavpptoF2CJgpH0q5gDoKcKqM
+I9g5mZcfhzTIm3RW/lknJKEjcff1/GrqWFvGAAuQPWrNNJq1FILsaI40+6g/AUbvbFGTTCTVCFLC
+ioWY560UgP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0050/full/!100,100/0/default.jpg</Url><Caption>29376_0050</Caption><Caption>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Caption><Caption>Exhibit</Caption><Caption>plate 099</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0009</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EQj0
+pSiDGSB6VMBQxRRlyoHqagZCYR6UwwD0q0cUzcKWwFfyB6UnkD0qzS4piK3kD0o+zj0q0BS4pgUj
+bD0pDair20Um2gZnPbKoyxwKj+yq4ypyK1CtNKCiyAxm0yNjkqCfpRWvsFFTZDuTCql3OiTLG4yu
+0nH+fxq4tcj42vX09YbhQNuCpOamo7RuC3N03sYVED/LjGfas69161tQJPNGCMkZry2fxnLEjLHJ
+uDZz9awzqmpauWhgjeQp2HYVxyrSexXKe822uWk8YbzByPX2q5Dc+fhkIIYZH09a+dU12eOAESMG
+UbSOevpXpnhjxbbpYRC6uY0O3lnYAL7AVdKu5StIlxsekL70pwBk9BXNr430KNC0l8No43hGK/8A
+fQGKydf8aafMbSCyvVaORm8wgH+78v1HX9K6XUilcIwbdjsbPUIL8FrfeyDo5UgH6ZqzXCR/ETwt
+oxFg145mGNy+Wc5x34xWvZeONGvyBBMxyeCRxVKStqwaOkpCKqR6nbSnCMSfarmQygjvVXXQLEdF
+KetFAh69K4v4haadTtIEFwYdhJBCbs59eRXZr0rnPFEqKFWQ4XaTjA5/E1hiJctNsuCuzxCXQ301
+282QSr13Dv8AnWtoniez0gSQpcm3ZmBcSRjNQa1qPmMyR2F2Fxkg4x/PFZ9z4bc2D6ncGERRLkxH
+nI643eteeqjfxaG/LbZGhrh0fVfKxf2doVbcZI0bLjPchsfjiubGr2GkasDbRLqCbdrGVd4H0zWy
+mkaK9pHdDRL4wMgYuG65GcDA5pbLTdOvJWjj0W6t4wpIknc7Sew4WtEratmfNd2SOi0XxfYvCY2m
+jhjccw/ZVUZx6kmnw6NZXNtI9gokRMnLzDjvx8vFcFLfx2OqLbNBDJFnnyiSQPrnrXcPp8EtgBBc
+sIyu4oj5/wDHaPZ3V0y1Oz1RkS6JFqr7baeJ3i4lkz0+mOtVW8OX2mTeZaXio3YAYP5ZrXtp/JUN
+byeaBnLIuGHqNp61oQamLqHMdvHM6tgjzdpP6cVLVSL90ttSRa8O6zqGnMsd/wCVdRt/EPlZfwr1
+q2kWW1jkT7rKCK8eXxI1vJ5cmkMJAPmxIGH8q9Z0m5S70q3nRdqugIHpXVhpSbakY1I21LLdaKD1
+orquZAp4qhq1sLiLlQQPUZq4pp5KkYNKSurAnY861S0AB84sYvRUzn/AVhppmmOCqhVGc7W9a9Zb
+T7SQHMYOe5qi3hnT3feQ4Ocgg15lfB1JO8GbxqrZnmd/4fEkG5ppQMZ++cYrkr/w3cuga2nMjZ4A
+fkfga+gP7FsvL2OrMvfJqB/DekO257dCTg9KVOhiIrVpkuUD5ug0HV7a+WSQXSsp4YsRivQdIW++
+z4mxISP4kU/0r1EeHtLViwVsHqCSR+RqddGsPuogGP8AZH+FdkKc2veIcl0PJZ9I1Bt89vGgcAhQ
+Bjr9KzfDnhvUYLueW6tgpfoQxBHr9fxr3FdIs1HEYp66ZaKeIxV+xGqjtY8iubfVhfR29us/lDGR
+GVBP4mvWtKhaDS4In37lXnecmpFsrZH3CIZ9cVPkYqoU+V3CU7qw0nmikJ5oqySJWp4NVQTkc1Kp
+PrTuIsZozUQJpwPFTcLD80HB6im0uaOYQ4YHSnZqPPNOqrgOzRmm96SmA4mmFqDTDSuMYzHNFRSs
+Q/BoqWx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0020/full/!100,100/0/default.jpg</Url><Caption>29376_0020</Caption><Caption>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Caption><Caption>Exhibit</Caption><Caption>plate 100</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0009/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0012__xz111ffbb66842f49d5f2e023e5131778d.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0012__xz111ffbb66842f49d5f2e023e5131778d.xml
@@ -1,0 +1,2890 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719890___29376_0012__xz111ffbb66842f49d5f2e023e5131778d">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="q1">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">5</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719890</Param>
+<Param name="viewid">29376_0012</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0012</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>d0dadd2c4a7f21568fcbd5d7419f4821</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719890</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0012</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719890%5D29376_0012</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719890%5D29376_0012</ItemUrlEncoded><TitleForTagging>Canis%20Lupus%20%28Var.%20Ater%29%2C%20Linn.%20Black%20American%20Wolf.%20%28v.%202%2C%20no.%2014%2C%20plate%2067%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="5" name="S_SCLAUDUBON_X_B6719889___29377_0049" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0049</Url></Next>
+<Prev><Url index="3" name="S_SCLAUDUBON_X_B6719890___29376_0038" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038</Url></Prev>
+<Self><Url index="4" name="S_SCLAUDUBON_X_B6719890___29376_0012">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776100</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;q1=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719890]29376_0012</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/538,420/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>537</w>
+    <h>419</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_m class="fieldsRef">29376_0012</istruct_m>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-19</istruct_isentryidv>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<m_source class="fieldsRef">sclib</m_source>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_color_space class="fieldsRef"/>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<m_fn class="fieldsRef">29376_0012</m_fn>
+<m_flm class="fieldsRef">2014-12-11 11:09:51</m_flm>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_iid class="fieldsRef">29376_0012</m_iid>
+<istruct_caption_image_title class="fieldsRef">Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</istruct_caption_image_title>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</m_caption>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0012</istruct_isentryid>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_x class="fieldsRef">19</istruct_x>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_caption class="fieldsRef">29376_0012||||||||||||||||||Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)|||Exhibit||||||||||||plate 067</istruct_caption>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<istruct_caption_plate class="fieldsRef">plate 067</istruct_caption_plate>
+<istruct_caption_image_id class="fieldsRef">29376_0012</istruct_caption_image_id>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<ext class="imgInfHashRef">jp2</ext>
+<md5 class="imgInfHashRef">839172d2f92639a1b9fffe33e2d0f53d</md5>
+<use class="imgInfHashRef">access</use>
+<loaded class="imgInfHashRef">2014-12-12 17:07:38</loaded>
+<collid class="imgInfHashRef">sclib</collid>
+<modified class="imgInfHashRef">2014-12-11 11:09:51</modified>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<width class="imgInfHashRef">8602</width>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/4_/p6/7/audubonVQ_v2_14_p67/audubonVQ_v2_14_p67.jp2</filename>
+<height class="imgInfHashRef">6708</height>
+<levels class="imgInfHashRef">6</levels>
+<type class="imgInfHashRef">image</type>
+<size class="imgInfHashRef">5467100</size>
+<access class="imgInfHashRef">1</access>
+<basename class="imgInfHashRef">29376_0012</basename>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:6/0/native.jpg</Part><LevelWidth>134</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>134</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:5/0/native.jpg</Part><LevelWidth>268</LevelWidth><LevelHeight>209</LevelHeight><LevelMaxDim>268</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:4/0/native.jpg</Part><LevelWidth>537</LevelWidth><LevelHeight>419</LevelHeight><LevelMaxDim>537</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:3/0/native.jpg</Part><LevelWidth>1075</LevelWidth><LevelHeight>838</LevelHeight><LevelMaxDim>1075</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:2/0/native.jpg</Part><LevelWidth>2150</LevelWidth><LevelHeight>1677</LevelHeight><LevelMaxDim>2150</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:1/0/native.jpg</Part><LevelWidth>4301</LevelWidth><LevelHeight>3354</LevelHeight><LevelMaxDim>4301</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:0/0/native.jpg</Part><LevelWidth>8602</LevelWidth><LevelHeight>6708</LevelHeight><LevelMaxDim>8602</LevelMaxDim></Level><MaxWidth>8602</MaxWidth><MaxHeight>6708</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719890</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29376_0012</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis Lupus (Var. Ater), Linn. Black <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 14, plate 67)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1846</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank">Lithograph</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/res:0/0/native.jpg?attachment=1</URL><Filename>29376_0012_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719890:29376_0012" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719890:29376_0012" canvas-index="11" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="sort">istruct_caption_image_title</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="q1">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">5</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719890</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0012</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. II; [title page]</Label><Value>29376_0025</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. II; Contents</Label><Value>29376_0011</Value></Option><Option index="2"><Label>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Label><Value>29376_0002</Value></Option><Option index="3"><Label>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Label><Value>29376_0010</Value></Option><Option index="4"><Label>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Label><Value>29376_0006</Value></Option><Option index="5"><Label>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Label><Value>29376_0007</Value></Option><Option index="6"><Label>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Label><Value>29376_0004</Value></Option><Option index="7"><Label>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Label><Value>29376_0008</Value></Option><Option index="8"><Label>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Label><Value>29376_0009</Value></Option><Option index="9"><Label>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Label><Value>29376_0005</Value></Option><Option index="10"><Label>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Label><Value>29376_0003</Value></Option><Option index="11"><Label>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Label><Value>29376_0052</Value></Option><Option index="12"><Label>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Label><Value>29376_0039</Value></Option><Option index="13"><Label>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Label><Value>29376_0014</Value></Option><Option index="14"><Label>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Label><Value>29376_0051</Value></Option><Option index="15"><Label>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Label><Value>29376_0018</Value></Option><Option index="16"><Label>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Label><Value>29376_0046</Value></Option><Option index="17"><Label>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Label><Value>29376_0041</Value></Option><Option index="18"><Label>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Label><Value>29376_0012</Value><Focus>true</Focus></Option><Option index="19"><Label>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Label><Value>29376_0019</Value></Option><Option index="20"><Label>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Label><Value>29376_0044</Value></Option><Option index="21"><Label>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Label><Value>29376_0021</Value></Option><Option index="22"><Label>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Label><Value>29376_0035</Value></Option><Option index="23"><Label>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Label><Value>29376_0038</Value></Option><Option index="24"><Label>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Label><Value>29376_0016</Value></Option><Option index="25"><Label>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Label><Value>29376_0037</Value></Option><Option index="26"><Label>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Label><Value>29376_0033</Value></Option><Option index="27"><Label>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Label><Value>29376_0022</Value></Option><Option index="28"><Label>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Label><Value>29376_0047</Value></Option><Option index="29"><Label>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Label><Value>29376_0042</Value></Option><Option index="30"><Label>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Label><Value>29376_0032</Value></Option><Option index="31"><Label>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Label><Value>29376_0045</Value></Option><Option index="32"><Label>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Label><Value>29376_0036</Value></Option><Option index="33"><Label>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Label><Value>29376_0049</Value></Option><Option index="34"><Label>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Label><Value>29376_0043</Value></Option><Option index="35"><Label>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Label><Value>29376_0048</Value></Option><Option index="36"><Label>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Label><Value>29376_0015</Value></Option><Option index="37"><Label>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Label><Value>29376_0031</Value></Option><Option index="38"><Label>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Label><Value>29376_0028</Value></Option><Option index="39"><Label>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Label><Value>29376_0030</Value></Option><Option index="40"><Label>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Label><Value>29376_0026</Value></Option><Option index="41"><Label>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Label><Value>29376_0029</Value></Option><Option index="42"><Label>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Label><Value>29376_0013</Value></Option><Option index="43"><Label>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Label><Value>29376_0023</Value></Option><Option index="44"><Label>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Label><Value>29376_0027</Value></Option><Option index="45"><Label>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Label><Value>29376_0024</Value></Option><Option index="46"><Label>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Label><Value>29376_0040</Value></Option><Option index="47"><Label>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Label><Value>29376_0001</Value></Option><Option index="48"><Label>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Label><Value>29376_0034</Value></Option><Option index="49"><Label>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Label><Value>29376_0017</Value></Option><Option index="50"><Label>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Label><Value>29376_0050</Value></Option><Option index="51"><Label>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Label><Value>29376_0020</Value></Option><Name>relview</Name><Default>29376_0012</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2ZE+V
+fpUqpzSouFX6VIBWNihAlOCU4CngU7AM20u2nHhScEkdhSIxcZKMvs1ADdtNKD0qUikxQBAyD0qF
+4we1W2FQsKLAKn3R9KZKlzvzC424+6QOtSJ90fSpVoAqlb1WG1lYZPYcDIx+maN1/n7ijr3Htj+t
+WJbiK3AMr7QeBxR9qgGMv19jTAjBvN/IXbkccdKdKboMREARnjPpj/GnpcwysESTJYZGPSk+1W8W
+FMwJPTJznmgRCWviOI1Bx6j/AD6Un+nbv4cZHGOnHPepxe2zAkSjAGack0Uv3HDfSgZTDX+PmjXP
+4cfrVh6mNQyYpAIn3RUq1EvQVIKEArwxylS6htvTNM+xW+7d5fI75NKIkLEkHJ9zTmiRjk5/76NM
+Q1bOBHDqmGC7QcnpTF0+1AH7rGOnzHip/LXAHOB70giXH8Q/GgCH+z7XGBHgY24DHp6daVLKCJw6
+IQwGB8x/xqXYPU/nSFAe7dMdaQDieKgcVL0GKhc9KGMUU8VGKkFJANWLGfnfkY+9TxHgY3v0x1pR
+ThQIaI8fxufxo8vjHmP+dOKhhgikESjbjPy9OaYCbCAfnbn3ppU5++3WpTTaAI8EDqT9ajepmqCQ
+9KTGPFPFMWnihAPFIY1Y5OfwYilFOxTAaIl/2v8Avo/40vlL/tf99n/GomtwBlWfI9ZGxRHEXX5m
+YL2wzA/jTAk8pQc5b/vs/wCNKaFQIu0En6nNBoAY1Qyc1M1QSHFJgPFSColp4NAEmQBShh7/AJU0
+GnA0wF3D3/KjePf8qM0ZpgIXHv8AlTdwP/6qUmmE0gBjVeU1IxqCRqQAshz2p7Sso4AoooGILl/R
+actw5OMLRRTEThyfSjeaKKAAsajZjzRRQBCzHmqs7sF49aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0025/full/!100,100/0/default.jpg</Url><Caption>29376_0025</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUHp
+UixD0pQtSAVmUII1x0pwQelOApSQuAQefQU7AM8sZ6U4IB2oEinnD9AfunvR5i+jd/4T2osAFR6U
+0oPSnhgxIAPHqMUEUAQsg9KqXMQKjI71fIqvOvyj60gJVFPApq9KV1Up8wBxzzTAkGPWnD61iyso
+uTngY7Y9PrV63CdViBI6FdvH5GmIuc5o57kUveq8wQJuIXODyceh9aAJ+PUUhrEilxhU2sT0zjit
+KCZNg3Tx9Pu5Xj8jQBMagn+6PrUyuki7kZWHqpzUMwyBSYyRegp5+6aYv3RTm+6aAMu43LMxz1IH
+U+1WLUgHafMHqwbr+dV52P2hhx0/p9as2sW5RvQNnrx/9egReVNpJ3s2fU5pkufL4J7+voakVQow
+On1qKb/V9uh/kfcUAZON20Lkk+5/xq/ag527XVQM/MTzVBGbcMbSRzgkD/2ar8Hn7cYCg99oI/8A
+QqALRFV5hwKn7VBKeBSYx6dBT2PyGokPyj6U8k7DSuIzpZCs77SM46Ej0qa3lZcOXQj0GBVefP2g
+5fpg4yc/+hVPbA7BtkJyecbv/iqYF9ZkYgBhk9qbMcR/n3x2NOjXYuMknvkk/wA6imJ8vqeh9fQ+
+4oAzl3OygHI7/Mf8a0oGzHj0981nQAmQkSYxjpk/yaryzkKAVYn2H/16AJSagmPAqQPuz8rDHrUU
+rcCpYx6fdFPP3DUafdH0qX+E00BlzsFnY5GAB3H+NXLWLzF3Fk68BVFVbhsTtyeMdz/iKtWsnmIW
+dpDg8YzTAu1BPjyxnHQ9ceh9anBBUEVFLny+M9+mfQ+lAjIBRcbjlcZ4P/160YFVl3bB7Nx/SqCy
+HcMFlPTIJ/xq7Ddx7Qhcu3sDSGTtUEo4FTk5GRUEp6UmBIh+UfSpB0qCM/Iv0qYGqQDWtYnYsdwJ
+64NSLbxLjCDI70oNOzTAWmtGrj5gDj1pc0meKAIRZwA5KZ+vNKYYgQQi5HTipCaaTSAaxqGSnsah
+kakAkTHYv0qdWNFFCAXec0u80UUDF3Gm7ziiigA3mmFzmiigBjMcVVlds0UUAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0011/full/!100,100/0/default.jpg</Url><Caption>29376_0011</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2JIRj
+lQfbFTLGABgYFPVakArj5UakXl0uypcUhwAalpAM8ul8uohdKCVPUGsDxl4kttF0WUm5MUsi4V1P
+Ke/tUOcUriOiYIgLOwAHcmsI+MtAW+Sze+WOWR/Lj3KQGb0z2/HFfOuu+OdV1AeQt7czQqx2tLIT
++hrm3mubgiSW5lY9sseK2jCTs9kTzH0dq3xAk0PxBJZ3lvbS2ZwYZYZPmYe+cjI/Cuit/Fmh3Fvb
+zC+jQzglEf73HXivkp43PzGRyfXNadnq89rEsM4M9sG3FCcEfQim6U1dp3GpH0rdeONFs74Q3Mrx
+QNkC5ZDs3Dt6j69OK30ljlijkibzI5FDK6cgg98184w3VtcxRN5s00UxI8uWQsqHHbPSvZvhubk+
+E4EmJZYyyoT/AHcnAH5/yrKEpNtSWpVzp2TminsPmoq7IZaWnVHI+yMt6Vg3OszI7BU5HP4VRLdj
+oiwRSWIAHUms29vZYwuyCQgnAYgD+Z/pXOSa3dTbpE2HZyBv4+tcT4k+JmotbSWml20vmgc3DoCq
+j+8Of51jJOWiYJnV+JfFNjotqZbi9SK42nEKMd7fQfnzXhGv+Jb/AMS3Aa4kZbYHCpuLY+pNZ969
+1JcvcXlxJJPIdzO7ZLU0CQhmH3Rgnjt0zVU6MYvm3Ym3sM+zswZCPmXv7VL5QVdhXkDFLKzQy7GB
+yR19amjieYdcZFdKJ6kTYSIE4Cn7opqoHycDGOaZKWL4PTtUttuAkB6lCBWnQSJdKb7PfLBKSYHb
+jnofWvof4b3Q/wCEd+zzTpvE7rCjMAxTjt9c/lXzmBvtxICQynNekeFNYvrrVdHeAEyPIsbMcY64
+P6VjVT5k0WtD3UrzRUpHNFTYsp6rcraafJM3QD8685udbmkBcSqzA/KcYxXU+P7hrXQY2BAQygE5
+56H/AOvXlSX8c0XzMV+TK56kevQ/5/CuWvKSdkS7Fi41S+e8aZCjQE5dGA+Ze/8AnvV61t9fuHMy
+XMUto6lQMKAF/mDjtiuWvrgNCVhiYrklnBwB+J6fT+VYkepSae7SWt9Isv8AdViR+PGKdOnUtqSp
+WOg1fwrGkUaDc0xzj6nH6cH865+8tvsMEhyMFfLB9TnJ/TH51r2PjErGx1K2cy4Kh42Bz6jaTkdO
+f8iuc13UZNW1Dy4EKxDgZ4Jzz+FbU09mNtWFggfVctGVVUfG+RgqhcdST9Kt/a9LsiIUWa+kxh5Y
+jsRf93IOfrVQWDzRw2kKsyg7nK/xN6D2FdLZeHobW0d7p1RguQuf0qpzSe44oyFh0q7j8tYL1WJ+
+8zLhD65rEXzkvXtkYSFGKhk5DfSun1ePSLm3tovtaW8UTHeioSXPrkdfSseCa2sUdVUSucjKngj/
+AAq6ctBtXIGjeF5ojtPfjkc10vw5uZY/E2nRlvkFyOPriueMrXM0kjALhAMAYrpfh5bCXxXpyqfm
+88N+XP8AStXrHUnqfSpHNFIzYNFYXKOK+KkbyeCpHjzujlR+B714zpc8Ijvbu9Ym3gC4iBwznkBR
+6Z9fQV9CeIrBtU8P3NojBTInUjPvXzTq1pJp2pT2wbzFiKmXZ25PH15oVm9SJLUr31/d6jc7WGyI
+fdgj4RBWlc6Hd2Xho6jdNHBExCpGE+aQnOKd4bextrx7q8aJ02N8sg6H15/zxR4k1m5122haCNxp
+tkpKJswuc4z/ACpO7YWSRnaSzQaim5Fm4BmeQb8E+g9e2PatOHwqUlF3NIiR7txB6twM8dupqrpk
+n9mQPdXgR7mU+YA3UfhWXqGvXd0dnmPtHQZrO8nJ8uw9kbd3q9vp4xGqO+MZ6jH+FYd3rlzdysRI
+3zdQKom3nki81wxyegHNN8iXkJEyj0wSa1hTW4OVhCGeUeYxAPrV1MJgKQT2z/Kq8drck8RN/wB8
+mrUFpPLK0cakuvDN6Vvyi5x3mGRvLXnJzIw9fQV6j8IrCOXxAblk5hjJXjoelcHp+g3kzAJFk9gK
+9i+F/hvUNKe4urtTHHIuFU96mWw0z0ZyN3SihgM0ViWRI25AO2K4rVfhjpepSyGKaS2jnk8ydU6t
+7A9ua66N8oKkD+1IRxEXwo0uBk8p8InOGGST65qyPh3bQ6c9rE6uuPkV8hR+A6/jmuy8w4pRJxUN
+IDxm/wDgtq+oXZlk1W02n1DZFaWlfBC1tCHvL0TuOgC4Ar1YPmkKgjAyPxprsI4uL4Y6ahBdg2Pa
+rC/DfSkfcFH4jpXWBVAxgnPXmnhgoAA4q0LlRzH/AAgGmfQ+wFU9N+HFlYXN/IZRItzP5q/LyBgc
+fnn867TdmlLc1aYcqMKz8H6TZyCQQhmHrW6AqLtUYA7CmsfUUwvjOBQOwE89aKru53GioKP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0002/full/!100,100/0/default.jpg</Url><Caption>29376_0002</Caption><Caption>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Caption><Caption>Exhibit</Caption><Caption>plate 051</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21FO2
+nbTt5605BxingVlYoy9T1S10iATXbFUOeQM4AGSfpWH4H8Xp4ws764WMRiC5MaDGDswNpPPXrVX4
+hSmJbcZDF0eFY8cncRuP4AfrXF+F/EsHhbXba0KQrb3QENx5edsbZ+Vgfx5rB1Fz8pXL7tz2fmnC
+lxkZpQtb2RFwxml20oFOxTaC5WlnggZVllRGf7oZsZqQAEVg6tZLLJPO1o0xCkbrp/3ag45UVraZ
+btb2KI0aRt12o5YfmazjJuVrFEzocEqAT70wxkr8wAPtVgikI4q2BSZTmip2UZooAmUdKkApq9qk
+FMR5t49Fzd6lHbBSiqP3ZA5bPU5ryXxTpUthb2NxCG/0gyKcghg6nBB/Svo3xDpy32nMcYkj+ZWH
+UfSvIPFNhfahaRRXV8rRW7M6DYqsSRjkgc1wVJKnV97qdEY80NOh2Hws1rU9a0djfajBc+R8hjKn
+zU9Nx6EY+tehCvmHSNR1jQb57zS7h4HYBWXGQw9x3r0fw98X/wB8lr4itPIJ4+0xD5fxH+FdUJrY
+wkj1gCq0uo2kF0ttJMqysMgGpra4gu7ZLi2lSWFxlXQ5BFQtpdq941y0eZWweT0I6Ee9aO/Qkdeo
+JLGcbiuY25HUcUQrcCV/M2+UMBO5981DfXtvaqILidFL4xuOCRnn9KsQ3CXESSxEMjjKt6j1ounL
+cZIRSFeKfQRxVMCuRzRUhHNFADxwM1Tk1a1hcq7MMd9tXP4SK5+/gDSE9faolKyGkav9qWEo2faE
+y3GDxmuG1vQ4jdzAxgNkkH61cuvIjx5pC+nrV0XsWoWLQyAmVFyjkdRXHibzjdbo1pNRdnscHBpU
+UV1g44B4rK1fSAJT+7BU8gkdq6+0snvNae1GEZFJJY+ta1x4dkhhJdlkAGcY5rgpVa1+ZrQ6akKa
+0T1PM/DXjS+8E34ibdPpUjfvIT1T3X0NetW/jjT79BdWAe4h2dRwMk15J4uFnGBbxIGdueOq/Wsf
+wbfzWeuf2YJcQ3J3AHsw5r1IVHKF0cc42dj2PVL+K5MshsovPkXaZGG5gPb29qpR63dKMzTupztw
+GwFGf0FQmURowAwCpw552sBxn2rJguGu7qdCAUbCDHOD3/Os5VHfQdrHWpd3i/OjyYHJJY811enX
+JurQM33hwa4c34hkTPypux9B2rqdAuEl80IQR7etbU5tuwSWhsYopaK3uZkcr7IHfOMKTmvKdW8W
+XsTy/ZxM6BsbzgD+tepzAvbyKOpUgcZrxDxEbi11R4ZGIkLEhT8o/AGuavNxSsa043ZXl8UaxKwx
+Z2yAHIkcN+vNbHhjW9UvGv7i8lgW3ih2hY1wCxPX8gawbSDUNYj8p7clWbJJ6FfetK7u9O8N6LDa
+uytJIS0qRqcuR0X+n41xObldW1NVFJl3wz4jin8RSQzMFuWYGOQn/wAc/L9c16PrV0bTRp5V/wBY
+qYBz0JIH9a+d7a9vbrWFvI7dQ+/dhQeDXsy6lPqWmRrLbMLhk2yQOcCQEc4Pr3q1aMeVbkXvK7PM
+NVzB5ssilpZMkknJzmsDToJRqkd3sZdjfJjqTXc6mI7S5EFwiMSPkdsbx7ED+dcvaaxbHWHmaBzE
+hwrDkce1a0ajatbYdSnbW+51kVvrWqxBPMNrbkchT8zfU1Zg8MTQZMV1Msg7hzmoI/G9hbwkxQSb
+gPTg1UtPiMj6yqXMSQxbCWJPT0rSLk9kTZIuvezRB7S8yZI/mSUd/rXd+BJ/tMcjb8hBjHua8f1H
+xA2sahMbBCwxhTjqTXqnwvsb630y5mvo9jOwCYPUdelaKNpIhnfZoppPNFaEkCvWTq/hiw1mQTS7
+o5uP3iYyQO3NXkc1KrZFKUVJWY02tjm7rwZHI4MEvlqBgheM1nX3gD7XayRO6dMqUGDn613Icil3
+msJYamyvaSPJtG8D65p8sqrbQbQPkeQhs1en8O+JbqNkuFKtjb+5kwO/Q9e9el7qYy55yQfY1n9T
+h0bH7V9jx9Ph7fG4xcaZI+OBKZ935jio7nwLfBytvo0iBQQCeQa9kRARkluf9o1Nu4prCrpJh7V9
+jwyH4feIMpt06LYp5DsRxVm1+ENze3rTahbGHecnbOCP5V7VuNG81tGhy/aYOpfocppnw50PTYUR
+IOVO4HPOa6qOOOCIRxgBQMACkLGmFyBxWqilsQ5Nkhbmiq5c5op6CP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0010/full/!100,100/0/default.jpg</Url><Caption>29376_0010</Caption><Caption>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Caption><Caption>Exhibit</Caption><Caption>plate 052</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dIx6
+VMqe1CDgVIiBegAzzxXOkaAq4p4WlAp1XYVxNtKRS4oNOwXGYppWpajkkRPvEZosBGyiqt0g8hvw
+/nUqS292SAVYr+lJcKBAQBgDFS0NEyDgVIKYnCipBTQmKKcKQUoqhDsUuKSloAZIQiFj2rndXvfJ
+i3E/M3vW1euAFUnHOTXn3iS+Ml0UVsKDk89hSY0bPhq5a51e5wflVR06V0tyP3LVgeC7Uppr3Tfe
+mbI+ldDP/qjUvYYqcoD7U/eqjk01DlAR0xWTfXjqxSOQL9Bk1POktRWuabXagkKpOKYL8q2CgP0N
+c1NfXka43jGOWIFNguJRAZnn8w52qobOTQqlwsdDd67bWiZckE9FAyTWSfGsavzay7PXjNURblpD
+JJ88h5OafcaerwsWAUYzT5hG1Jq1rfWvnwOCdvKnqK85vUN3eeX93zZNoBPOKx7rxhZ6JqLr9rUF
+SVIA3A/XFTeHtc07W/ERna9hGOQhOCfoDTA9jsIorSxigRgAqgdamm5jasy1urc7QvTtxWlKf3ZN
+JvQaFjGYR/u1x2prNHcufMePBPI5H612MZAhB7Ba8+8V6jdxzkQPGRnG3HJrjrytFFRKkMBnuW3S
+XFwzkDkHAH41vGNLa2QKuQgzha5+PV7Lw1pNu2uXwhmvHJRG6gfQdBXSW81tcWiXFvPFLCw3B1YF
+cfWrp3SuxNhBdRSKJGdR7V5t8RfHLyxSabpk22EZWWRerew9qqeM/GdrmXT9LZWcjDzxHhfYHvXl
+s9xM52uT16mtkSPVWuCWY555qrJLLZXSyRMUkRsqQcVdsgpRgA289MjrVC/3PMc8H0qovUOh9AeG
+tevbiSzdljELopBx7V6szZgB9QK+fvhrr0N7bRaa48u8thkZ/jTPUV77CS1lHn+6K5oNqUost7Ji
+yNssGJOMJ1/CvItSvo11S5up3UQwn7vdjnpXrjp5tg0Y7pj9K8a19fsmpNHJbeZ82SGYgH8v61FV
+K8ebYaPMPEWp3fiLVZ9QvJGaTdtjjUcRqOgFVILvU4rBraG7lSCQ/PErkA/UV6jHqWmQI7W3h+zj
+uJARJMxLbs9eD0rMh8OW8y/aLe2jimEgYHeTkfToK2daC6k8p581vOp2FSoGN2RjFadloUt8wZo2
+WJR94jk131joMSTFrqNXkP8AF6/SteKxgi+WOM7s4+lcdbGJaRLVO5xtto6WKKVjbGeuOtaFvpqy
+y5NqrNjrtziuo/s6OXbvcKnpTZBHZzHjjHJFefPFLfqbKkzKsvC0beILPVFhlhmi2j5Plzgnk/ni
+vbIBizj/AN0VwWiXYvLiKJPmKn5iPSvQMBYgvoK9HA1JVIuUvQzqxUXZCwf6pR7Vj6r4UtNUmaRy
+VJGK14D+6T6VOCfX9K73TjONpGV7HBXPw2V0xFcAH/aFC/Dy4SPat0uR0r0AGnZ464rH6lRfQr2k
+jiovBdwn/LZAMdOtQzeDdQlyivCgY/M464ruTv7NmgB8cuQfwqXl9F9/vGqskcKfh9JsOL1w54yc
+Vbh8CwIiiSd2wMH5v1rsc8dc0wnimsBQXQftp9zJ03QrPSkAhQbgMbsVdkPFSMT61DK3FdChGCtF
+Gd23djIGPlJ9KsAmiimtgH5pdxooqhCgmgMeaKKAELHFNJNFFAELsRVd2NFFSyj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0006/full/!100,100/0/default.jpg</Url><Caption>29376_0006</Caption><Caption>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Caption><Caption>Exhibit</Caption><Caption>plate 053</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xIwB
+wKeqgk/KRj1FPjwVBHQjIqQCuexZF5Y9KXyh6VLilxScUFyHyl9KPKU9VFS4pHLKuVXd6jPNJRQX
+MrWNW0vQLQXOoyiKInAIQsSfoAaybPxv4e1AHbK64OB5kR56/wCFdHeWdtqlk8EyB43BBBHSvIL3
+R7bRNYSySNwULELnO4dB/Osq1R01dIa1PUtM1HTtZgaSycOqnawKYP5Grpt4/wDnmv5V5tZ6gNFk
+WSCePzONw2nB/wBnPpXpFjO13YQXDoEaRAxUHOM06FVVVtqNpoDChBBRSD7VF+5J2qUJ9BVzFMKD
+0rflQrlJoUz9wflRVgrzRUcqHcfZA/Y4M/8APNf5CrQFQWa7bOAHqI1B/Kp2dY0Z3YKqjJJOABWp
+IjMqKWZgqjkknAFc5deP/ClnO0M2u2YdTghX3Y/LNef/ABH8Q6rrJFppYnGjhiklzEDslf8Au7vS
+vN00uKIgXX7tScbz0zjOKwqVeVlxhfc+jLTxz4Wvc+Rr2nkjqHnVD+TYp9r4y8P3l7JaQ6rbechA
+w0gG7P8Adz1r5xj06CC7m2qJWQbh3ypHau38KeFE8RzSXLHbbx/I+xgZG4HbPA9zWartuyQOCS1Z
+7XI3kusyZKNgOAePrXDeN5Db6vb3kGnm4Zh5TSKD8nGQc9vvY/Os/W/E8+i3Nvp+mtIllaLiRXIY
+v1ySecjp0961Z/GumWGjnUdQwkcigLF94zL6Y/kffmlKUanuErR3Mbw5orapfRz3FoY7SCTzmeQd
+RjPHrzXcWMf9uot9OhSwK/6Nb5IyP77Y7nsOw9+nAf8AC6NEPm2cmkXdvaupTMYTIBGM4yK6/wCH
+viG31fwzHGrfNZjyWYjAYD7p59Rj8a2o0lTjYcnc6LTkkWyQSb85O3zM7tuTjOec4x1qwwrH1LxX
+p2nahFZN5kkzrvIQfcHvWjbX0F5HG8LZDg4HcY65rTni3yp6isxWXmipSOaKLAPXgYFcF408WW3k
+XWgeU7zyxFS0bDAbsP8AH2zXejpXhuuG3tPiJftPbh0dyQpPQ9zjv/8AXrOtKUY3QR3HLquu3EqL
+qIeSBVAW3sWXEYAHBX0+mafcWMV64nfQb0nPAZPl+uBWxFrdvGBHG8cOVBGEKgjn/CnPq0KRs0uo
+nr0Qkn9K8qdWT3/U1suhz9zpisjD+z54CRjcARxXOrquoaTrEaJeG1ZUK7ljCuVPqcc/jXT63qUk
++ms9nvUYBaVs5A7n24rPn0q3u9AWRZIGl3BiyINwB7g57fWs6NRqQpLobf2KJ5TbzzOzqN6zvht4
+6EY6V5x4tmlj1v7DcSyPFaxbIuMKGIzwO2eK09GMkV3LNctI7x8pvkLc45PP+eapXNlNJO11cLtN
+zKHeR1PBzwqjBJ9K7KEXCb6iS7jNC0mHVdAvZGkjF6ZkSNXYAnnkDPc10HhWfXNEt5prC5gMIJEk
+LjIbHH1z9Kr6fpF3phiurVkR5JPMG7+AYIB56H0+taZltLKKR7i48+YnJCnIH5cCtqlS2kdyl5jL
+CaSZZ7qR2Mss+92dyXVAc4/M/pXoHgvVVfVZbZUP+kDfjj5Qvc+5zXkQ1aZ5Z57eIttOF2Hken8j
+Xo3whme/a4neRj5KlNjDkEmlTpS9rzktqx6oaKU9aK7SAWvEPHtnND4onlMaSAvvTOQcemQa9tU8
+VyPizQBfTrcrCX45K9RWdX4RxtfU8v1C9e+tonS28iVRtC8c9iBzz/8AWqnN4h1qzLQpFEuOeE/+
+viuw1TRYk02YLbh5FXfhsk8cnHvXEalepuWOFJGEah2IOQPpmvHnG0lFRvcqV4vQiuH8VayQFDhC
+MjBCD9OtMuNL1Szgjhcz+dbkSHugBGfoO9dT4eubprdZrqO4CEna7LwB+VbdxBJdN+6gMrsAdxOB
+gdK3g4xdkrFWvqeY6ddypA01wGSYHKns6kY/SugF6EtVukINwBlS3z4x2rZv/DoMAFybe2iyABjG
+SeBWY/gaWzie4tpZJSo5TdwR3/SrXLJ3DlMi78QNcMqxRm4nkBYlzwuDj8elYV5fy6hMBM7RQ5wx
+jHyCtpdMu7O7EyRsYyuz5s5xjPfoP8a1df06xh+HcAigjS9RwZQrBick5PHauinZPRA4i6L4LeVP
+OEpZZFA3oeCPYivZPB2hW+h6NshjCvI2527mvEfBF/rVtqMWmxFpbdhuEWOg789q+iLNPKsokIIw
+o4NawT5ncmb0JCeaKQ9aK1IIkfipMhhg1TjkyKlB+v50rhYrXOkQXDb1wrHr71kt4StI3MkVnb7z
+/EEAroQ+OOadvrGVKDGpNGENHnVVCqgA9qyda8N3TWU1zYoyX0aFozGACx9K7TeajkBYghiO3BrL
+6vAbmzyO28Ja/qsQ+22UiSNjc80mdvP8/pXdwaBP9kWGdd5AwSe9b6I4bmRsfWrCnAA5/GqpYWEF
+ZCUmjiL3wK8z+ZbvGpIGUlQOvH6/rVST4f6legQXV/BBa5yy2sO0n8STivQ91G6t1TiPnZhaD4P0
+nw+hFnbgO33nYlmb6k1vk4FRE+5ppcgVasiXqOLc0VXMhzRSuFj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0007/full/!100,100/0/default.jpg</Url><Caption>29376_0007</Caption><Caption>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Caption><Caption>Exhibit</Caption><Caption>plate 054</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dEGP
+pUqAMoI/lSRjipgK5kjVgFp4WkjZXXchDDkZFSgVaQhoWl204ClxRYCF2jjI3sq54GT1o21wHxQe
+6t0sZ4ndY8sDtOPm4NWfh54qOsWr6fdSbrqAZUk8uv8A9asFV/eODRq6XuKaOxcpv2559KieMVcY
+VC4rZoyQyMcCluTGttJ5uSrKVwOpz2HvToxwK5nxdrf9npAICzS+cEbaMhMkE5+o/nSuoq7GQ+Br
+1ornUtFmMitbymaFZfveWx/x5/4EK7NW3Oy4+7ivLNW12S08ZWGoWUKi6I+y3EbZAIbpz3xXplrL
+iPfMQsknzFR1HAH9KcZJ7Ay3S1EJoyQASSenBp4bJxg/iKsgxvFekLrOgXNttzIF3x/7wrwPS9Um
+8P8AiW2ukJXyZgsg6ZXOCK+lmxtOelfMfil4rjxNfx2/zK90RGF+tceIjaSkjrw8rxcWfS6sJI1d
+TkMMio2plhG0WnW0b/eWJQfyqRgM11X0ObqMj4UV85+LvEt9deK7qC/ykMVwyjbxjBwM+o96+inM
+gt3MKq0u07FY4BPbJr5z1SU3usXlhqls8F0JWHz/AHlJPQnuPespq8bMa3OguLst4bs7mMHfDcI5
+LEHGPmI7HqBXuVrIksCyRhQjDIxXzrFcX1lokmlywLJbjc0cmeemMH1/+vXu+hanbSeGNPvJJo4o
+pIUwXYAA45H55opaKwSNkqGGDVW/1Kz0q3ae9uVijA6uawfEXjvStDQxJMtxdsuVjjO4D0JIrxXX
+dRvNc1uObXLyWC1LfMY03lF9lBonVs+WO44wT1lsdv4s+KsE0MtnpUjRoQVaXHzMP9kdqofDvwVP
+quox63qFqYbKNt8Ik+9M3r9K6XwN4a8CTxC70iVNTnjwWe4OXQ+6EDH5V6L0GBwKiNJuXNN3LdVJ
+csFYaahfrUxqF63bMUEfSuX8a+B7XxVaieIrBqcI/cz4+9/st6j+VdPH0qYVCegHzcLi6tZp9M1G
+NobmI7Srjof6j3qG/wD7St7RIH8yWxDF1gzlVJ6sv5frXrHizwYuu3vnPK0bIz5kHJAO3bx6fe/K
+uM1XRNW0GLZcobyxXj7RGhwPqO1YyWhcZWdzn7OKxFqsqBo3LhiJPQVj6/qaXU+2LayqclwOn410
+h0ganCkkXlTKg+4z7Tj+X6VR1FrMeTY6np0duYh+5uok27fZgOGHv1+tYRfK9eho9ShYXN54au7P
+XNOcrLHguueJF7q3sa+ldC1m18QaNbanZuGhnTcP9k9wfcHivmq8jup53tlIIVQxCYKlexz711/w
+y8VReFFuLPUXkGn3A82IgFvLcdRj3/pW9KqraszlF30PdWqFjVXStZstc0+O+sJhLA+cHuCOoI7V
+Yc81s2QLGeKmFQR9BUy0ogxsyBkOQMYwSfSvLvE2ua3ZzlY2EFirhFDDcrAdhxXqpAZSD0IxXB+J
+PCJ1C7KxPNI7AuWdshQBgAD6msq8ZNLlBHIwWtjeP9r068SzvHAY27cJuzyDj7uaZO8N5M+n6xaL
+DcdPnGM/Q9/qK2bbwvPpmtxBrJrm0ZgGdQQUIPPT6Ctrxb4ZXWJZHjg+ZMIrsWyGPTbg4xWMYyau
+0UpWPK73QxpLSfvJBCy4DKM/L/gPamaZ4fv9TRY47i2uTPuNusThslRyCO3XvWxeLfaPjS9ZhEiH
+mGTsR3GfWsu9srmyuodS0Wd7ScklTGeCfrR7Nu6kzZSSs0jsPhroHijRNake7tVhsJVZZU+6Nw+6
+wHr/AI16o9ef+AviNJrd1/Yusx+Vqij5XVcLKB7dj+ld/Iea6oxtG1zKTuxY+gqYGq8Z4FSjJ/iN
+WkSyYU4VGDQdx+6+PwqhEoAGcDqaKgJlB4YEfSnDzMcuAfpTEUtQ0PT9UV0vbdZo3xlG6Z9f1rzj
+xF4Jm8ORS3mjtJNp7czWzncYx6j1H616qCQPmbP4Ypr4YYPT0qXFMpNo8/8AA2gweeNWkhZZo12x
+seOCOa7d+tPxt4HT0xULtzSSsrDvcIycCpgaKKEITzDntThISegooqgJAeKM0UUAISaYSaKKQETM
+agkYg8UUUmNH/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0004/full/!100,100/0/default.jpg</Url><Caption>29376_0004</Caption><Caption>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Caption><Caption>Exhibit</Caption><Caption>plate 055</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hEOw
+BeDjqRU6qQo3dcc4FNhB2LnripwOKwSLKsF9aXEojiuI3cgsFB5wOtXAteL6402keLtR+zXUkEyT
+GaKPkYBGcr6jnkdK6vw18SI7+4NrqiQxFVH76MnBPqVPQdOeaUZpuxTi0rs7/bRtoWWNohKHUxkb
+twPGPXNZV1renyr5cGpxxzhgV7gn09xVNpbk3NXbTSvBxXNzazqJ1poPKEMcg2wb+QFzzIw9PQVr
+3l/baDpHn31yWWJeXb70h9h6mkpJ3sBOBKT8yKB3w3/1qjkiDdQDXMeFfG8fiPVrm2YxRnbuhiU5
+O0dya61hVAhkHMSnpkCrCioLcfuUz/dH8qkmk8m2ll/uIW/IUlsB5L8Tre3i8U2987sCIApVTjcc
+ng/hXnFvti1u0hWUx28r/OxP3F7n8K3NG0vU/iNr+tqLtY3iXzlaTON+7AHHQYz+lYuo6Zd6Jfmw
+1aBoZ4/X+IeoPcVlHXXuavTQ9SgvPFXhgqscL6jpzjck9shkRl7HA5HFNPiXRtYU/wBoW97HcNnd
+Ak7Ku4eqk5WuQ0HxbqOlhILW/wDKtx/A7FvyHSota1u78UanBB5Uclw52owRVY/UgZpuV1ZohwXR
+npeizQ6jpVwLnybC0t1Cj96TIQDnlieR7VwvjbXJ9X1VkMjusn7qyhU8AHjJ9/U1Z1DR9R8MfZLT
+VIBOlyPllRtyh+u05/nWf4XK3HiC6muLiOJrAAxPKudvPYAcnpihNRV2S1bqej/DzwRH4Y0z7Tc4
+fUrgZlbOdg/uj+tdk3WsTw1qNh9nj0u2kuZZIlZ2eWMruy2Scn3attutXGamrpgNgGI1HoBUrIJI
+2RujAg0yPpT3kSJC8jqijksxwBTWwj56We6+F/xLmneN2spTslA6PGxBBHuOPyNe2avoGh+NNIiN
+1GtxC6h4Z4zhlB7qa8v+MPiHRNTtobW0dJ7uJjulTkAY6Z7813Hwt862+Hmnm+fb94oXOMJnjrWd
+OSu49DSd9zl9T+DmkaVY3upf2petHbwPKsWFBOASAT/9asDwLoT3Xi+yaMNsi/euSQcKMH/AV6jq
+fiqxuZbzSTY3VxGMwzOiZUKRgnjJxz6Vy/8AaC+HraSy0qCKK9uY97XRlLssfUE5xg+g/Gom1KSU
+Xp1FGaSdzR+IOq21xJDZIQ6WjGaeRT9xsEBc+tcB4M8OXniKfUr5JTbxeYhSQkjJDcfy/SqcV/Pq
+lydOtc/Zy26Z3G4nHJPua9F0/V7Xw3pGnQCwnitZlDeayAb278A5Pb8M1Upx15tDI9CjhjgUYVVY
+gBmwAT9aRuTXm+p+Plt7q01OAy3OnFmilRQFbdxzk8jH4d67vTNStdW06G8s33QyDjnkHuD70Qqw
+k2olEl5cSW2nyzQpvkVcqvqa8U1qPxt4rvWhMVx5W7CoBsQCvc0xgVIMY4FRKPO99C1Ll6Hjvhz4
+MuLhLrxBcB0X5vJQ9fYmtPxb4g0/7LbyxLst7dGSG2I4foAdo7VS8eeNL+w1SfS4LlFkQjzJF6R8
+ZCrnvgjJry2a7+y3W4lpGdOWZsnP41jUu1yrYaTlqzrPDniC8h1r+0ftQ3Rws0jt8xPAAAXOOuAB
+71Z13W5JpZJdqS3cwCOGOSc9/wCVc94eheyefUZ1MUYGc44PfFW/DOn3Xi/xgZbKAOFfzJZZMiNF
+zzwOv0pwbXuoU431PYfAHhkaVpK3l2iteTgOSVGVGKTxnos92Im06BJJ4lcrGTtG5sfhzg/l712K
+LsjVeOBjgYrAuvEemG6uLGOZXvduY4yCBIR0APQ88VrVUHDkn1IRxPw9+H9/Z3Oo3viS2j2znEVs
+WDAerHHHtXoOl6Va6JYJY2YYQISVDHJGTnr+NW7e6jmjC7080KN6BgSp96VzzTUYxWgIWP7oqUVE
+lUr83F3OlhAHjjcbpphxhc/dB9TzTWw2eDeOY7SPxZqU8swZvOZgOu8Hpj/PauUty8t2gihSdzyE
+wT+ua+i/Ffw/0fxRaQJKPsstuMJNEBkL/dPqK+fdRsLnSdVuRYJLPp6yFI2kXG9RxnAqfZM0UzT8
+ULNa6LFbeYC00uWCngccDPfrXqfgHQNa8N6CFt9Ptm+1IJDIZtrjPQYx6V5v4X0XUfG/iCxt5LZ4
+7C0YPMxBAVc8j3JxivpNVCKFUYAGABVU6fKtSZyuZCajfxxHztHmXA6RyK+f615J4st4B4gk/wBJ
+ECFtwWWJlaH2Br3I1zkeiWOsSXVxqemIHaXCrJ1wOAeD39qwxNF1LJEo5bRfCFvqEEV/Dq13BeOC
+XkhLDf7gk55GM89a78goqqTkgYye9VtIjs4LaS3sIBDbQyNGqjpkHnH45q0/WtIwUVoND0qUVAhx
+UgY5+6f0raKBlDXGvmtUgsYd7SvtkY9FTv8AjXn2u+Btb1KeKJI1EIOSwcZ/WvUwaGYjoufxp21u
+IyvC+iromjRW+398wDSHvn0/Ctqq5ucdUI475pVmdhkRn8TiqETGo9ih2cZywAPPpSqxK5IwfTNI
+TSGV47dLdAkICJkkj1JJJ/U02Q81IzH0qBzzUMaHqTUgJoooAcCadmiiqAWkyaKKGAhJpCTRRSAj
+c1VlJ9aKKljR/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0005/full/!100,100/0/default.jpg</Url><Caption>29376_0005</Caption><Caption>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Caption><Caption>Exhibit</Caption><Caption>plate 058</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V4o
+XDDIB/EYpyDipAKysiiPbS7akxSYzSaQEe2l207bTsUlYCPbShaeBS4qtAI9lIUqQ0lFhkEm1Bls
+/lmmYDAkfTpVk0wjiiwFUjBoqUjmiosMsIKkApkYqWrZIyk45HcU84PWqVxceQd+77hwwP8AdP8A
+hUSdgEa4WOfax/dqM7vQ+/8AnvVrcBgd65TVtZigt5ypVnCuSrdHHII/AVGniZFuIozICwXABYbm
+9Tjv2rCNVX1Bo64OpIAIOaeSAMk4Fcm+tiW2e6iOJUlHA/iXdtI+vX/Jrjdd1q71kJKS7NNJ5dta
+hsBQehOOp7k1r7VDjG56lqOowabbiWXcxZtqJGMs59AK5i88cRyTnTra3mttQHMi3KbTEn97HfOR
+j61wsd/rOiapbpFcGZFG2P7QxdYyRyQM8Vi+IZ5Y9YsdQt5XYvvWaeThnJ5yfrzgemKfO3sXyJHq
+Gh+J4z4jvLC8uBlkR0Zm+XOTx7V2SssiBkYMrDIIOQRXzx4X0WTxj42FtNIRZwr5lxtON6g8Dj1J
+r6IhgjghSGJAkcahVUDgAdBVQT5dRTsnoMI5oqQjmiqJHJTycCmLVC6vEhl2z7VB6Eng+lDYiae9
+hCOu8EgZxgnj8K5bWNWjihYhy8Uina+c8Y5H+feszxBrZs5RLDPmMnjnODnDDPcdD+Vcvd6nJr15
+LHBILe0Rt8sgPLvjBx6D+dclWd0VGLbshNR1WJmAafZz8pbksCPT8awNNu501hJ7iTey7mdj1xjA
+UfnmrclvZWM0u+6t7SV4zs+0N8z+5Hb8cZrnrq5AuEgWUuqjLPuBLH14rGEbstpRj5nWTa2kVxGV
+YgOu1iD1P+f5VHfXotBYXZmKyCNlUAHnK4z7GuTe42yxMXBMZB5/iA/yalnjv5xBcRQ77feHRQeg
+9PbpW8aexNOWjudReTRaLpizfLJeyr8q4yE3evqQP61x19fedGqzTM3ljMjZ7npWjq08NqizySiV
+9uFj7Lx1P41j+G9Oh1fV0ivpCtmWDS46vj+EVvFK1yr2O4+Eugatd6uusxzPBYed+8JJXzgBwoA6
+9fpXvlYmi3lm9hDBYxxpCihUjVfuj+lba5xz1q73M2MI5opT1opgNXpXnXiOSTW/EWqWgLfZ9Lt4
+2ManG+Rucn1wB0r0NTxXkfifRvEaa7fXMN7MiXSqj+V8u5VzjOB71nOzQ1uctqM268a2gXy5G+6v
+RWb0I9fepbOSDRdKuLxi0k6jb5T/AHSe3681E3hjUseeJbgSA/eJJNJJpF1fgR3jO7jqw4z746Vy
+uG2ponZPucncTLcXBeaUtLIdzueSxPrTBjd80hHAXcBwQK7G68Gw20CTCMHIz83Wlh0AyIFaBQOg
+yOtUrLZmXKYGi2EepatFBKymPIBOcgDufyrt7jUdLllntYFQQW6eXGQQBx1Nc7PpE9pKWtA0cuMN
+heMelVWsJltWhTmST5WfB4z1P+fStLXKSsczqt+by4kj+Vgsp2MvZPSremTi3AzwqkHOa1dK8EmW
+aaS5ZkiB4CjLN6/Su+0rwPpMVoCulzXDEZyyNmtHJJWRVr7kHhTx7Z2JSKVJl5/hOR/+uvZNPv4d
+SsY7u3YmOQZBIxXmmneEI59RSOLRpLeLGWmkQqB+dem2tulnaR28eNqLjinHbQmSsPPWikPWirsQ
+RI9OOxvvID+FVUkzUu81IyQW9uRgwpj0xUK6VpyuXFnCGPUhBTt9OEhocUwuNfTNPf71pE3sVpPs
+liODaKMf7Ip5kNL5lTyILkf2KwkBBsUbvygpRo+lg5Fhbg/9cxUgfHQU4SGrURXEi0+yh/1VtEv0
+QVYGFGAABUIc0hkNOwXJi3saYzUzfTGY4pgKWGaKpyylXx7UVN0Ox//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0003/full/!100,100/0/default.jpg</Url><Caption>29376_0003</Caption><Caption>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Caption><Caption>Exhibit</Caption><Caption>plate 059</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2lVJb
+7q7cdc80/wAunoKfisLFkXl0FABmpgKbI2xGYgnaM4FS2BUtLq3voBPayrJGSRuX1HUVY2VgeFNS
+bUraa4a2jt1dyY9qbPNUEjftz1yCPfGe9dJShO6TEyPZQUqSlrRMCLZSbBUppMZpjIWSq5SXPzbM
+e2aulajccUAUWXmipWX5qKLIC6g4p+KYX2JurGuvFFjBerZG6gS6f7kbOMk1N7Dsblc342vJLbw5
+dQxxzBriNo1lQDCE+pzx9aSXxIYePNiZvTH+FYXiPxVdSaNIIo1U71Xb5e4S5O0Lye5I5GCPUVlO
+SsFjH0LxlhF/4SGMQ63p8LLAxYf6QNp7epBX64q5p2qyar8JLrUGuZbu8eSSZ0SQlwwkyqY6gcAY
+9PrXJ3Om2etXsOpxsVmddymRjlAF2lW9xjOcc49q5XTjrHg/U1maQf2fLIfM25cdcEjHeslK97D8
+z034f/EX/QZ7TxHfxqYVRraefEbSqc7hngHBxjvg16Jp2vWOqf8AHtKrKRlWBBDD1zXhst7p2t3U
+M2iRwzTyq3nxMwXI4wQhPBz17VVtV1HQZJnsbj7O6MTJZyDKt7gH+YqoVmtJI2lRUtYM+iY7qCWR
+oo5kaRfvKG5FNkvbWJ9r3ESt3BYcV5Zo3iOPV9M+3RILaZfkkUNyGHv37GuY1XV7iPUHKTvuwcHd
+6HkGtoz5ny2MLWPoHIIz2prDIrgPAvic3hSG4ldjMoABOQhH9Oleg44rRqwiow5oqVl5oouBwvxT
+v5LLR7ZopniZS0gKNgkgcdPrXkseqG402aKRhJcA/aludvzrKOTlu4616X8XraG8sbUPIUeJWI5G
+DnHGOvbtXjtteLFIYpXeJD8oKdOnXP8ASoteOhcXZnTvqut32HN5DAwUMBFCCCPX5s1asfE087Lp
+2sRJHKCBDMi7VlOc4Po2fz9q52w1+6skZGsIbqPdmQyA5ZOnH938K17m20zWbG5u7K7kxEqtLaTR
+/OgLDo3/ANb8a4588fi2NrQkrI05bye3gSaCRUlVi2P7x546H/8AXVtJvt1jLIluJps7bm1PXOOG
+TPfH5/hXMpb6ho0qW+tLLHEwLQSSkZHHTd0I/UVZivXs5Y7uO5RJM7Y/MO0yj2B+8PcZH5Ulq9Nj
+BpxdjC1bTWtX+36TFLBNavukJz8mc4xx09vrWjcavJfaHaXszMk++T5SeigYI+hJ/SumS9XWYoCk
+jxXKuBMiqWVmPHzD8ufqM1y3i7TJdODtHEptuqbBwD6Ee5rV+9aJpTaTuVvDd7dm3ltrVDveUuzs
+PkQEAZJ9eKl1J2guo0abzlkIQkrggmqWhavbQWFwiymGQ8vG56MOMj25PHbFOkSJ1E4uN5EgYknj
+jsK6YR11M5yV9DrPCVysFxhm2yqMJxxXq3hfV47q5uLEsxmjUOcjivBRJli3nctzj0Fd58MdXuv+
+EpFpLIHjlhKnvyBkHP4GqkSj2EjminEc0VIzzz4l6L/aFvbzLcGM4K4PQ147Hod5b35SPbNHJ8rK
+y5BBHX2xX0nqOnx6vpvkuSpIDIwOMGvM/E/hfVLVV+y2DTucgOBmMe7dz7Cs25RKSTPP9Rmt9PlE
+Mao5RcZkGQcY7f561Q0fxEkLXSSKqxzRmJsEqcZBBBHQgjitTVfCGrX7Bmt5YhnLERnj2GAKgTwV
+M+nNDb2Nx9o3hjdSKT2+6BUOUOWzKad9Dq9E1OW90z7PNd2moR7uIL1Q3T/axjPPXBPX0rO17UdT
+uNUjhl03TLd3UeW4h81iOgw2AB04wO1ZOl+F9U0+53JZyz8dGidAD+BrZRru0CteW9v5gbh1UsR7
+bTn9CO9c6UVK8R3dtTDW51nQr9LgWwypz5ikk/lmt+LxTpes33kzKiGRSJU2lVLgH5sHpxnnvVGK
+/wBTkndk0Tzo2bmSOQbx+FY994a1nV77zdP0a7ijH8e0kmt0ubci1tihr2kRw3e2CUPKjdjnI/Cs
++3uQo8u4Rgqtw46fiK3ZPAvigv5otLxJCOcoTk/XrWrp/gDxRcSfvtGlkRv4nULj866Iz5VbcLXO
+ftLmOKffujYYIB3D/Ir0X4UwSz+LxNGVEUMLGTbznIwOenetDSfhC82Hu0jtRjo3znP0BH869J8P
++GtP8M2PkWUYDNjzJMYLmnzX6BLTS5qseaKYTzRU2ZJVspC9nAwPWNT+lW1Y9yKyNKcnSrMnqYU/
+9BFXw5q9BFvdRuqvuNG44paCLBbjggGomkmU/wADD2U/40wsaN5FLQCZDNj5mjB7fKf8amDcDJGe
+9VBIacJDQMtbhSFqrbzQXNNATlvQ0xmPcioi5pjOadwHF8Giqxck5oqbjP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0052/full/!100,100/0/default.jpg</Url><Caption>29376_0052</Caption><Caption>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Caption><Caption>Exhibit</Caption><Caption>plate 060</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rhc
+4z9Kcqg/Njr6jmnIOKkArGxYzZRsHpUmKXFS0FyLYPSkYKoJbAA7mmX95Bp9o9zcOEjQZJNeGeNP
+H2qahK9vAzWtufuoGwzD1NQ7IaTZ63qPi7w/peReanbxkdi2TWbF8SfCM0nlpq8IPuCK+X7pJ7ue
+SWZzgepyTVeOzaRsfNVpID7Js9TsNQUNaXUUwIyNjA1b2V8hadJqOlXAmsryaFl5+VyBXtfw8+Jb
+alKul6yyi4/5Zyk/fp6D1PUSlQOyBtpYbvSrmARkdKjZaTQrlNl5oqVl5orOxRZiyUUnripQKit8
+/Z489doz+VTityAxWLqviSz0x/JAae4/55R8kfX0qh4u8VQaLatDHIPtDDBYEfJ/9evOBrtvcI0e
+8/vMhmzyT65rKpPl2KjG5uatrs+pvI19JEiIfkgRsgfU9zXj/iC5xqjzuxKnge1Sa7Le6ZfvtmaS
+BjlWJzWA85vGw5zWUYtvmbKeisT20iS7jsPP8WecVbNsFAIcIuOgHNQpGlugx1NaMqoYMAZ45rVo
+SMqabGMk47kU5JpVEd1C5SUMBCqfe471XMoErIy5U8EVJBFJBIUjx84+WRuwquUEz6V8DeLYtb8J
+peXkqRzW/wC7n3MBgj6+tXdJ8XWGrX89jhoLhGIRZOPMHt7+1fN9rqd7p1pNDZTOsbMGf0OK2/DW
+uyy+IrRbpI5WMqjzN23vQ+bdDSVj6PbrRTuoBx2oqSSvq2qxaLpct9MpZIx90dzXmusePtXuNNlv
+rWeC2hXOyFTiQjOM89eewrsPiBdJaeC7x3VWBwoDDIyTXiGk3FtBpEmqX9tJdtFc+XFAW2ou4Zye
+PatbMRnajc6hqINzf+e4c8EtgZNQ29i8jrHaNL5xOBtbdz7jArrb3xdc3dta+TokG+NHlTnK7QNo
+OO+3J/ECsu61rTdYjjnjt5rC/XC70PyOf5g1Mr2GmZGpm/skW21W2CSOMqSQQw/CuZaFopSyj5c1
+p6vLJPMqMW2RHjcxYknkkk/54qrD97B5FSlZaA3fcYLrB5zitO3uXmhyPuYwahn01VWOctiJuvsf
+Snx3AOEjhby8Y4HWq0a0FqVJ4S7GRc1Yth5sIDKzGM5wPSt6y0mS/jPkwt8v3mYgAZ7c027tYdLg
+kiLK13JwEXnYuOuR3OaL9B2KI3PgRxFI+mcVL4ftWbXLdoxumSQMAe+DUkQu5rQB5EjhHqan0l1t
+tWt59x8ouFZs4wfWi9k0ho+m49xiQsMEqMiii3bdbRN6oD+lFSIivtOtdVs2tLyISwsQSp6GsbW/
+BenajorWFpbwWgyGHlRAAkdMjvXQxniqOsa9Y6JbmW6kOcEiNBlj+FadNSTyy7+H+vxAstpFP9nQ
+pCscuwOOex78nv3rhb62v49TLTab9mVWHmRq2/aw9wK7nxL451nXZms9ODWVoCd3OHZfVj2HtXF/
+2XJbEy2187l+XMZOD+dYucU7XL5Xa5j/ANnT6lcuVTagOWY8YpzLp9iMK4uZugEYyB+NbR1KT+y5
+NNjgCJITuCDJPTqTySeaoXc2n6fAjrGfNA+6OQD6elTKfQLEcKPfRhZIdsAOdoGc/wCFaqWtstu5
+VYUCsCMsMgfWuVufEV7cA29um1JCPlj5ye2P/rVqWfgrxdrsqQwaXcqdmfMnBRR+JoUZvfQaaRtN
+LBbxopuQzMnJ3EAE9ucVQurm2muGkaRCxbr610el/A3X7mJf7T1O2tgp+6ilyf5VZ1X4NTaHo13q
+X9tCUwIZCgjKgqPQ561ooNdSudHGRS25dpJljaNTj58jJq5HPaXcyWqRiGN5F+YdevpUfhrwzeeI
+754NPiYqpP7xzwB657fWvR7T4PzWlzbTLqUOI3Duvlk9+cE9afKJtI9OtUEVpDGpyFjUAn2FFSY2
+gD0GKKRmRxPxVW80rT752e4gVnZdpbvikhmyoNWVkNXdNBY5mXwBYG3mWG5uC8i4zIwYZxx2rAHw
+zvwiqb6AhTkKMjP1OO3p+tej+ZSiSs3CPYd2eVX3wr1h+LTUbeHI2kqDux9e34de5rI0z4F3Ukkb
+a9q6rEvUW/JPsCRx9a9t8zijzaSSjsJ3Zz+j+BfCeh2ohtNNtj2aWX53Y+7HmuojMYXahXCjGAel
+VSVD78HNPEvtVKQrFnNQ3dtBfWz29zGskLjDI3Q03zaDL9avmHYg07SdP0iJorC1jgRjlgg6mrRc
+diKjMtRmb60XCw5m5oqu0vzUVFx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0039/full/!100,100/0/default.jpg</Url><Caption>29376_0039</Caption><Caption>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Caption><Caption>Exhibit</Caption><Caption>plate 061</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29elO
+TDruH8qci1n+IdZTQNHlv3habYQoRTjJJ9aydkVc0ttGyuEs/ifa3DIH0+Rcthirg4H5V1mm69p2
+sKxsLlZWT70eCGH4GoU4vRMLmhto20ryJHEZWYBAMk+1eRap4ovb3xLHMl7NDDEdyRRyFQRnuOhp
+SqKO4m7Hru2kK1zuleLrCSyDajfW0U5cKse4byCBj5RzXRiRXbCHd647VcWmrjTG7aQpU2KQirAq
+SOiNtYkHGelNKgqGHQjIq2RUbDigZRZTuoqVl+ailYC2gqrrVlHf6Pc28q7lZM4x3HIq4lLKWCfK
+AfY96HsI+fdXszol8ZI8tbyfeH933rT0bUEsZV1G3m2iJ1JIyQfUHHYiuv8AE/h8XcMrJCjITwFz
+uH1rzzTreTQ9Rmiu0LWVwNhOOEOeCf1/OvLkmvVENWZ61f6/aXvhe8uLO4V4jFnIblc9frivHhMZ
+9U2xtuDpyFPPBJIq/dx3GkT7bFFkhmbLRbhtI7+2CKyo4v7Lub2dU3RHaEIbJVd2SD/LNEKrmm3u
+TJ3O18JaPZXPib+1PNUyeWv7piMg4wCB9QPxr0O21q1t7qayuIpLeVHCqWGfOJzyuPpXkGn3oTzP
+JSJyjlSXP3R1HI56k11Nh4hvY8zsYFifoSg3P/tewrWNTkLizutU8TaZpEqRXU4Ds2MDnb9fSr0L
+rOom++rcqRyoHt/jXm01/pky5u1t0fuJkHB+pGDUp8T32l2yLaSxPa5wpRQdo9Bjito17v3kUj0s
+imMOK860XVtU1TW7aWS4nFsXztDY3j/D2r0fHFbwmprQZVYfNRUjDmimMlTpXn3iTx5i/ksbGYQp
+CxWSXAyxHUD0FdjrcNxcaDeRWtwYJmiO2Qfw14xaeG7C6Ejm4MzK2GJkBx+AqKsrKxDv0N2Tx6I4
+dwvGkk244AJ/lWdb6rd6jbPdC0imiBw4dsN9SOlO+w6NYhYnePd1WJcMzHsMCq8y2eoxzWhmWzm3
+Bdu8byD3+lcMn0BJt2LcfiHQYbNPNs4jMF2srKDj/wCtUT+ONDtIg0ltBGpB27lAz68VjXfhzTIL
+dGuLNBCrcmEhmP6c/wA+azU0rSbe6kjuIWQE8I8ZUEf8BGf1FOME5f8ADDcLEWqeJ5Ly4LWIWKJz
+n5IgMjrjH07n9Ks2aXutXMVqZJXnkOBk4C8jk+2M/lWls8LtGlvFpVxJNnCvCcNn2zn9a6Lwp4du
+rG7kvJI3jikBESSEFx8p644rpcUti42Rx/iDS7/Rwqi58+LrxkgnPTmrGheIFuLrbeFTA67WwMbT
+68dq6HxLayzny5Ihs2n5uvPXp+f5V5wiG21FossvOOnWqUFONmNq53gvr+wupPs84VUbkYB5POfx
+r0jwPrV1rFhc/a8b4nG0jupH+INeMRi4HluqsWP3iTnPavWvhtaSRadeXEiFfOdQv0A/+vVQiomS
+vc7JhzRSnrRV2LuQ3QZ7GdUGWMZA+uK8DvdHvINVX7PEI5yxyVbgHvXv5J8pgOuOK8d1iTb4guop
+HaLDYLEc++P8awryaSsIgY/Y1/f+TJNt6xoAQfyP51i3fhqWYG9aJwzNljIwz9c1qS3MFtbFLZRN
+KxyR157ZPapBMj2Si9vsFh/q84/CvNdVwd0wUblXT9btbGIxypcMSfv5VyPpkZq6ms6BcZdluW2H
+DPJETyfoKzWsbaTDECNc4XJ5PFOt7N7Sc3EKKkBHzs/3WHpiiOJjfVFNSNMT2cLi5tbyFGTkYjbc
+OehGOa1YvF11dW0RXT7uWQEMDFCSG/8A11zDayss8giheWOUAEIvMZzyM456A1r2DNBbs6vdFf7o
+TBUdsnPPXH8sV1RxEVuCTZp6wj3VjFdlDbseRHLgOvsRmvMrrSdV1S7dra0MYbgyyEKMeors4LiB
+7oNLGN4PG/5z+takk0ZhaaJDJ6OF4qlimvhRXKY/hjw2mnxoJ5WuHYhid3A+ley6SqJp6KibFA6V
+5Voh1W4ngb7IojEn3MEHHpnFeuQZW3UFNhx930rWhKU5OUiZKyFbrRTWPNFdJI1G4qN7W1mJMltG
+5PUlAc01WIFODmlowK6aDo6SmVdNtlc9T5YqO78L6FfLi40y3cYx93H8qvBzTg5xUOnB9EF2ZA8I
+eH4YFiXTVMYIIXLHGOner32LTI4lhNlEEHRSgqwXNJvLcHpSVKmtor7guyodI0eaMoNOi29wqY/l
+Vy3sbKLJitY04x93tTg5pd5qlCC2QXY1dPskkLrawhj1IQVKYoghXy02+mOKbvNIXOatJLZALHFD
+CMRQog/2VAp7NxUW800ucUwBjzRUBY5opAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0051/full/!100,100/0/default.jpg</Url><Caption>29376_0051</Caption><Caption>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Caption><Caption>Exhibit</Caption><Caption>plate 063</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29AcU
+/bQo4p6KQMEk+5qChu2jZUmKSloIaFpdtOooQCbaNtPFBp2GM200rUlBFOwEJWmMtSyKWGFcr7gU
+zaQuGYsfUigCqyndRUjKd3FFIC0nSn0i9KdTAKSnVBJd20M6wSXESSuMrGzgMw9h1NJiJcUCo3uY
+Yzh5UU4zywFMivra5VjbXEU5XqInDY/KkIsUtc9a69Lc6hcRGMJFAPmJ53H2pzeKLZIpXZQCnq3W
+mpIDeormJvGlnEsUgAMbHBJOMH0pl74nTzVMMoEbAFSDyaHJFJM6gimkcVjW/ijTXgQyzFGztIYd
+Pc1sRSx3EYkicMh6EU9wImHNFPYc0VBViVeFz2qvdTsqoIXXduBYZH3c9ald1jgd2+6oya8+1XxH
+pUQlmRVm8scKvOfQUTnyoSVzsbrxLpdmJPOuAPLALEDj8+lec+MPH/hzVEFqmjvqLD7ssh8sKfZh
+z/KuQ1p9Z1tjJclYYs5SAdFHv6msX+zxApBClz1OODWEqt9ClC2pPdxWD6l9rlhkkieMfuZbluue
+zYyRjtSy3n9nywX+gwtY3KMMvDIzIwPY7v1Bqlc6TuUSsvyD/a/pWWyPbKWhkEa5x8pxURd3oy+Z
+rc9Estfa/eSSAM1xjEhRgdp78f8A1sVTv9ZEYKN5mV4OOpb6VyOkyrG7TNbXEx3Da8dx5XPucEn8
+K6lLG2/tWz1BLO4McYLGG4l80B+Np9x14PoM1ra25MUmVrbVDcwSrljsXJRxhh/9alTVpX0nyckM
+hKqQecdf61Jq1vcaldWt3LaR2dw6kPJE2xGIPOB2JFZccMFqX32s0j/3o32A/hjn8apWd7lOKWx0
+dpq//EvjEsRmYD5tzdfy5r2LwnfQ6h4fglhj8vaNrLuzyPrXgMGt6fbsPtWn3Bz/ALf/AOqvcPAO
+p6PqWhsdJVUEZAlXaQQ2O+a1Rm0zpmHNFDdaKkBskYmtpI26OpB/GvD9c8C6hbXEnlPtjDl0ZVJY
+f0r3FDxWR4h028v7XFk6CTvuqZptaDg0nqeAtpmqLujNzuAPJYbaqHStR3kpdJn/AH816Ze+BvEc
+il4p13ema5aTwR4ve62OLnyx/EozXK1PqjZ8nQ5aew1gIInlQxsem7Jqu+jIqbpJmLAEkFcV3C+E
+fE0UgH2C4kUfxOST/hVPVPD+ryTGI6dOsgHRULnH4DFYTqVIWDkizlbPU/s5XcimKP7qjtzXQW/i
+VpjhYUVB0DcmsaHQtQuL/wCyTabPAS20Obdhn8AK7Sy+Fl2YC83nbSMgJHtP5Hmt/dnqC00Moaz5
+ifNFjnjoaz7u784feUHHQGu0t/hQ8qNn7RH6ZI/woi+EWoKCxmRyAcK/H8q0jC21x8yPMZEaW4xl
+mI71738KrGO18LvKo+aaTJP0FYegfDG4iumbUrW1iiP9x9x/WvTLCwt9MsktbZNsa9BW0LvdWM6k
+k1ZEzdaKa3WiqMyON+KlDnsB+dU1c4p4kNUSXA3HNLuqr5hpfMOKQFndSMxHRQar+YaXzDSAd5mW
+4gU+uakSSUkZjVV7/Pz/ACqLeaUOapAWd1JuqDzDQXOaYErMe2PxNMLHHOPwqMuaaZDigBWbmiq7
+Oc0Uhn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0018/full/!100,100/0/default.jpg</Url><Caption>29376_0018</Caption><Caption>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Caption><Caption>Exhibit</Caption><Caption>plate 064</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2mOMb
+R9KmVKaiBowDnGOxxUyrhQOeOOaxS0NGASnBKcBTsqGC5G48gZqrCuN2Uu2n4pcUWC5FspClTYpp
+FOwXIStROnNSyRFmyJGX2GKawpDEjHA+lTAVHGPlH0qUUIGKBWEoe48cFwH8u2s9uc/LuZs/ngVv
+YrG0DM11qt2TnfdGNf8AdVQP55oe6QLZm5RRSk4GTVECUhpsU0c6b42DLnGacaBjDUL9anNQv1pM
+aCMfKPpUoqJOgqUVKBik4UnrgVxlh4gj0g6Xpzo0k1/cOxKjOAXI/wA/Q1188git5HPRVJrzae5t
+rXxVoocn9wivJt5Kja7Yx1PL1E58skVFXR6ezqiF3YKoGSSeBWJqWtW9x4eubqwnWUZMYZfXdtP8
+jWL4311V0y3soCfMvDnZ/EVBHy49SxA/OuevhaaToFp4aWWVtXaZZGKsQGkY4IyOw3Y/CidTR2FG
+Ox13gUzT6VcXc7FnlnYDnoo6f1rqDVHRdJg0TS4rG3JKpklmPLMeST+NXzVwVopMUnd3GGomHNSm
+oW60NghksiwwM7HaFHWsRvFVjazslxeW8ZVC5Ejhfl65qz4kljh8P3bSlcbOAxxk18/XurRy3bwG
+2/dMQu5cMQM9jisJzaehSVz1/U/GcVzps72k6SwSRSBSEI5AzgZ68d/Y1i3Wr2sPxEn1IbdttZJH
+CW6B2IUH9TXELc6HPBHE93c2UqAqv7sEc9f51FJpt4ICLQyagJ/lLjIGPfOKxlN3uy0rI7uTVLbU
+fiJBLPNCIbYBUbdlSVGQwHfJYn8BWkiaVqXjq0uoHQpBJtDsfvbVPT33tmvPLXQtQisBDPbRo6vu
+iJkyfoevH8qim0m8n/dQ30Qc/N5LSDr3xS9qn16hY+hItUs57hoYbmJ2QZYK4OP84NMGqRS3Rt4s
+lvUjj8K+fVOq2TqWuFUQ9P3uBx25rcsPGGt6WvnsRKrvhV++Se+P/rVp9ZI5D3I1A55rhtF+Jlve
+usd/bNb5bb5mDtz+NduWV1DKcqRkGtVUUloKzRzXj4Rnw07S3K28auCzkZ/ADvXhN7eaat0PsKyS
+jcA0sxCjr1A7fjX0brejwa5pctlOoIblSexrxvVPAd7HdSM1qI7WPIVduS+O/tWNSOt2VFmTLqFt
+DItumlr55+cSnhWHUYPfj9c1pyvrFzbAwytGSR80Z6Duc/8A1zWdplu9ndSws0jJGvyxuCVQ8due
+2abLqmsyXEiwwFucjeMAVi4XlojVJWu2acVy9qC1zLCHB5JUFmPf5s4x7cmqWqeIrSdEi8hXaIho
+hGNgQj/ZHNZ7adfzlpr1sM/TYMc/jXS6bpj2VosgsLUEr/rDFuf65Pejks7tjuraIxI5Jr+VF3ZT
+IASP7zevNT6zc6naqEVVW0YbFRojtU8YOexz3rfttNhZo7mdJZZAOHIAI/KtC8sptSKo9vPIhTG1
+0yB+HrSXLfYl36nn1zcajcWvlSoVdioYEdSDkMO4PWvoDw+07eHrA3H+u8ld3HfFefW/g/UbieEG
+0k8gN8zHAOPxr0+GEW1tHCvRFCiumknbYzkWFNP+VhggEe4qJTUgauhEMhfS7CUkvZwEtyTsHNKN
+NsEXi0gAH+wKn3U7dTsgKp0/TmILWkBIORmMVJ9ns8bPJjweMbakZFbqKcNqjCgD6U7INRgtbdcb
+YIxjphRxTyAOwoJppNFkA1nX1qBzUrGq8hyaTGgDHNSAmiipQDgTTgTRRVALuOKAxoooAaWNIWNF
+FAEbMc1BIxFFFID/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0046/full/!100,100/0/default.jpg</Url><Caption>29376_0046</Caption><Caption>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Caption><Caption>Exhibit</Caption><Caption>plate 065</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YDAy
+elcX4zl8Q291bX2mPHFZW3zyyvINp7FSvfr+tdshDKGHIIyKV4kljaORFdGGGVhkEVlKN0XGXK7t
+XPO9B+JYujp9rqNoRcXM5hMsYwh+bapA9yfwxXoDTxKxUyKG9M81iatbafb6po8jW0CrBMVUkBRH
+lTjH4j8Kx/EnmafqLXtuqeVIuRcod5ic9mX+6fas3zRXcb5W9NDprvWrGyiaW4uY4o1OCztj+dVL
+fxfol5eW9raXizyzttURnODjPPp0rDtrE69p7tqlrb+bgbZYyCJBjqM8j6VwGqeFba4e+bSZX8+x
+wzqOMHPY/hUxqO+qJaPdpG2IxB5AJxUf2mEcGRd2OQDyK8b8O/EiW1t103Wt5VDtM68Mw/2u5r1X
+StUsdUtUOmzxCLHJTGfwFbom5dN3bBlVp41ZzhQzYLH2qbbWHrfheLWb7TZnupI4rObzWjHPmEEE
+ZP1Fbg2QxktJ8o5LMeg+tNeZTtpYyta1ZNJS1JAZp50hC9+TjNX2KKcMwB9Ca8/8SeMdJi8WWRjl
+ErWaks6gkBjxt9OhPP0rt9K1KHWLFbuIDY3SpWrGyxweQeKKeRiigQtkMWUAPOI1/lUZ1WyVJ2a5
+iXyG2ybmA2ntnPrUsAMVlGMZZYxx9BXi/ifUGW7fUHi320rYlXrxnrjjkVUnYErnZeOv7WW0tLnR
+5d9xEjXSqvPmFACeO4welYeh/FyO/C22oaAxmIwWtmDBvX5Wxj8zW/pN3ZTjw5a6BfQ3QjjlZmkO
+SqkDO5R0OT0pNV+HaHVP7a0yeGC+yTLG0e2GQfQfdPvzUO9nbcHuY82vTjeNKsWsgzjZBIQ3JJ5x
+0UewqtqenX1rY3F7dara2txKuHS3jO5yT05OP0rkvFHjCwuLmGOygc3VtL88iSARsB1A7nt2qhqP
+i5dRWBSjptO4qTkk+lc0VK92NtFKawaW6KBi5BwDjrWlpl5e6DchbKR3nc8xKePxqK0ncR3d8ykL
+CpPPqe1ang+zaW5N3OVLSDJB611J6EW1L2oeN/F1lH5slzAqgZ2CPP6msXUfiRq+tWNvp6+YN7fv
+jGcF/YU/xorXepiGJfLjRMux6VkaJFHp0cuoyD+ErCTjk9Cad7rUtLU3tJtdR8TeJZNG0+OOxjYe
+ZNPjeVUAAnP5ACvbPD/h218OacLW3lnmPV5JnLFj/IfhXJfCO50ltFljhwuqNIz3BcfMwzxg91Ax
++NejkU0rA2QkDNFOI5opCGT+d9jk+zBTPsOwMcDOOK8E8Q6ndaffTWOp2MkM80jPJvAwwJJ+UjjH
+0r6BXpWV4g8Nab4m09rTUYdw/gkXh4z6g02rivY8PsrK50q4j1jQ7owXCDcY93yuM5K+4PpXqOhe
+PdL8TWz6ZeM2najKhjaGRsbiRjKN3/nXnWt6ZqHged7YSPdQJ84kZCAUPb3x3+tVN+k+IEWS5jaA
+hSwZU5bHpxzzWPO4svluemp8LfDtxoaWF7Yp5iE7Z4TtkH/Ah1/EYrgPF3wsj8NJDfaVK88G7bKZ
+zlk9CMcGtzwRrfiG3njgkuxPpucEXp+eMc4wRz278V0uofadZ+1efPayWyAGOONCSvPdj3x2AodS
+NtCOXU8i1OWwbRrC2sb2Kc3EoZwoYFcDvke9d5pWnww6ZGzgYTDZ9MVwXiXSYdHgi+xR7fLnYrk9
+c84HtW3Y+I4J/DrmWeRbnGPLzjB/woumlYaXczPE0yanrCWNqdu9suw7Ad6ZYWlr4g8S2ukwsq2y
+ARKxP5nHeuead4hcXCv+8uSdp7hc1J4KuHg8V2b8gmZV/WtoxuNux75a/DjStNSKTTnlhu4skTsx
+bLe46fhW/pcmqbXh1SGISJ92aFsrIPXB5B9q06Q1VibjCOaKD1oqQBelKzqmNzAZ4GTTFPFOOGGC
+AR70wIb6AXVlLGFR2ZTtDDIz2/WvPPEHw9Ouo+oaPcfY7hB5ccDoAi7cgqMDKjP+cYr0VraFjnZt
+PcoSpP5VmXBfRJ2vA0kllK3+kKeTEem8e3HP5+tRJJ7jTa2PDZtQ1fw1cfYtctZ7WXoJQeG9ww4N
+all4jn+1xyrqT3FseJIjww+le132n6frFmYL22gurdxnbIoYH3H+NeU+J/hBFZiXUtD1Q2kSfM9v
+PkqB3w39D+dYypdUFyv4outFfTEJmMsmS0YX5ixPr3H415vc3KCXy4zhnILAdh6fWuivLWx0Cyml
+vS8j3Z/duQN+F54HYf8A1q5PT4ra6uWaSQp/c55HuaVPRFM05CimQSx7ZQAuw/wAdqk8J2zz+IYD
+HGWKygkD61sG00W/tIjcx3C3IUh5Y3JEgHQnOevHNZ2mXOp+FbyNtOKyTyjJDp1XJwfUduhrpjNW
+sS4u59EaNPJbyy6VcszSQjdC7HJeI9PxHQ/hWsa8h0rx5qGr3NsZdKuor6EkK9v+9Vx3Ug8j8zXr
+MMvnQJJsZNyg7XGCPYimmDQ89aKaetFICJWqQNVCO4JH3f1qZZMnpRcC2GoYK6FWAKkYIPeoFk46
+U4Px0pNiItOsl060FrG5aJGPlg/wqTkL+HSk1PT49UszbSuyxlgWC98dvzqYkNwRTSinpxU+QHl2
+vfCW613xRZXNzqIk01GHmRgbSqDnaPr61U8Y/BmzmuFuPD6zWwZfmjQ71DeuGIOPxr11YlBz1qRV
+VPujFNJWsgPn6TwJr/hqxE0Wl3mqTkcZ27Y/fYCSa2vDHw71u/Q6pqwWKWfkRyEhlH0HT6V7RupN
+1PlRXMzM0fQbTSYxsjUy93xzWqTTCcnpTSeKei0EKTzRUTMc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0041/full/!100,100/0/default.jpg</Url><Caption>29376_0041</Caption><Caption>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Caption><Caption>Exhibit</Caption><Caption>plate 066</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IWA
+G4j6VJspUHFSAVjYu5EwVVLNgAd6p2uq6fe3MlvbXMcskfDBDnFcB8XdfvreK10LTZTDLcKZZpAc
+EJ0C57ZOfyrK+Cui3q3eoX13IdlufIRc9WPU/l/OpcRXPYtg9KXYPQU/FRXNxDZ20lxcSLHDGpZ3
+Y4AApJIBxQen6UmweleV6p8T9Y1C4ePwxpKvbKcC6ujtD+4HpUOhfE7Wj4gg0vWbOHM5Co8PT/69
+NNbDsz1nyx6Cq95dWmnwNPdzRwxDqzkAU6/v4dO0ue/uDtihjMjfQCvlfxd4v1jxvrDASS/Zmk22
+9rHk59OO5rWMOYTdj6Hi8deGJ5zDHqkBbOK2URJlEkVwXQnII2kEenSvmtfhN4zgsRfrpgzjcYvN
+HmY+mf0ro/hj41vbLV/7I1EyBc7dkhIKn0xTdNW0DmPcWTnpRUuQwDDoRkUVhYoGvbew0oXl5MsM
+EUQeSRzgKMdayNI8feHNbvWtbC/3sDgM8bRqxzjALAZPI/OrepWMWo+GxaXC7onjRmB77cN/Svn7
+xlLaPqrz2IWBZAJHWNSBuwOfboDj+tbJJks7v4o2Utv4y0+/kTfaT2/lMxGQjKc/1rQ+FmqC3mvN
+JuPkkMgkXd1O4ZH/ALMPwFcd/wAJr4ggSxtNeuTJbWy4kgAKy3G6PK+Y4IJ5ZflBBIU5ya57+172
+DXZdStHe3SWRkhWQl8Ju3KuWJPGAfqKynOMdxqLex9SYryj4sapNealp3hiByscv+kXIB+8oOFB9
+sg/kK1fCvxV0/VHjsdZVNPviQiuW/dSN7H+E+x/OuO8bMz/FG6D5ytuixnOOMZ4/HNRKXu3QJa2Z
+WvrptMhlWFMJbxhQgOMtj/8AVXp3hPwVZ6bbwX97Es+qOgZ5W52E/wAK+gH6145rKt9medjuAn+c
+54wGx/Svo+2O+2jYd1FFKKKk2cj8U1l/4Vxq4h6+WA3+7uGa8V+C66fD448y5CM4iIgL9FY9T9e1
+fSWpafBqmmXNhcruguI2icexGK+Q9XsdQ8D+K57KUskttKdkgGNy9mHsRg12Q1TRk+59hYrhPE/g
+W1vdZg1e0iEd0GyzqMZ4q94A8Wp4q0RJyQZV4f611rKCOajYoowKRBGG+8FANFWSozRWZRyvjiG8
+uvDVvYWlylpHdyJDPcP/AMs4yPw6nA/TvXiHjFba01W5sEuFuktCIfNXjzXHXA9uh9wa+lruJ5rC
+aOIL5hQhNwBGccV5Hf8AgDQ9K0zSVlEx1W+nMkktzkkKqszJtzgfwj1NXdJXZFiC00/7dFp2o6oY
+X1NYAryy7WYnt6AEdO/51n+KdAkvIY/s8Em8HCuOAuepqbU/EMD2csYZEVMgIh447D2rlfBs97L4
+tCwEvasxMqOfl2dz9eleTWozu6zlt9x106qS5Lbmp4i8LoulLKq7ikYG7HXArCg1xria1e8kke6t
+gIWd2yWQfdPvgV6pr09nFphFy22NwdvFeK6zAlvdyvburRsm8Mp6HNLBzclyyCskndHWapc+f4fu
+QgJMjOfl7cgk/r+tfQ3h+Yz+HtPmJyXt0bP1Ar5itJmuNERVXe037tEHVicD+Y6Cvo651GHwf4FN
+9eDMen2YLKONxAACj6nA/GvSpK2hzSZtXV3bWUJmu7iKCIdXlcKo/E14z8ZLvwdruixXcOs2E2p2
+sgUC3lV3eMnBXj0Jz+frXmtz4i1Hxbey6trt2ZMEmOL+CMf3VHYfz71l6kqyN5EcKpLJ8zNjoK6o
+xsyLnb/B3XTo/in+zGfNvdrhc9d3bFfSB6V81/BrRo9T8bieeeMfYYi6pnlz04+ma+kvMRnZFdSy
+43KDyPTNTU3GiMjmilbrRWJQGRI42d2CooySTwBXlHxK8X6NdJZR6fcPJqVlcCeIqvyMuMMpJPcH
+07V13jiwXUPD+3yDNIrgoucc144/h1oZJjfxrA7AiNUJ4GP1I7VMqijoxqNyvf2mnXqSXcFwqiUZ
+8h/ldG9geuKv+A47eCHUJcobuMoAgbny8nd+Z/kKx/7F0yyKziea+lDcgMMA+jd6t3er3V3Gww0X
+lhf3YmIDDPIx7DNclZ+0g4R2ZrD3JczO516wi1PSol37gE4Ze/vXl/iSyFjbWUewEt8jerAHP+Fb
+lx4t+z2sUNvJbxtGMM3lDd78/wCelcvqeuQahJ5lxcSTuo+UZwAPYdKww1GpCXkXUnGS8y1p+qx2
+ep2Doke6B1aCKQEqWB+Xgc4zz71seMPiNr/iLSLrRLpIJ7N0WW5NrbsGjVWDcnJ28gdazfB8+hXH
+iywgvIPLheTLTMSMYGRjuOcCqPiK11bw9rOqabp6CO21LeN0LeYssRJIAY/XB7816tJa6nNJnOyX
+cAQQQB40YDJDE1owy3Wpn7KsYL/89Ox9/aqdlocoUtdssSZ5yea0LZ3t4rqKyYFZmDA90A7Z7VtK
+ore6KMH1L2mWX9lTpc3F5cW7gHYYZMOOMHkdM8/hXq/wd1mzk1LUdOt4SrSRicyM2S+045/76rxF
+p0jk/eN57DsM4r2H4GMlxe6tP9mWNo4kVWA6Ak5H6D8qxbbd2aWSVj2djzRTT1opEFS9jM9hLGqb
+22kqucZPYZrzDWfBvirXZTGsUFrA3DF5gcg9Rxk/lXpkdyrIDhsEZqRZlHQGolBS1Y02jyi0+C96
+JB5+rxQxjHEKsTkdOpA4zWzD8GtMhjCrqd4CM8qEHX6g16D9oHoaPtA9DU+zgNzkzymX4F20900w
+1MwBvvfu/NJH44AP4VpW3wN8Nov+kXupTnviRUH5Bf616L9oHoaaGi7JjPoKcbLQlts4KL4P6baX
+jSWMiwxYwoOWc/Vif5YqSX4dXKJIbaS2M7f8tHJznHY4OBXcgxjPy5/AVIkiIDtTbk5OBQ4RerGp
+NHikPwW1u/1EtqV7bRQbuWjYsxHsK9Es/hb4RtdPjtJNMFxt6ySyNuY+pwQK6nzxnoaDOPQ1qrBd
+nKy/CrwTLydERT/szSD/ANmrW0Dwto/haKePSLYwLOwZ8uWyR06/WtIzAn+L86Z5wx0P407iJGbm
+iqct0EfGD0oqRn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0019/full/!100,100/0/default.jpg</Url><Caption>29376_0019</Caption><Caption>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Caption><Caption>Exhibit</Caption><Caption>plate 068</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3VY1/
+uL+VPCKP4R+VKBT8VIxmKSnAEDk596U0hDAadmkxSimAZoyaDQBTAKQ5p+KYyMScOR+VAxDmmMDU
+uKQikBWIOaKkK80UWQFgUuKBS0wEIpMU40lSxDaKWigQmKWloqkMKSloxTASginUhFIZERzRTyKK
+QDhTqaKdTEY194js7GZopGXK9fm/+tVA+N9M2htwx/vY/pXLeMY9Qi1d5luVjhzwHdQp/OuDufEU
+9vdOtuEmY8NySmPQZrz6mIrRk1ZGiinse0p4usJDhVc/7vI/MVm6n8SNJ07T57lQbhouBHG4JZuw
+9v6V4bdLqN9KZZJJAxOQsZ2gflUSaVNFEQskuV+8objJ6/pSji7fE0Dp2PZfD3xXttZvrmxuNLlt
+rmDBwkokUg4/iwOeayvEPxsXSNVazttEMix5EklxP5eT/sjac/WvJpdNktlYwrJt3AuFJHI9vxqG
+SA6gT9pDvsGE8znArojiE9VsChc+g/D/AMSbPX9MF3FYyxuG2PEZASrcHr3HI5rWh8VedMEGnyKC
+epkXivni0sLiZxIsyRAcAR/Lj8BXQ6fLeWsgi+2tMrnDKQT+R6/rSlXd9GUqeh9Do25A2MZFKao6
+LE0Gj2yOSW2AnJJ/nV+upO6uZDCOaKU0UgEFOqMGng0wOJ8T+DJtYunuImDyMeDK3Cj2Fc0fhlqE
+E3mqEmb0DAV63z60CuSrhYVOrRaqSR4reeA/EISQC3Z89FjZR+uaoQ+CvEhKedp0pePpskwGX0PP
+Ne8nkcHBqLEwP3lIrmWXRW0n+BTqt7o8YsfBurzTNDLo0iRt1Z2G0frmoJ/hzr0lw7R6fsHr5q81
+7egmz8zDFSqCBhmyfXFaRwEU7qbF7XyPI9G+H+tRxgXNvBFk/wB4Z/GtS3+H+pfbxJLPAkKtkADJ
+r0mkwf71X9Qp3u238x+3kMgi8iBIsk7RjJp9HakNdtrKxkFFNJ5opARq3FPDVWVuKkDUATZozUW6
+l3UASZpc1HmlzU3QiTNLmo80uapMB+aTNNzSE0xjyaaTTS1MLUAOJoqPdRSA/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0044/full/!100,100/0/default.jpg</Url><Caption>29376_0044</Caption><Caption>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Caption><Caption>Exhibit</Caption><Caption>plate 069</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3S1G2
+2iA6BBj8qnqrpribTbWUdHhRvzUVbxUjGnNJzTsHJ5GO3FIRQISjNBooAWloFFABk0nNLRzjjrTs
+Mac1GwNSAP8AxbfwoIosBWIOaKlK80VIFXQB/wAU9pv/AF6xf+gCtPFZ2gqV8P6ap6i1iH/jorRq
+hCUhp1Vb2+trCAy3EoRe3qfpUyairsNyYiiuH1Xxvvt57e0ikidgVWVSCy57gdM1yXhvxrfaH4hS
+z1nVnfT532g3z7mXPRg/btweK54YulOXLFlunJK7PZaUVQvtY0/T4g9xdRJn7o3DJrhdW8Z6hDdC
+5ttV09bSKQMYSnzSLnlScnB69K1lXpxdmxKEnselUleV6n8V5n0yG70y0CBnKnzPmzg4OK1fB3jW
+/wBX12TT9SktY9kBbC8EvuAA6+mTirVSLdkS9HY9AFIaI5ElXdG6uvTKnIpxFUMiI5opxxmikBX0
+kY0iyB6iBB/46Ku1XshtsoB6Rr/KrFMRzXinXJ9Lh22zRo5GS7jOPpXkPiXxM6/vbq9aaRueDwPo
+K6P4hasi6jKjy42H7uCa8wW1XUbm7mvmeNIxvVVH3l/GvLxHvTbnsjohaMbl+x1S6uYpntraVkcg
+GViABnocVmX9udRusO9vLcfdXzGYAH0JOADxXQjWI7DSZBJGkLkBIXEWVdeo+oqvdPbx2LzrJGs0
+hBVFbOz3GemcGuWE2pXUSXVZUstLlmhlgbV7m4nwqQojARq2cYLMc49Peob3TB5amzvJBGi7JFnd
+SWfvtxxirlne2FncXF2zsIux8xRjockHJPzcgDH1reN34d1XRENh5n2vdud5kIRF9EycdhyM11wl
+K92tCeeXc5a0CW2nR2Ydm3yDBY4wTzuAzxkdPzq1Ckulw3E0gcTtIdoVvm2nufSnWsLSzzmZW8vd
+lHYjZ1x1B64X8s1f8k2expZYZklYHbGyttJ6dPp0/Ot1O7sZW6nqfwnuzdeFpdz7mW4bIJJxkD1r
+uzXA/Ce2Efh+7nG3EtywBXoQO4/Ou/Ndi2BbEZxmihutFIoSJdkSr/dAFSVEp4p4NAHjXj+wf/hI
+5ZpLDzrcsGcl9vye3vXAXlnd3C7IDNHZZzHHnJwe27qASa+nL2xtNQhMN5bRzxkYKuuaqw+H9GhK
+mLTbZCowuIxwPSuWpQlJ6MG7nzBFpxtIZZfJZlQgYUZO7nb+v4Vs6d4dtrwq17amSYgFmd9zADn8
+Ca+jYdL063GIbG3jH+zGBRJa2O7D20Yz6JjNQsPU6PUcXFbnznrukWttZbIIY2Ocso/Wq8cc+pWM
+xVRArJtRc52Bf8a+h00HQ97sNPjYt94NGWH5GpIfC+hQszR6Xagt1/dg1UaE0rNjqOM0fPjR20CR
+tFsMMgMku4kFfYe+R06nNNSCbyVJwJps7ovXnOK+hpPDOhy/6zSbRuc8xA81ag02wtuYLKCM+qxA
+VqqOmpnZdDA+HulXOk+F1iu41jkllaUIOMAgYyO3SuqNGaQmtxkcmd34UVDO+1wM9qKQxytTw1V0
+JxTwTTuBPuozUQOaWkA/NLwetR0oPNFxEgwOgxTs1FmlBoAlzSZpmaQnmmMfmmlqaTTSaAKl5Ltm
+A/2aKz9WdlulAP8AAP5migD/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0021/full/!100,100/0/default.jpg</Url><Caption>29376_0021</Caption><Caption>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Caption><Caption>Exhibit</Caption><Caption>plate 070</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2eVvK
+iLliAPSsi816SAHy4lOBnk1o6pKsentJuUAkYJPHNeca5r9vaq5MyMysEZc8gnpXJJdi7mmnxAvE
+k/e2KbCeuSv4dakh+JMTzGOW1EQ7MX4/HivLtRv2N8JZZRMVO5YVPX2HpWFe3U13ALq6llgZJSss
+aMy7QVyox6e9TKyBXZ7n/wAJvcDJH2Vh2wD/AI0+Lx/Gn/H1DGgHV/MwP1rwePTb4xs8TTwqihmZ
+Zj/LPXmorCW4u9Wjtr68uJI2GMs+7ZzxjPfjrURa7j5WfSmm+MNJ1NS0dwAM43g7l/MVvxSRzIHi
+kV19VOa+ZtPcaf4gmtIJTHFIGXCk4Dr0P5CvQ/CHilE1qJLid4oQNkiMf4iMD9a2haSuJ3Tses7T
+600qfWoTqdiFDG5jAPAOamiuIJ/9TNHJxn5WBrTlQXEKn1qGQSg/LtI9zVrFMIpOI7lT58cnB74o
+qYrzRWdh3OQ8cLK/gi3CNhv3RJzjtXiV9BLI0hkLMX+Ykc817Z41Eg8EWpU4dUj64/uj1rxp7C5n
+kLebgH0pymovUhxbKEJEMTtIiudwXL9P0qKZGuIYyUKneEPH3x6c8d+9b8Olrbx7rmZjDIRknA2E
+dG/z61E+ky3lrcXEVlMVB3RSRjIb1LAc1zOd5XRslaFi/Hf2lx4bW3jgjiZWeMuj4R2U8HrjkD+V
+czahrfXIpJoX2oclNuD7CrBt/O0ttOYPbyrIZFBXg+oPpVmygv7DRLnzpTMJoQlvFwcMSOfbAzWS
+5Yp6lXd7WMyaO607XzcXURKFGmRM9SeP6k1uWd7HeT5iO109eCR2qnqtvcLoloAUdoQVeSQFRgnO
+0euDmsWK+QKp5Q+o7fpXbSqRlHc55RaZ67pviSKS3KXbLHKhxgjhh6irza/bW86XEF95cg4+5mvK
+dPuibcRGTewJIIPP61sJeXSlT5Ub4AGGXn8xWyXZgj12Px3bmJd6qzY5K5wfwqaHxhb3DoA6oCcH
+PWvPLW4a4t90trIjD24/CtCw3NLHsgQLkY3A/wD1qhzV7F8p6uCGUMOhGaKIFxbxggA7BwPpRQI5
+zxjZrdeEwmAGUIVOOnFeWppl06kRFZGxwPuge9ez+IoxJo0q8ADBrzKG+igvhAqKVXqfUVlVSY4m
+Dfi0061bz5lEwz+6JJJOO3p9a5Hz5L6JTAGgljbJaOQ8+3tXU+I4Y7jUY5EaM70ySvXqetYM0Mdm
+0eZFjDDlcEsffFc8IRjr1Kdy/pqPueZ7ySR9wdizk7/qe9XnZb+EyzTlQrbgkY2hSO3v+NcvGl4i
+P5UU0kQO+MnAxz35qrZwXGqXJS6uJBubAWMcAE46UnCN+ZglLax0GpCOUx/aGmML/wCq3gkNjjj8
+asWGnabfjyvKWd40w6CP5gvWrfh/SzZ6yvhrUv3tm6edaSD+BmGcjuOc/jVKSO+0LUb+1U+ZMScb
+h+RJ9uPWr2Vkxpa6k0nhvT2tEuLTzIpHUOoLbgO+K0rHxDdXASzeKBpUGM7AC+P61x+j6hdaXObK
+4LSW0h2qDyVYntV6ZLiO6W8ihkTawYEr3961u1o2KyZ3DS3Eg+eIIMfw5ot4sTRsxlKhgOH3f1rH
+tvFSCH/SLZ92OqkYNW9P16OS5gZrVh84IORUq63QM9si5hjI6bR/KiliIaGNh0Kg/pRXQQYHjbzT
+4an8osDkZx6V5Hbq8EuY2Zn/AI9wyFNe3awM6RdcZxGWx9Oa8dGt2cNyoxyzZO5a567aeg0RX4SV
+kuZkASOMg8HG0c5Jrhra5n1TVJZY7d5QThUUcBR0FehX2t6fJaSwtbtNFKpVtp/Os2z8QaRYjZZa
+e2QuOE2gfp1rl9rJRa5dS1ve5XktdVNnlLZYD3I64/Gq2lRQWlrE10XjgJJdYYi8hO7kE9FrpYvE
+Vo2zz45I9ww3oPwqvqEml3dtJHBM8byjErBNu8e9c8aj2ktDTmd7la5kfWdZi1a0kNtbWyiJFC5b
+C8gfX1+ta4u7HWVa9Zwt4ABKoODwP/1Vj2dtFDKEsr5EcEAfvM80mq2F/et5jpGZEX5JI0w5+pHX
+6fWt41VJ2EkvmZ2o2UNzL5iJL8pB+Yc8EfmT9BW7pmmu9hGHtpIpMfeM+7P/AAHJqxpElosbeXZt
+cXKKAwY8/wD1uh/Krc11KF8xtLUgdFBHy+1OpVbfKkOKsMNpKEWFrWORSOfk4P59Kjs9CjkvYgLK
+MMWHKyAf1p1xqpERD2Mm08kBiRU+grDq+t28KC6TDbiB0455pQu5KwSSPWoV2QRqRjCgfpRS9OB2
+or0jAZw4KkAg8EGuN1z4fWmoPJLahEZsnaxIwfYiurV+KlDcd6Ukpbgro8b1D4ZayuDZxYx280MP
+yqg/gXxBDCcW16sgI3BEVh9Rg17pvIpRIcVk6a7sd/I8CPhLxhAoENvO24knfF/+v0q5Z+H/ABfP
+DN9r0tXUdIjEFLE/XAxXuPmGkYlxySPocUlBdSX5HgieHNdVsTeEZww/igbb/I1estLvImBmstTt
+iOSjwmTP44xXtiod2TI59s1KrYGKHRjIak0eTW638cMnl2MweV8tttwp+pJJz+VV7jTddWZzBpt7
+O8hyRIvyD9K9i3mjeaI4aK3ZftH2PIrLwb4s1CT99ss4j/z0YDH4KK9G0Dw3baFb/KfMuWA3ynv9
+PatcsSKjLH3raNOMdiXJsUtyaKgZjmii4rH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0035/full/!100,100/0/default.jpg</Url><Caption>29376_0035</Caption><Caption>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Caption><Caption>Exhibit</Caption><Caption>plate 071</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3gEgd
+z9KUMSM4I+tKBSGpsAu6k3H1rxjxVqmotqN9dzXUwMMuyK2UMBGATlt3boPQ1oeHfE+q3Go+c2oT
+XUWBCYTh8OXQAkD/AGd3Pqa5vbxvY09m7XPWN1G400CnYrexlcXcaN1Jik3Lu27hu9M81SQXF3UE
+mjFFOw7jWO1STnA9qi81WIUFsnp8pFTUlJodyA5zRUhFFTYZOKjaSNQSzqB6k0/cFTcxwAMkmuA1
+fV7e6uJVtbhJApIJjbOPyolLlBRuYfxZktI7y1YkiRoCy+X/AMtGzxn1rD8FeJv7JhE19oRmJfcL
+iOTaQB0+XGKr+KvKuhazTT5lhLoRnJCnvj8DV21vrA6JHLBKpH3ePXPSuKo7SckjpiuaCiz17SfE
+Gna1AslpONx6xP8AK4/CtSvE0S2lxIJOSc7s9K0LbV7y2tJo9PvJlljG4FnLDP0NXHFfzIylQ7M9
+crj/ABRMIdRgmWaOCSF1KO+Rlj6kdevTpVnQ/FRvdNgublUPmxqwMfHPRsj6g1yV7dS6r4kurqOT
+dbwzLJCWUHaQq9M+4redRcuhnGOtj0qwnnuIN08Pltxg9m/DqKtVxVt4wvVjaKeGFpAflk6Aj3FR
+X/ibWFiKmEQLIPlnUBhj2960hNNA4tHc4oxXntr4s1OL5HmSXnALAZxXS6HrNzqNy0cwiChcjapB
+z+dXck2yOaKcRzRUFBLjyH3AEbTnNfPuqQ21nqU09iDFL5hOIwSPoR0r6CkG6J19QRXzvqu621O8
+yrkB2AwQc8/WufEO1jSkr3GaZd6a8st1qNpHNO0rHczn5eeABUjnSb68a3SZ9OtnHmDAyN+R+lYp
+jjklKQSMG6lUXH6nmk+ySu6gBVQA/M7Drx/hXK6mupo4tbHSf8Ivq32cvp2q29xFjIKjk/TBNR6B
+qDQW07zrIVz5buw+63v6VkWf9qWV0Us0uR23xLjcfqeMVuaM2t2kd1ItpCUnbMq3L5aQ8/3enU0n
+UpvfQlOa8yxY3Is7Ce3glYkyEoCfuK3JH5k/nVvT78WsEjMgkkKkKM8ZAJH8qxr+6t7WSO4ayltJ
+d2ZFSXzI3Xv15Bqe11jRnnmi3EGMFzlDjHT+tar3tmRdp3N4a5bywhWtik23cVI3DJxnmr8mofat
+KS0PyspdwO+AM9PxrmZLzR1uDG97AsqkhgSAQe/ardpJaRTyPFcRywFc5D7tvYjPvmtYpxZXMpKz
+FSOQuByynoQpH611/g57qPWHhkTMRQ4YHNc/CNMjRZfNxE3QnnFdBoGu6Fb6lDbW8jNcTNsXj/69
+dEZJmTTO8NFFFUIO1eMeJdCeDVbnyIl2tKWy9eyg1zHizT5ZIhPbxM7fxBFyawxEHKGhdOVnqeTP
+ZXEcbLHG7OerBeB+Aqn9nnWYx+RIHwM7sjj15robhrgyss8ptk6bVXLfmen5UkK2qFrhbSRzjaZX
+cl39gSc/lXj1I30udSZmaal3Hv8ALO/J2lVAO38atJdyQN5ZeUSHqOoq3JqGnw2ztDbC2YrkvcqV
+yfTca58eJohv8vTJXKnCPGNysfY4H8jUKjd3E5Mmumtpd3mSDew4ZqrW/hiSVMtI6REDJBByBz2p
+zMdTJudS86EpIDHa25VWxjqWI/Tir8l7YRFEh0zUPOk+6ss4GfpgGuiKnFWTFZHJaxpNpaXWy3Es
+rHqQ6k59arLcLBY/ZoQwmeTcxz0A6Dj6murk0C91W5R0s4tOjyQ0ks6t+QABqpfaTp2mx/ZoQbiY
+thp2XAJ77VHJHvmuyEnbVg7Gbb63eR2i2rbGwxYmRSce1dP4CY6n41sEMb4RjIzDGPlBP5VTsbC1
+4jtdPlmnI5bYxJ+mRnFeqeAfCR0aF768h23kvQMOUX09q1pScpbGdRJI7eikorpMCMNTs+2agDU8
+NQBBcaVp94cz2cbn1I5rPbwfozk74Hb2aRjj6c1s7qdms5Qi90O7RyWofDXw/qLq8y3I2Y2Ks3yr
++BGPzqH/AIVzpEZwbq+wRj5GRePqFrs80bqn2cOwc0u5x1r8PvDttuIjvHyc5eY/0rSg8E6FGd62
+sgbGMtK2cfnW+MDkCnZqvZw7BzS7mUPDGjBAhsUYDpvJP8zU8Gh6Vbf6nT7ZPcRiru6jNWoxWyC7
+GRwQQ/6uFE/3VAqTNJmmlqoQpNFRluaKQH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0016/full/!100,100/0/default.jpg</Url><Caption>29376_0016</Caption><Caption>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Caption><Caption>Exhibit</Caption><Caption>plate 073</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3hadQ
+BTsVNhjc0ZNLtwSck5pDSsITNANJilxVAOBpaQUvWgApDS4prpuH3iv0oGIaYRTwm3PzE59aCKAK
+5BzRUhFFKwE4paBS0wEpDTjTTSEJimu4QZJAzwM+tOPSo4pI7qJuOMlWVh0PcUXAhtmKqZJpCS5C
++wIGOPxq5Vby1WOSFuY9vA7470tpN51srMwLAlGPuDiknrZiLFFRLKXnZFwUVRk++Tx+lPVg2T0G
+cD3qxi4pCKfSEUhkRFFPxRSAcKdTRTqYhrOoOCwB+tJx6ivG/GXifWrLxHdxxmbyUkwgVtoxVCDx
+prUgUppdwwPDM91x+oNYuvBOzZfs52vY90quytE7yIQVbqpP8q+ddR13xXeSKWv761LMdkdsWVUA
+9SvWqNhqfixNWivr69ub94GxDE8pbaf7zew/nS9tC17k8kr2se4+IvE0OhhJ5LlUQ5UCTnBx0Pft
+XD2nxRghv5YyrIDJn6cZJA98CuF8WDXdU23+oB2kLbQsIzjr1P8AX3rCTTpRHuEEkdwsfmDfzmsf
+eqe8paDcZR0se2WvxCgkujFaTAvODtDgn5u+Men867DT9Wa6ePIzjgk9fqB2/wA+tfL1vNqFpIrr
+DNGyZ2lRg89ea6rSfGutWKq3zgE9Dnn3pxm47srkk+h9NDkcUVj+FtTbWPD1rfMfmkXkc8Gtk12J
+3V0RsyM0UtFIABp1Rg08GgDgvE3ho3epSzy7jBIQcKfSuPRZ9OV4GiVnDsBIxB4JOOAP/rcV7Y2G
+GCuR7ioWsbR8FrWEkHPKCuOeFu7pmqqu1jx46sIXZCqEnniMLj86kQtdxq7WhGTwGOM/lXqs2h6X
+OweSwgZhyDsFSLaWUWMWka/8AFZvBtvRjVU8ouA6QbUtYgBywOffNc2LHUJ5WliRgJACiBNwA9+M
+ivfBb2jn/j1Q/wDABUkNvbqMpbIn/AAK0WE01YvbM8Mh0O/uIttxlVyeCn681rab4EkuJg3kll9S
+MCvYfIiznykz67RTs44CmqWEXVjdd9Cno+nJpWmRWiAAIOg6Zq7RnikNdSSSsjHfUQ0U04opgMDU
+8NVdWpwY0gJ80u6ocml3GgRLuoyCMGodxpQxpASqABwMU7NRZNLmmBJmkzTM0ZpjH5ppNNyaaTQA
+paioiaKQH//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0037/full/!100,100/0/default.jpg</Url><Caption>29376_0037</Caption><Caption>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Caption><Caption>Exhibit</Caption><Caption>plate 074</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Nc4p
+TmlUUoWpsMjyaXJpxQlgcnHpRigQmTS5NGKXFMBQTS80gp1ACU00/FMdCwGGK/SgYhzTCDTwhXOW
+Jz60EUrAVWBzRUpXmipsMnUU8CkXpTqoQ00mKdimE4ZR60bCCihSGXIpwFCYABSigUtMApMU6kpg
+NxSEU7FBFIZXfg0U9hzRUjJF6U4U1elPFMRkazriaQoLW8snuozXI3HxMt/MVI4kDbufMbbit/xX
+fW1lCGnYqTwDXmWuz2bxF5jEq5wGdeT+Qrjq1ZqXKjWEItXZ11r48uAFYwxSQ5JPljLYxkdD61ot
+47WNFdrJyjdHB4NeIpqJS7ZbF0WNQRmYEr9RkcVTvba7eW1a7vDMiA7CsmQOc8elZU60k7TdipUr
+6x1Poi18Z2Uo/wBIjeDPILdMVp23iLRbwZt9WsZDu24W4UnPpjPWvnFPEuoRxGIvHdxxqUw5+YD+
+tQpvu5C1s8ELEfNAykEY/E1vHEpfEJUG9j6norwrTPGuuWlokTtJcqihNyS5PHHQitG0+Ilwr7D5
+6uOCGbn8ulbRrwezE6E1uj2TFIawPCesT6zpzTzq4IbALLit81pe+xnsRt1ooJ5opAKh4p+agQ8C
+pM0COC8feG9R1q6glt1mliQYKROFI/PFcHN4PnO7ztD1NWX7pDghvyJr3gse2KM+uK554fmlzXaN
+Y1bK1j5+Hh3V48pbeH7ojOT5mcH9aqt4F1+VwU0qSFeeA5IGfbmvovPsKaSwz8qkfWoWEV73G672
+sfO0Xw38RM4b7Oygf59Ksv8AD7W0dJGgkfbgbVSvoBZJGOBGB9c1Kpfd8yqB7Gr+rLuCrvseGJ4L
+1+F02RSlV6qTxXR6d4Qmu1VLmx8ojk5HBr1LikJ9MUfVYdSvrEzM0TR4tGtDFGWJY5bc2ea0zRk9
+6QmulRSVkYNtu7GHrRSE80UgI0bgU/NUbWUyWsTnqyKT+VWA9CYrE+aM1DvNLvNO4EtKKh30u+lc
+CcUuag307fTuBLmkzUe+gvTAeTTS1ML49aYXouA8tzRUBkGe9FSM/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0033/full/!100,100/0/default.jpg</Url><Caption>29376_0033</Caption><Caption>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Caption><Caption>Exhibit</Caption><Caption>plate 075</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YZoU
+MByxb608CjFSA2kJNOxSEUWATJpQTRio55ktoWlkOFUZJo0QElLzWB4evLm/uZ5pnbHlp8hHCkkn
++X8q6HFKMlJXQPQbSYrIk1Hf4itrJHHKOxA9sVs4ppphsRkVB5TjGZnPPcDn9KtEU0imMrleaKmK
+0VIEwpaWiqENIpMU6jFADcVUvYJJIJUj2vvUgxucfke1XKZLAkwG4sMdCrFT+YpNXA43+3JNMtJh
+GFjuoGTfDKPlcDII3DIB9KWP4kaZd3UCW2VtyWMssoI4HZV6tk9+lXPHF9a+HPBOpTx2qMXjKLGo
+xvZuMn165NfNMuq30WxtiEJguiJhQOO/rmsknH3UUrPVntcnjGy03Xv7TuyIomyicgk5IySBzXf2
+3iXRLu2S4h1W0MbjIJmUfoTXytdk7EE5kk+QkFmyzHPr/npU1iLSSIoWxvYFRg7s1pDRDaufWEF3
+bXalra4imA6mNw2PyqWvmbQdZu9E8S2rabcGINIqSbz8jKSMhvavoCx8VaVqd0tvZTmdycEopwPx
+qtyWrGxiinYopAPHSua1jxfa6VO0LB3cHGFTPP1yK6RxmNh1yPXFeR+KNBvJr9nfZFCv3SZN2P0z
+UTnyK4WudFJ4+ZR8lrJu/usgA/PdU58dgAf6HKSRk/Jjn0615deW8VtJD9pPnZGGUn34OT9DVeS6
+hMEXkzfMvDeW2Bn8653iJWukVyHqI+JllbzOl7ayxjPy4HJ/OtC08d21/F5trp16yZwDtXn8mrwm
+S5mSMyCQumdoClj/APWqKLWry3cNBOI3xgbhn+lONaXYhx7Htfia60zxFaRW2qaTqoSKQSL5YXrj
+HPze9ZOp6loB0u5sovDkkTy27W4Z9i4XJORyec89Otecvr2uXkQSR5JEHpEcUJNegiRtMjkU9C8T
+L+u4Voq0Q5ZHLadYXuqakLOORjKgZiHyQfyroP8AhFb61kSSWSNNhBwqH+vNWYLmy0+/bUWsI5JI
+0WIxlsLkjOe/uK0n8aR3IKDT4VTHAMjHn8qp1EXZmJo2lXE2uTRhV3xKzor/AMXevTPhtPftfukj
+RpbjI8tVVTn+dcnHqMYaG/jgQSjKECQ8g++K6bwjr32O4tbNLRJd7Aec9wAeT6YoVRXHKOh6yRRS
+0VoQB+6ee1eP+MjdG5kKOzqpP3mJJ9q9e4Iwa4rxdoE1xtNlE2G+9tHSubEqXJeJcLX1PEL64dtU
+WMwykiHOF7nn/Go7gRPCJYCFWLGfm5PrxXU3vhSSe5f7Tu84DCqASVFRR+BboqQVWOLdv+Trn8Tj
+9K5Y142S6mjgzmbi5EkF0umRs0kzKxKHtjPT65qgjQrp5mngV7rorKT09SPXNeh23gu+kto/tc0S
+eiHBKj0JHBqvqPgOcRbY1TGM4jQLu9s8YpqvG9iXBnH2/iK/021wk7Tvxu3fMEJPTn8K1LDWX1je
+Zkw6Ae+OvY8DpWhZeCNSKF5rKP8AeY+Viz4x+NW7XwSG1F98qwqoyY0HU+5/OqqeytdaMIqXUzJI
+oARAxLDbuYFwMn6gVUg0uGaTCoxOf4c4/M13lvoVrFHt8pGPGcDOfxNRf2O4kdbSNwewAP8A+qsl
+Wi+ppY52PT5pFKRQGNAfk8zg/lW34c8OH+1bVpZ38xWDAR+ta1joGpeUXdQ0p4C5/nxXWeGvDUlr
+It3en96OVReADXTTUpPQmdkjrB0FFBorsMBgal3L0JFQKxp6sc0AI9paytveCNm9SozTJNMspRh7
+dCPTFTBqXdWbhB7od2Uv7E0/IP2deOlPbTbIMGdR7bm4/KrOaU8jBqVSp/yoOaXchW2s16BfzqL+
+xtLlZpfssLM/3nA5P41aVFToKeDV+zh2FdlMaJpynItU6Yx2pw0jT1YMLWMEcgireaQmmqcFskO7
+AKkYwAAKNwPQ0maaWNWIUtRUROTRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0022/full/!100,100/0/default.jpg</Url><Caption>29376_0022</Caption><Caption>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Caption><Caption>Exhibit</Caption><Caption>plate 076</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RVx2
+H5U5eR90j6inAUGpGJikOadmkNAgBNKCabS4NFgHZopozSjrTsAtIRTqSgCNjtGTn8BUe8McDPry
+CKnIppFAysQc0U92VGwxxRSAtCmsQqlmIAAySe1P7VzmrXksKXKqcxujKwPbIobsBeste06/n8mC
+YtJuKgbTzj3xitIivKtA8eWWixy2TafM6pM6idNpBGeOpB7V0ll4+sru+jhVJgspwGdQAD+dZKtH
+qynB9DsKoXGprbXMsDoQ6QtOp7Mo6/jmmw6vC5yzKVPIIIOPY4rhfFU8uoeIILZb6aGOTMUUiAYy
+2PlYZGVJFU6iSJSuelQSpcQJNGco6hlPqD0qXFUtKN79gjXUIoY7hflIhJKkDoRnp9Ky9T8a6PpW
+pnT53le4UDcIoywXPqavmSV2JJt2RU1zxO2k6nNYtHKVkVMTFMJAWO3czenf6g11SMrorKwZSMgj
+oa8xt9XGv+Pobm0kuFs5BGkkDkASLtbBK/Uf416ciLGioihVUYAAwAKIu+pUlbQKCKcaMVTEY2pS
+MlyoVcjZ/U0VJqTFbhRj+D+popAa3avN/ElzeQX8vlLIVPZSD+lej/wmvFPE2t3UWtzxFmjw5G1E
+DGom7IaVyrLJFCsUn2bEwJfbgEAZ9Pfmr3iIymTT4bWWb97EJHSM4wSBgDH4n8awZ9Q3TtGZpdxV
+TnYueBz/AFqOHVhd30KzXDxcLh2GMbenP+etck46aGsZO+psjRteEBMf21MjqHI/WqF5HfwGC0mk
+ckSK6PKcsuGyQT+tSL4g1VoUjm1I7GGQZA3P4jrU9xd6ibhNstrK4UeW7y4YAgdP1rJQd1qDqLsd
+lB4rk8oYlOccBZBn8qxUubESX9xdxCS6vJ3MLEfMrAYH61zkyzzxEXSqcHdxMDgn3qvdQiOLCHGH
+GCZBwCM9j611t8yszKHuu51OjS7L+ymhgjW9ijJc9DtPIHoeCv5iuxXXtSXlwmfQ4x+gryeS5Nnd
++dDJIkmzZ+6fsD0/Sri+JtUMIEJnJ7lguaqF4xsipavU9QGuXrP8y4HfaOP5V0dnOLi2SQHORXkm
+n65qrzxlwp453xj+lenaBcS3On75QA2ccDFWpNuzJaJrxEaYFhzt/rRVmSJXbJoqhDyflNeYa5d2
+iXsouViLOx2gLyfwr00ciuN1jRngvWuorV5dxziOIN+YrCuna6Lha5ws9hZjNxsEasNoJHOO+B1q
+KPTLSaQE2+/0MpJ/QV0lydTg3SPbzBP7rRYA/DNZrahczuBCwjGOrNgfpXDKrbc15ShLp80QaKIW
+MUZIOPLJz7nJpt5p95eTbYrmJIgqgskeMnAzV0Weuyy7hewvGf4ViLj891adhoV+YcOXdv7xjIpQ
+quWxLikYEHh2BVYT3MsueuPlzV2Hw/bS+axiBLuGw+cDGf8AGultNJmjO2S1cMfTOKtyaWyHc0ZV
+QP7p5rZTkldhZHEr4fN5K6x2SoFLfO44HJqSDwfGpB82RmHUDArsI7SYjcrO6HtyMVWnEtsyqttO
+Wc4+QZI/IUOo3sUkU7DQ4BModX9OWP8ASvQNMs4bK12QxhAeTgViaZobu/nXMtwSf4CxAFdJHEsK
+BEzgepzXTRUrXZlNocRk0U09aK3IGK1ODe1VYnJRT6jNShjQBKQjDDKCPcVF9jtM5+zQ59dgpdxp
+c0ml1AVYoUHyxoPoKXzEHBXH4UmaXNFkIcJVOSFJ/CnjaQDjr61GDgU4GmApjjbqin8KAqjoAPwp
+M0Zo0GOJxTS1NJppY07gBbmioyTmilcD/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0047/full/!100,100/0/default.jpg</Url><Caption>29376_0047</Caption><Caption>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Caption><Caption>Exhibit</Caption><Caption>plate 077</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2RI81
+IsWR90j61Ii81Jg1Iyv5JzSmOp6aeaQEHl89acI6k20AHNAiPZTtlSbacFo0Ah8uk8oVYxSEUDKx
+gqq64/5ZSfkP8a0sUxxxQBnGHmirhWigCwo5p+KVBzTiM0NgREVWuLyC1uLeGZtrXDFIyehYDOPy
+z+VN1LU49NaFXilczEgMqZVcD+I9q4bxjJeS3kC3N4q2xZWSNMrtb3Oc+tY1KvKiowud7b3cF20g
+gkV/LbYxXoCO1YviHxdZeH5BC0M11cld3kwAEqPVieBXL6NfeIbO0ktLS30+KP8AgkZmcj37AnNO
+stO+yTTzX8pnuJwWllYZyaxliHbTcpU1fUuWnxAv9R/489AYD+9LPx+gouPFviKNv+PKyjHvuNYc
+F7/ZOoEL8luzYIk45PpVnUNatT5kSN5skh+RR1HFY+3qM2VKPY0h4y1+2j86fSbe4i7+TIVP4ZzW
+nonxA0fWbxbErcWl63AhnTGT7EZBrP0xJP7DSN0LSj5SpBH86x5NIMXi7S76NMOkjHaP4gF5renW
+lflYpU42uj1LFNYcU23mM1pDMy7DIisVPYkZxUuVPAIz6V1M5yseKKew5opiJwcAmuau/FcdncmC
+SaFX5IBRv6da6ORPMgdAxXcpGR1FeRaha6tp15Nlo54wx2+Z94D61lUk47FqNzvbfxPHIm6SWBlI
+yu04P5E1TufEs03ywwWhB4zK+7+VecXNteXMqzQRxI/TA3kD9cVXFpr8MhYXETZHII4/nXM60h+y
+Z11w9yJ/Pke2BB+VkQKF+mKoyTXgkxC0hidg8zSMCcA5OK5a/S+s9DmMk6i5lkBCs+3ag9OepP8A
+KsCNtWkCmOJx6FiwH6mpi+bVhytaI7SUS6xci4RFZFYlCW7g4zV5G1lJVD3cMO7oW2H9RXIfZtR/
+s2OXaFnhJDjJw6nv9QT+tUPtV+EVZbZyobIYyd63hy2sKUZt3O5j8W/2fc+S5aTkhpgP6d6dqXiu
++SYQSoijPyvGwJH9RXMmTT7BoZ9QZvOI3CIYYj0zz+lWotT8PynzJ3nkdjnk7QP0rN8rd7GqckrG
+3eeJLy3ntoYZmkR0zjdkseuT+f6V0fhHxPLqOrpbeXI27OWLDAAGelcvc2WkXMcLvhDJCBGTJhiv
+rXaeCtA0+1uDfQIRIF2q28kH14rSNSLaj1Ikup2bdaKVutFdBmPzwRmuS1W0Mkr8lutdWDXHeLdS
+k06VTHCSjdwueazraK5UGZv2KWRgrHA9qnewVEAVeneqFvq8k2GkUj8OSa0mvYwqxvExdhkj0Hua
+8+U0bGY2jW4ufMEcTysPvP8AMatDSF2qfJRVH3zwAB61D/amnrMd7KrL0AJyTVmSH+0IZBFdPEMc
+svP86zVRNgZmtQWNrpwZmZDneUTAeQdMZIOOo96k0XT9H1CykmtrJAmMBpWyx/E5IrmbzQI77UHN
+1rlw2ONuwZrd0vwTFJCI7TUbsJjsRj+VbRqRk7REvMFtvD7Sy25jgjuF678ZPbr3p3/CGWkuJCEK
+k5GDWpbfD7T7WYTXAlncc5kfAzXTRaYfJVYwqKowFHatrSK5kcDf+FptSmgjlMawwpsRE64z613P
+hTQYNFtGWNAGbvk1PHYGOTLkGtaFNkWOa1pp9TOctBx60UGitzIj3c0OI5Rh4wwHqM1CGNSAmjRg
+At7Xg+REMc/dFKYLds5hjOevyik60dqVo9g1K6aPpkblxZQ7mOSdgzUqWdjb/ctUUeycU7Joxu4P
+Ipezh2FdkJ0/Snl8w2MLP6mKr8SxRqBGioPQLiq4VQchRmng1ShFbILsnbYwwyg/UUYUDAAA9qi3
+UFuadkO45lQHO0Z+lI0g9DTC1RsxosFxxfmiqzMQaKAP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0042/full/!100,100/0/default.jpg</Url><Caption>29376_0042</Caption><Caption>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Caption><Caption>Exhibit</Caption><Caption>plate 078</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vDBc
+gFj6U8KSASMe1PVakrLQogKkUmKlYZpNoFPQRHtpcGnmgU7IQgpTS4pQtHKh3G4pCtMuLqG2eJHY
+CSVtsad2PtU+OKLILkDJwcDJ9KgPmFgDCQPXcOKukUxlpWGUmU5oqwVGaKiyGWUp2KF6UMyr1IH1
+q0JiYoIqJru3T70qD8ai/tG3Y4Rt30oZJORSgVWbUIgPumkGoIeduB9aOYCxPPDawPNO4SNBlmPa
+ueXxNc6lIY9HsWlX/ntLwv5Vk3183ijW/saMV0y3b52X+M9zj9B26muytZLG1t1igZI416DpU3cn
+psPRFHT9GlW+GpalP9ovApWPHCxA9QB/WtC9vbbT7V7m6lWKJOrGlXULJ32LdQlvQOM1znilkuNY
+0C2d18iS5ZnGRyQBgfqat+6tBrVmpY6/ZahOIYhNG7DKiWMpuHtmtMjiuY8Z4SPRpbdgJ01CMIVP
+Yg5H0xXUYyKAIsUU/FFQMeW2RlsZwM1xWoarNc3DeTdw7ckeWQQ4P0JrtHZVhZm+6Bk4ryHWbjSb
+zUJHivim1/4lIKn2pSlZbglct6jeahbbZD5hU9SVzj6gdBWXL4p1GEhY2QN2Cjr+dWY7zzYRDc6p
+mMHJbbliPSqtxd6VboxifOMksYjxXP7dlOJDdeK9UghLz6nHFjtwTWHfeP8AUJIRHb3s+6Q7SzKF
+AHfmsyR/7T1FrmfJiztiU9l/xqQW1vdwyQx7A2SAQCQPqfX6UvatMORdTsNJgvdPs1MNzMHf5mZT
+hW/PtVk3+pXLGGSSZlzzk9fyrL0q81PSdNjt1dLhl4VZF6D69cVXu/FWsAPHE1u0hyCIojhPfJqo
+Vr6ITgT6jrllZSGMLJNcxnlYxyh+vY1l3fim61GewiSS9WeO5RovPO4DPHWnaTbQ2cuLhCWbli/f
+PerGoQWczmSOGVWjwV2dCfbvVqu726GnIjprqXWrmW1ecxSi3mEo4I5Axz+ddx4b1S7vnZLiBEKj
+qjZFeH3Wpa7dNsubyfHTap2D9K9I+Fdq0X2iWZpzIwwN5yMVspXM2j0kiilPWikIhuMfY5QckbTw
+K8i1GwMcrC3hSNQT0Gc/j3r1q5i+0WksO4rvUrlTgivMptGuLOeSFpJZYyTjcSxrnxK0NKeuhycx
+ugSqDnPJFRfY76+eSN0zbIM88bz7nsBXZQaTIkRK2xT6LTWtJCmWil8tT0fP8q4ZVOVbGnJqcVcW
+UMUAt4C7SSgruIK8YwSPatzSvDTC2RYiE4wDmkuoIzcA/YZnbswzkVds1mEiJDdtCzc7W61m6mmr
+Hya3L6aS0ChEjklcDlmIwartYJ5XlHTFGDk7SQCfwrSt0vIm3PdGRR3q4l/CG2tIuT6NWkY+YW7H
+L3GmXN5KGWAjyxgYGP8AGobjQNTJXZvHHau8ik3DKDj3FBa4LYSJW59DW0YruHqee2+l3TShJYy2
+3rk16p4StkttOwgI56GqMcDySgSQxg9jiulsoVggAAxXVRi07syqNWJyeaKaetFbmZEjZFGyJvvR
+g/hVa3lLxI3qoNWA9MRIIoSP9WuPpUUlhaS/fhU08PS7uKlqPVBqRf2fZIMi3T8BVVtK0oyb2txv
+9ec1e3Uu6p5Kb6DuyqLDS9pUQLz6Z5pkOhaTHMHS0+f1bcRV8NgUoeq5IdguwWytlGBCgH0pwt4R
+0jX8qTzKDJTSQXYrRxdDGv5UmQBgDApC9RtIaYCluaKgLnNFK4H/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0032/full/!100,100/0/default.jpg</Url><Caption>29376_0032</Caption><Caption>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Caption><Caption>Exhibit</Caption><Caption>plate 079</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tE4x
+T9lOVak28VFhkGygpUyqTnIx+NBWjQCHbTgtPC0oFPQQ0LS7KdTgKLDItlIYxU2KawbPG3HvQBAY
+hUbRVa2nHOM0xhQBnvF81FWWXmikBaUVIBTIs+WueuBmpRTAYeKYc1KwphFIRHThzUF3dQWNs9xd
+SrFCnV2PAqnpGv6brbTLYXIkeAgSIVKsv4GjmWwGrThxTRS596YDuKCKjMqguCfujJp6urEgHpQM
+QimMOKmIpjDigCqy80VKRzRSAmA4pwFNXpT6AEaq13cxWdrLczuFiiUsxPoK4bXvEeoWWr3MT58p
+ThNny8VyviHxIbjRpbaN5lZ8Bgckbe461zSxCvZItU2zqdZ1NfEFqoGUi3B4yp5BHeuXsmfw94ug
+vo7xIBM4ScynEciHqCR0I6j6Vz+k66YI3tppVeMD5WXtUOtX0WoAH7SWSPBKY6+nNckZzU9TocI8
+uh7ff+K7C0sorq2DXqSMVHkEHGOvU1Uj8YaZecRO4kYcxsu1h/n2rxXwvrq6fNJ5sjNaqSGhB6jH
+DfUdK6ZxdX5hv7JdsbP8u4A+WPXg11SqyvYwVNHdL4h/0obn3Iyn5vXB6H3rX8P6l9sV2diMHGT3
+ryUarfiaZJtPUzIxztyoPvz2rR0jxY1vG0MlrKpzkGMjiohOpzXkPkZ7UORmmtVDQrn7XpEM2X+b
++91q+1dqdzNkRHNFKetFIBUOak7VAhqTdTEcnrukrLdF1QMSc4PasOXw/HdAxPGrMT90LXo5Ck8q
+D9aFjjU5EaA+wrlnh7u9zVVbKx4/f/DZ5W326mJ/VTisS5+GWqBPmmyD97Jr33j0FMYc5CKRSWHa
+6h7XyPCbL4am33CcyvnqFOAfauqsfDF7DAsVsrQxjsTXpY+Y/wCqX8alQeqqPpQ8M5byBVbbI8vu
+fCWrXLMjOxQ/xEk5otfAM0ZCuGZT3r1PikOfatI0EgdVlbTrUWdhFbj+AYqdulLk01jxW6RmyInm
+ikPWimIYjVJuqkkhqYOanmHYsbqN1QbzS7jihSQrE26lDCq+404MafMBYzTg1V9xpQxouBPuo3VD
+uNJuNO4EpamsajLGmsxxRcdgLc0VCWOaKnmCx//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0045/full/!100,100/0/default.jpg</Url><Caption>29376_0045</Caption><Caption>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Caption><Caption>Exhibit</Caption><Caption>plate 080</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21QFX
+J6VLtoUYFPAqAGbaNtS4o20tAIdtLinlaMU0kIbijbT8UuKdkBHtpCtS4pCKLIZCVqu0kYz83T2q
+4RTCKWgFPG7BHQjIoqcrzRU2Aq6u8iwwohIDvtYDqatQSJaxJE7tnA+9zVLX50tbOKdwpVJBndXL
+P4oM7usUbF07sepPasqk1DUaO2kv0jnKtkIE3bsd6sGeNYvNkdUTGcscYrz7/hMntVaWeCNli+Y5
+4249/wA64rxpr+seMNDuLu0Vo9PQqqxocEjrz6njOOgFQqy3Go32O91n4veFtKuGt45Zr6ZTgi1Q
+FQf94kD8s1z0/wAdbVWAg0KdgTj95MoP6A14/YxKkLeYhbPB2HBHvmtzT9NtkhkNxIsUiKChbLCT
+Of8APFKVZor2Z6fa/G6weF3uNGukZQPlSRW/nitPSvjD4a1GdYbj7TYOxwDcKNv5qTj8cV5Pe2BW
+MSnaokjGVxg8Viy24L4C7gG+b0IqoV2xunY+rba7t7yBZ7aaOWJuQ6NkGiaUxxb1AYfWvnHRPEd1
+4N1QKk7CxufknTsv+0B6iu7vNTvjDG0E8ioQHTDfe9M1p7W6uZyjyuzPS4boyQvKwbaBnGOaljlW
+aPeh4ryePXdWtnQx3LtFIcvHt4Pfit3w54quLm6eO+8sQoo2sp28+h5pxkK53RHNFO4YAjoRmirA
+yPFto114enCfeTDDmvK7W8VLzZgiQsDI5HRfqa9ovrc3dhLAG2lxjNedT+GoknfcxZuQc5HesK8E
+wR594p1BTJPZRTgu6FiXbHHp+P8AStXwuzN4Ms0QqXF0S0f8TDkZP4Go9W8BXd94sWcKn9nyKrO+
+cbdoAx+NdNZaXHZyyCMxxhT94nnHTj8Qa56rUYcq1uaQvc5zWfBtuJTKVRVY8qF6EnqD2+hpPDOn
+2z6NPFqNwEQXDCEHJbaMdPxzW3qAZr1LWKVneYgZLDA4z/LJ+oqzZ6T5K4RRgDaMc4Fc0Oa1pM1q
+TWjijnvE2mLJbILYSSkj5W2kEj05rntLsQ0skVwgjijXczMOM/XpXcMkl1qrQI/7iFMYPTd2/QH8
+6oWFkyavcaZID5cmZI0cZH+0v8j+da07/CU2kub7zm9fgtNVgzbsmZCNpxgAZ5P0/nV/Rby7NvDp
+bxkT26Z83O4sucAj14rXvvCd2B5djKIoGOXiK5J9MH09qz7PQNT0rX7MzTgbnKGTYcOp/wDr10U3
+y+6yJ2mroty28yRjdLj5dpXBJP68VUtbaTdF8sZYyKcsQAQD0NdbcabOcgbWPqUp2iaO76jCs8Sl
+FOfu4z+FdCt0OayPSIf9RHwB8g4HTpRUm0KAAMADAoqyhSf3Zx6VyWor5s23aCCcHJ611YORg1lX
++ji45Q4PrWdaLcdBxavqc01jbkgOjx46/NwTWdc28sV5IkaRMjgBXkz8oHoB1710Y0q7j+Vi7AHg
+5qKazlTKtCJPdkz/AFrzJqSeqN1boc1d2EdrLBduwk/hkKjZxg9PzP5VBZA3V6TYWzeWnLyyHAHf
+8a6CXTHmieNoiY2Ugjpz7VFb2EtlCtusQCHIILZJrNX7Ddmcm0eoQXVxFaTtAHlLvIY8g8DpzWjN
+HLDpQv2eSaa3lR2kcDOARnp7ZFaR0u5hvSVgxETxt5xU8sM00L20cO6NgQx25rVSegLe4+8kWKIT
+NPCEOCrM23IrF1G5kFkVcptkbKMWI59Rnk/hVi10V7e+Es8aSmMExoEHHuM07UNITU50kuYp2lVc
+IQWBUZ9jitYvoxWtqhjeIxH5CXKr5kx2pg4LkdcAgV03h64jubpSjMCD911INcZP4ONzd27mW9le
+A5hDSY8vOMkcZPQV6VoVg9nbASD5gMZPU1009ZKxlJKxqnrRTSeaK6DMjVqkD47GqiPxUgemmBaD
+ZoIVuoB/CoBJSiQ1LAlKp/dH5VGRH3i/Sk30bzQrACiA9IM/8BFSRxQgfLCE/AVH5lODmqtEBzW8
+DMGaFCw6HFBghP8AyzT8qTzKTzKegAIYkbcsS59QKcW9sUwvTS5o0AC3NFQs/NFTdAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0049/full/!100,100/0/default.jpg</Url><Caption>29376_0049</Caption><Caption>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Caption><Caption>Exhibit</Caption><Caption>plate 082</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29E+X
+pT1UkcjBpyDin4qBEe2jGKkxSEUWQEeKMU/FLtosgGAUuKdtpcU7IQwrTdlS4oxTsO5Ay4GcE+wq
+HJLAeU4z3OOP1q5imMtKwFNkOaKmK80VNhllBxT6aOFOKz5Lu4WQ4HTtgVaRLdjSxQRWadQuB/yw
+J+lQvqVxuwqlfqpNJi5jXoxWUuqShcFAzeuCKkXUzj7gzSTFzI0sVm3Gv6XaXwsp7yOOc4+Unpns
+T2qP+2WQ4kgGPVWFedeJdPl/tGWTS7oSpJlng/ijJ9B+NTUm4K6KhaTseri4gO3E0eWGVG4cj2qS
+vCvsMUZk+0xuZiC7swyxz3P61TtPF2reHZY7ixupJLJW+a3lJKEZ5AB6fhUwrqTtY0dOyPoA00is
++x12x1CzhuYpU2yoHALDIBGavRzJL90g/Q1u0Z3GEc0U4jmioKFlJFu5XOdpxjrXLvqF0lxhpAyp
+nI/vV1EjiOB3boASa5Ke5jeVmCAL2JOc/hQ3ZEsWfUTIBtldRkNtIIrO+0zrMJYp3aXk5IPQ9qzN
+cvZo4GaMScHIyoAGK5K68YX7Wa2VqREzjmQclR7elYyqIFBs7i68Sy29wsEcvmSZ/ebpNoT/AOvT
+J/FgghhuZLo/vFISJXJLHOM47/WuEh042+nSztBv83jezc5Pf3rYtNPis7F766IVlXO9uoHbrWCq
+NtlyglZHUWXiYmykuLlZHJfCpJlePUA1m3uv+H7hh9rWRcNuA27wD+Fctp/i2xa/ex1VQ1nK2IZZ
+ODGT/Q1b8T+Cpkha70q4faOShO7j2zmqV29RpWRLeN4cnczNqFy8jcg7mTH8qy7670Z4hbmYPBG+
+8fekZj+PauLnN9aA7zubPO4DFS2/n3s7IjAEY6fStVFdx3Oo0PxJeQ6mkUE0zwZwkbjccfTsK9s8
+OC7ZRJcBdrDsuMV4B4cWXT9WjklHyBuT1xX0folxHc6ekkZUr6rWsW72IkluXiOaKG60UwI7mJJ7
+SWKT7jKQecV59qusQaMreTA7bR1PevQmG+IqehFcb4j05JrSWIQjOMHis6iugW55hqnia81hmjjU
+QxofmzyT+FYtqs1tdTySxYlC71DjgjHFdZoPg2/F75lzGPIAPLdSc9vauql8PwyIk0kcr+WeIcYB
+I6ZHp3rllZKyNeaxz+m+d9gj1LWiQsfMUIwMD6eprldb1qbULqR5SfKT7kK9AP8AGu61Dwxf6o6y
+XO5EH3YkPA/xquPAwaJg8Z3HpgcgVClZk2OG0rw/Hq9hNdTqu9RnB7V6J4AvDfeHzb3T7/Ldo0bq
+cDpn3/8ArVUh8EzxufLDxq6FWCkgEe/bNO0bwff6Dd/aLCR/JLZkgbIDe/19615k0FjG8Z6CYblb
+yCPdEeJlUcj3rEstJFs32lDvhOCSBytezTxxTQq8ibWxkqwrlotCWLWrgW6E20yhioHyg+1XGWlg
+Zi3WnQPcebDhk2hiysOOOprrPhtezTXl5BFuezRRl8ELvz2z149K5mLwp5OvFfsdxJBMrEGMkMnq
+p9q9Y0Swh06yWCCLy4wBwRg5q6VxSNE9aKax5orYkYjU4qjfeUGqaXA9DUonz2NK6AmEMX9wCg20
+B6xLUfnjHQ0ef7Gk1ECQww7ceWOOwpuyLB/ctx9KZ5/1pRNS5Y9gHbYiOIXPsMf405IYmHMRX/ep
+vne1L5uarlj2DUcbWA9UB+tKttAo+WNR9BTRJml8zmnaIairFFGSUiAJ9BTi3FRl6aXqgBn+aioW
+bJoqQP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0043/full/!100,100/0/default.jpg</Url><Caption>29376_0043</Caption><Caption>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Caption><Caption>Exhibit</Caption><Caption>plate 083</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xFwv
+TNSKuVyRg+lOjWnkcVnYoiwAaXaKdik6UrIVyI8UopSM0YqkkK44AUMMU0LT8Zp2C4zFLtFPxQRR
+YZAyPu+ULj3NNEb4O8L7YqcijGRSaHcpPH81FWGXmio0GWE5UEdKU1FZk/YoSevlrn8qbLeQwqzS
+OqqoySxwBVIlkxoxVG11iyvVY21zDLtODtcHFcb4u+ILWUsmm6Oqvdr8sk55SM+g9T+lTOSirsEm
+3ZHa3+oWWmW5nvbmOCPOMucZPoPWo9N1aw1eNpLC5SZVOGA4K/UHmvG7KC41i7W61S5lvJBwu984
+PsO1egeHtD0/S7lbu3uXEh4dTJkY9Kzp1ed6IJR5dzpdVu5rGxaaCDzpOgXOB0rgbT4h6raaif7V
+0/dZE4LwxsrJ+fWu8vNZtrS2lkPz7FztU5J9q4HxLryzWFwktqqSYypQZB5HB9Dg1dSbgrhBKR6R
+YXttqVjFeWkgkhlXcrCpyK8l+HPiE2GoSaZO+La5XzYQx+6/cD6j+VeoDUYG6NWlOXPG45Lldizi
+jHFVvt0ROKsxusgypqmhIjYc0U5hzRWRYxCF09WbjEYJ/KvM9W1aC9E1vtuPvg5UdcHPfivTJ/8A
+jykB/u9K8u1UPbyuxs3kAJxsbANZ1anLoCVzI1HW5LG9S5hgMbeQ4wT19Dx74qr4Ws4bpzJcyBjn
+cdx5JNRazFc6nboY7UQyR5Aw+7ep6ik0CA2qyC6Ji8wbArDBJ9vU1yTlzJamkdDXu0s7W4WaIeW+
+S0cqZGOSO3WrkGtxMmxYGfndne3XrVF31aUeTDZrHCBhfMQk4qzb2eqKqfu4Oe6qeK53VcXZENNs
+nkvXmyY7NgWHJ+Yn9aLeyEyM92smzlmWToTjiqrHUFuTEbmQAckLHmn6lqLwadEJJzJmTG7btx6Z
+rRVnNWHCNmc1qzva3cbg7ZEcN8vbnpXWSLaXErMXmRdoKmOTB9888Vw97MtxdKo5LMCST26mt5bw
+Xl2l1NHtgXiOMAE49T711U5tRKnFXOggQt5f2OaVSOS8zFh1/wA813eg3EM6t5Rk91YHiuDt7y3k
+AALIPXH+Fd74d8trYtHLvH1zWtObbtciSNVutFK3WitCSOYotq5c4UDkmvLvE2qW1pG0kx3AMSih
+sEjPOPWvU8BkKnuMV4z44+G2r3d5Jd6cxlDMSUJ459PSsasOa1yomefFem3TpFAjA/w9vzroraW3
+uYcS2qysBwQORXB6f4C8RLIplsSqhuuev9a9Q0vQtSRS0sGwYHQDJrlnBJ+6aq1izAWFopLMpUAK
+rZYn/GsltRsopmjvZCZWbaEY9/p+NaGs2OtyQmK0tnGFwNhxn8a4qfwd4umDGGxEWTks8g61m6Ll
+5CbR04liDmRZY41z+FU7+wv7uxbe3mQnkBVXn65HH4VW0vw/4h0mMy3lgs4UZIUkn8K6u2W2u7YJ
+tmQ5+aMg/kaz5Z02I4PSfDMd27NcQpGyt1+Y8duCcV19j4b05V83/XsOrMM8/TtSS6ZfDUV+xW7g
+c5YrxitJdO1W3jWQh5VJ+ZU4IroXPJbAPt9Pt24WJB6ZTp+VdLpkJhhIMap/u96p2VvKwGUdR71s
+IpRMHrXTQg1qyJMRutFNY80VuSRI9Sh/aqUbkgVMGNVdCLIIPYU4EVW3ml3mpdgLBbjgZpvm4PKE
+VFvNG80tAJhLn+A0qEHPybfy5qEORTt5qlYCfIpN1QbzRvNUImLe1MLVGXNMLnFAwZvmoqFmOaKV
+xn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0048/full/!100,100/0/default.jpg</Url><Caption>29376_0048</Caption><Caption>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Caption><Caption>Exhibit</Caption><Caption>plate 084</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD22NOK
+kCgjjBp0a8VIFA6CoGQlKNlT4ppFAEO2nBKftp2KLIRHt4xijYKkxTgKYEPlimmOrBFIRQMrMgAy
+cAe9REITgMCfrVwgHqM0xkHUAUhlFo/moqwy80UrICxGOKkxTU6U+mIMUmKdQSMgdzSuA3GKTFOr
+O1bWrPRola5f945wkS8s30H9aOZJXYWuaAFOxUNndR3trHcRbgjjIDDBH1qene4hMUmKdTA6sSAw
+JHbNMYmKaRUmKQigCsw5opzDmipuMlTpStKifeYD61HlhCxXG7HGa4rUNb1BJjG1tlwT8y5AFTUq
+KCuwSudx9oi/56L+dMeeFhxKgYcjmuLtrrUZ8NKqCPGcDOfzqhrGryafCzj5AflRU5Z2PYZrknjY
+rZFqkzt5ddsoVbfISV67QTXnd7qtrqXjS5muVfyE8qNFbg7MAnH1JNVEvLq6cLfWl+m4ZXDBg35G
+ormzjyJYVZSRnk4PFc9TFOWjiUoOLuelJ4j02KyVYJlLKAoRnywqnF4tSNt11hIVyWc8DFcVaeF1
+vR9pkuApP3mJyQatanFY2lmqiIXUyD/WSMcnHQcV1RryfQlQu9Tq7X4gaJeXiWqNNHJJ/q/NjKB/
+oTWhHqitDGFgclDjcMc4OK8b1O5lvI1e6WCNkOU8tQojH4d61fDniC/kuHto5ri4TCiPOWA65Ocf
+StVVlbUp010PUJtWuB/qrcf8COTRY6hcTzhJigB42hSDXJX02qiNZRGwdOd4OMVseF9QuLyYrcoQ
+R0yo/mDTjUbdiHE6dhzRSt1orQQ0coRmueu7RBMRtyCe/NdCnSqV3bkHeiFj2AGaxxEFOOvQqDsz
+JkiPk7FwBWDNp8kjnz1Uc5X5AQPoa6eG0nuWLS70A/hGRmnnT3MpJU7ccHNcns1L3rGnNY4q4067
+kiZDezbGHIDk8e2c4qjYW1rbu9rb/u/KxvY85Ndpe6ZLLEywfKfde9c6ng26uGlaS4njyeiEAN79
+KajbQLmXqGo2sR8sSMz5xtTliapS2c77POBt42bH7xhn8s119n4OtrRVL2zySjOX5Jb61MPCSXJ3
+3dsAsZyijkn8e1VylKSRx9lplvc3H7q3kkgjJBkdQoc+o9q7C3+y2FrllVffHT6ULpuoXDmG3j8i
+MAY3A5FPfwnOiFmaS4nPO5m4/KlGXNHmivwG2urM671uF22puYKOSFya2fC7Wr3BljbEjdcgjNVb
+bwldxStJtiUv15zXS6Zpps0zIEL+qirowk582vzIm420L7Hmimt1ortMRkbcVJuqkjmpRIaLiLIY
+GnZFVfMNL5hpNoCzx6UzeB/Aai3mjeaSsIlEoJwEP5VIr5JBUj61XDkU4OavQCxkUZqAOaN5ouMl
+LU0tUZc00uaLhYRm+aiomY5opXCx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0015/full/!100,100/0/default.jpg</Url><Caption>29376_0015</Caption><Caption>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Caption><Caption>Exhibit</Caption><Caption>plate 085</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21Fwt
+KqkjJXB9KlVeKUis7DIStJj2qUijFIVyHHtRipdvNBwOpApITZHjFV5L21iOHnRT7motWnaK2OwZ
+yOtefXksklxKZ5EUAjYrdTj2rKpV5HZIa1PQk1OwkJCXULHPIDCrWxWGcAivIdOaCTWWlkbbhd2w
+fxHPeuqfxJNDCuz5Yl4DF8DAqViFs0Ukzs/LT+6PyqBowetsf/Hf8awdG8XQ3kskU5GRjaw/iPoP
+WupBDAY6V0LlkroVyk1rHn7i/lRVwrzRS5UO5YBwMmoftMZmSMZJcEggcf55qRzthY5AwOprm7rx
+XpljO0bS7yp4VO/45qtkJnTYoxWFY+LdNvzGAzxmQ4AYd/wrSvdUsrCxlvLm4RIIhlmzn8PrSuiS
+S8n+y27S7GfHYV5R4m8d2ouxAbqV5ASGitwCVPpkkDNZ3iT4gan4o82x06M2Vl1V/MVZJOO5YjAP
+oOa5W10tIIlk+Rivys+8NknocA55yTjnge9c1R8z30LUe53Nh8TrfTIjbX2l30sO0EMXViM9Dg/U
+d6qyeItN8QSb7ORluWyUh24dR2znr+Fc9PaqJkTzUEYzyUy6qenOT09cduKg1/TbFX2W7xpIAed3
+zcKOOOCRzwP0pW5kkPlR2KW8GmWqTzMJbtz8zDgAE9DzWfqthdzMslxcIkTKCEHGB6Y/KuO0nW5o
+LmGW8jW6UcI7dc9Qc9629S1stHiJirvySw9ulEabjLTUTLukvHYamjtI8kaH5SQMD9a7vS/Ft1c6
+vb2zIRBK3GQNwHvXmVrds9sn7tXYDOc5P+FdR4Kmmm8U2ysgEZXOSMDOD0rpje5J6/iin4xRQWVd
+Xm+zaNdzc/JEx4+leM2SxX8csxBjlWQdTnIIr17xJJLH4bvGhTe+zAFeA2Ut/aXQ3MrQbuUSQAkf
+Wpm7IXK2dik0Gm232p5H2Id20JyfauW1jVm1Z0e5nfyZn3xxZ+VV4AAJ46lScjofpS6rqTm1ihj2
+xCSZEZS53sDnkYBGB7muf1K2VIbWZmkCQ2gjA34IkzyT146cVgnfcrlsXdMeI+ZLcv8AIck7MKdo
+J4GTj8KqreXct3LNZS7bJ3CqJ5QM4HPVsZ/GqNx5WlxOst8JY1zHGIiw83198c1VGrLLMEEHmJ92
+ML8uPpQluxNnU2jzRE3gMKi2UK5hCkKvOThTz16nrzSahK97aG4eG1d4sBcGNWAPIKrlivPoQaqw
+20jWxzBLa5XO93GB75qHTJLl78wxXBYhdoML7Rj6AYpp3eg1e2pqabY2Wp6e9koWC+kIkSR0yST9
+4LyADVSQ6g1zbWdxps8c0gbZEynLAZByD0zg0jQeXrDRRANHENrbD1bj6dPYVea6uyjCWe4bK4Cl
+yNv1NbJolvWzKOn3xgxFLbtC0seR5qcgZx+fFd34FuIzrUCu2QDhdwzg+3pXJx2szWEomuLYJIow
+suWYEHggjp3/ADrpfhyI/wC3o8sMqeW6hvQCneNxHtRHNFKetFUUc/4089vCF+trII5WUAM3TqK+
+fH0HVbiYsbyPJ/u5NfTVzClzZyQyAFWXBBrze+0SK2uZPLHy57DgVMnZCdzzrT9C1K0uopWvMgNy
+pHDD0IzV7U7G5nuoraGP5FXLSEngg/L9c4/WtuWymeXIZiueMf4VVc3TkLHHKRnrnAP6VzTs3cFO
+SOJ1HStYaWNGtonSDIjA688nOaqrfzW7NDLpzLJHjLIvI49uK7O6OqRuD5BC+rpu/pWZM1/IGkh8
+vLcMUg5OPfFVGzIc2ZT+J7LYg+xpI+Pm84Hg+3/6q2NP8TaZLAMO9vKvTa3Bz19/T8qwr20uJIXW
+ePJYYDGMcVkDRJMbhHKGA+8vQfhWipxsNVD0bR9P0C7JmYrLcSNveUkE8noAenFdStv4XP8ArkdC
+OivkZ/WvGo9F1FYTJbyB+5CHDAfSkt9SvYZNjTyErxhm/pTcPM0TPa49E8LXDCQROy5/ikIH6Gut
+8NaZomnzEadYxwuedwGT+ZrxjQvEWouotpWiKZyPlB5/pXsHhQXW4M+CnfFRGVpco2tLnXHrRTSe
+aK2JI0ORiq11ptvdj5xhvWkSbipFk+v50aNBYx38LxbgU2HHqKil8MFzyqEfU10HnfWlE3tWbhFi
+OYbwl8u1VH/fRqhJ4Ic52RjHpvIrtvOprfOc7mH0NSqcRNHB/wDCCXDOP3MeB/ebP9KJvAuoYzbw
+WIbv5mSP0rvFXA+Z3P41N5mBjmtFCIcp4zqfwt8SX7sTParG3OyNyB/KoNM+DOqQXBkn+xMAPlWV
+iwz+Ar20SUpeq5EVdnlWnfC3WYJZTLqVjawyMCYrWNjx9TjFem6dZJp1lHbqdxUYLHqamLZ9aYWw
+c801CKd0Dk2OZuaKgZjminYVz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0031/full/!100,100/0/default.jpg</Url><Caption>29376_0031</Caption><Caption>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Caption><Caption>Exhibit</Caption><Caption>plate 086</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tI/l
+qRYyB8xBP0xT0HFSYqBkW32pNtTYppFKyAjK0u2nYpwFLlQXGbaNvtUmKUCjlQXItg9KaYxVjFIR
+TsO5WMVVmhnyPmiIzz8h/wAa0CKYy0WQGc8XzdKKssvzUUrIZaQcVJUFu2bWN27oCfyqK41O0t1y
+9xGv1bFUQy5UckiRKWdgqjkknFc1d+NbRTttA0yg4abZ8n0H94/TiuM1aW/1yQnUpyI/4LdeFUf1
+NY1K0YlRg2eqxXVtPnybiKTHXY4P8qmBz+FeHJp0Fqyyqzwvk7ZImKsgAyTn/PWtbwj8Qby21Uaf
+rU3n2kq/urgr86Y6BsdR+tTCtzA42PXAKdisGTxRpwCtHcxuTgKAepPrV5NasfJMj3UYUAsSDwBW
+6ZN0aGKTFZ1rr2n3kQkjmKg5wHUqcDvg1ZGoWjdLiP8A76qhkxFNI4oWeF/uyIfoadkEcEGkxlZl
++Y0U9h81FSMqzs40RmWMu/kghAcZOK82nkvZJmAtEjZjzlwWH5V6dMzrp7FEDME4XOK4TUplh3ST
+FI2P3gHBx7VnVk4oFFPcpaZeadYhhJBl/u7pJATkdgg6Vmanq009yyW1oVQ9JHHrznFVbrWLGJ2a
+BJZeDuYLk/rWBe+JriPKWkG0dcvXE1Uk9IjlMsTNeXUixyXARVOMDgE5/Wrj+GJ101Ls3JaYnMSA
+chckZOKNOSDXNKWeEqJ42UXCNlWBPPy+ua00e80hpHgtpZlEexPOmB2/hihXTtIUU2rlDTLDUY59
+pl8wAZww+n9BWvDeymfyBaGeFCrSBGzwDnHp29axJfEup2jBpLDZ6MGyP0FdbaQpcWQmvGjVmT5s
+ADfx1PvTjOa3KjFMlJjkiF1MVjklOBEeuPf86SOYKMK5z6bv8aqJpVtdwSsIh5aAbTjsfSuK1uK5
+s+bWeTy1P3N5IFbRnKT0dhygjvpNfhsiBcTuEJxuU5A+uK67w9qNrdoBDd+aWXcoLZyPb8q8OXbJ
+bxyZbdIuW55JyRivQvhvZ+XqMkykMvl4JB4H0rojJ7Mlx6npDfeopW60VQhqgeQVJ4xivOvEA0qO
+Z90gLf7Kk16Kh+Q/SuQ1mzjjZ3WD5T1AUYqKnNy+6OJ5+/2ZwUSBpIyf4gBVK50yO5dSlq4xxjPA
+/Suha2VJwywsVXnHOD7VYhujJGY3RUx0GcV51WrWhrYahfdmFoKLaPNa26SSSb95CRkgY4x610fl
+3t7Nzay+VxlduCR3rDv5L0ll3ssec4QnDfXFVLNr+znE9k5SXGCz8ce1YKtCUrt6lLTQ1NUltdO1
+WW0umKR7PMDrgkUyK/sWRYreKW6L5YF7jBP4AVCVe4Jl1J0mkPLMTjJ9KqiziedriImObOAVIGK6
+lyW0ZWp2FjrWl2WmmO4haCc5DBdzjH41yd0trfXbrHcxKspOxjkBfrkDFWYYLszKsl7HJGeSsi5/
+WtNbO3iQ7YlYnqQOtDrqDV19w1ExG0y10uwgtt0F/dM3PlZwoyTy3413ngTTxayyyqJFDLjYTkCs
+i2s/OQrHHg9OFrs/D9ibSE7l+bHWuilVdSV0rESVkbDdaKax5oroMyONqJYYZ1xIoYe9V4mJVfcV
+KD7CncRG+lWkg5jH5VTHhnTt5by+TzyAa0t5xilDmolGEt0O7MyTw3ZONpGB6AVXbwlZEkqwH1rb
+3mggEEYA+lcn1LD3vylc8u5gSeELSQffUH1PNKngqwzvyPTgVuooGcjOfWpVO0YAAHtWkcJRWyFz
+MwV8HWaE4YY9CtTx+GLZFCs5YfStjeaN5q1h6S6BzMqwaVa2+No6VbyoGFx+FNLGmM5FbRUYqyQt
+WDNzRUJc5opXHY//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0030/full/!100,100/0/default.jpg</Url><Caption>29376_0030</Caption><Caption>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Caption><Caption>Exhibit</Caption><Caption>plate 088</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOPi
+nKpOcrj096kQcU4cnFYWLIylRTSx26b5GCj3qziuD8eX08d/bWkTEL5RkwO5zisa8vZwci6UOeai
+drEyTRh0IKnvUgWuZ8C3rXmjushJaN9pzXVgCijLngpE1I8knEi2Uu2pMUpFbpEXIdtJtqVyqKSx
+AA7ms86h5UipcIIt7EKSwwfb607IpEzCTnEWfT5qTYSuWXB9KsAhhkEGkIpNBcovFlulFWWUZoqL
+DJWYpC7gZKgnFc/L4tsEnliMhzEvzY/i+n5GujH3D9K8iu9B+0Xd7cLIyEzyrjGcAOQAMf4VUpKK
+1FY6OT4jW0Mrr5DuuAUP+NYHiXXodaktruKIrJbZWQHj5Tj+VcrPofkicsJmlU8bn2/57VktNfW0
+7FNgj+6A4z7ZBrnc41bwL5Z07SPSfCmux6TezK3zQXAyuD/EK7uy8RWV5bNIG2uoBZT2zXz5aauL
+SQW825UY5Abnb7it2O285lkN9Iv8TBj8uPUH6VlSk6PuS26FVf3nvx+Z6RdePYobkrHH5qo4VgnP
+H1rSsPGdneSrC0bJMeNvXmvLbO50+JzEtz5TlSnnLz+orqtIfSopxe/ame6K7Q8hJUKPT0zXTGo2
+9jHl0O2u9QDzIigBM9+pNc14p1wadBvklU8ZVT1Nc1r3iqzsbu5ltLvZcTDBdTkr/u1xY1WW+uFv
+9VlaZEOEDdZW7cVdurLSOxsPFt6jAvKyuQWUE8AelejeHdZbWbISsqhhwcGvGEnmu5Eso8ea/wA0
+xXoB6fhXpHgVWiu5YVKiFY8AA9TnkmqTBnaMOaKe3Wiiwhy8x5bjjmvNPEOvaRZXU8WZ3JYk+Wp2
+lh3616USBCxYZGOa8m8TTW/2t4Yvkd3wIwgJJPPcVlVeiBGMfEOmXdyq2yFH/jzCvP1O6qHiO6tJ
+tJiaKPbcAEYA64PGKlk02WeNrU2zKH5J24zV/TtHFtepLdR/6JBFuJI6MMY/rXHe0k0aqzi0ZFv4
+XR9KivtbmELNgpDnDe2T2+lVdQm0yB42muHaKPhLdT8pA9areOPErTzrbQuWCnp6VzWlhtRnYT7n
+Crnk9PSulXerMdnY6STVZLqLda2cEULcDdzmo31W9MAgacRL0G1e/wBarNH5car5vl9jGDjHpz9K
+v6TZTXW+3ZVkXPGec1qrJXY9Wc9cWjxXHnyPJIQc/MuRSm7nkuUuZmJjjOY0U8Fv6V0WuW/lGaEx
+HYRkEVg2QVbceeu4M5BB747/AFq1JNXDXY7Tws0f2JpmkVrmVuVDDdj6V6H4J0u4h1B7uVmZdpAB
+G3HPpXhBuxBOyeaFaMmvUvhX4yubvWv7EuJBMroWRxyVwOhzzU8rvcLnsB60UrdaKoBrMBCxPTBr
+ybxFDbalqEgWJ2kOAVjY846Ej1r1Z18yBk/vDFeca1bazZGaGx8hdxPKr81ZVdkOJjSy6xcz25uZ
+ksIYEEandvdlHcKOAfc1leJvFqwaabO1JmC/I0jNuOff3qC50PWriQ/a7593XYq8fjTYfBpkkUSE
+sxUBiq4yfU1g5RHY82l3TXDMNzM3Umt+0A0nS7Z4oS9xcShip4yAen+fWuyn0bQtJu0iaNpcKC0h
+Ubc+grMuprOO8WcW05VTnBHA96Upt6BFJbkWv2MI0tbqNBmUjHPfjNY81xqNvbLd6arwNNw44yOa
+6K71nSrq1WO43bQ25VCnrWYdX09P9XBK3++hx/OinUnZKxq4Qu3cyYbrUX5lY+c5O/GeR6ntmnu3
+nzDzCFCfewMACrH2ya9m8u2s53dv4VXH+Nbmn+BdY1QAXCLbQ/ewO59/WulSS3MrNs5G5hhkf7Qj
+bjI2SvcV6d8GtOg/tqe7V8TRxEFR3Bqza/C21EQ3yyF8de35V6N4X8O2Wg2Oy3hAkb70hHLU4Svo
+ElY3GPNFMY/NRVEjI24qGayt5yWZAHP8VMilyAfWplcelLRrUCgPDlkPur+fNSrodsqEKME96uiT
+ilElQ4w7BdmPJ4R0yWUSSRbmHTNRXPg7R7lDHIo54Izit7zKXzMjkVPJDsF2crB8PfDtudwgQv8A
+3mOf61aHgbRSgxbxlfpmugDhegxTvMq1CHYLsx7fwpplr/qreJP91AK0E0y3QAAEY9OKseZSeZVq
+MV0C7FWKKPAAAp24Y4xUZkphkqroQM3zUVCz80VFyrH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0026/full/!100,100/0/default.jpg</Url><Caption>29376_0026</Caption><Caption>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Caption><Caption>Exhibit</Caption><Caption>plate 089</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xI+K
+f5dSKtLtbPbFY2RRFso2VMQFGSarPeQocbs/SlZAO2U7ZVY6jAKj/ti3Bwf50Kwrl/ZRs9qqrqkD
+VML6Bv4qqyC4/Z7U0x+1L9qg/wCei5+tSKyv90g07IZXMdRtH7VZaIkk72HsMUMvFFkBmtEN3Sir
+TKM0VPKh3LiiiWVYU3N0pyisDxBqHkOIh6c0xC3uqbshTxWHqF5dpaNJaRJLJnAV3K5/HBqg18ZZ
+VUsEDMFBbpzxV/7NPG63D2rSiLIVlO4N9RUslsw21vVftiQPpOyPhpJjcAKq5wcccn24rUWRHOUb
+KnkHsa5vxhapqFsSYGjlXkfJjPtXI6L4mvdNVrCd12r/AKrfjKn0p2vsiU9T1kXSRIGkkCgetUbj
+xCFbbEcD1NcTLrUki7pJMtVCO/e7u1hEyBmP8TAU9ldlpX2PQodVDtnzfmPvWxaa0YmXL5rgUtDG
+VCSSM7AkEj5Tip4b5lbaxww6j0pU6sKnwluDjuev2OoRXqfIcMOoq0wrzvQNUMd4nzHmvReqg1bQ
+isw5op7DmipAnWuB8a3q2d8xYPyvGBmu+XpXD+N7P7RMjY6LgZpSdlcErs88bW4nl2+TJI2cqhXg
+kcjuO4rc0ab7Tfwag1/OuoLbKklk42o2M4ZQevJJyCetYcuntBcJMiZKNnA71Z1fSLbWoIZLTUBZ
+3SDOfuMPriiE1LRkVItO5i63pUtpDdfabu6lSeQyCN5MlSTnr9a5rRdB1LVtXVrO0knfPLHoB7sa
+6Wz0rWrjXrbS9XvVubV2ws0bBjgDOD06161bxJZiGz0+CKHCZJxhUUdz61c58uhlCN3c82HgDXBC
+0krW8aquSGkzx+Ao0DTI3FxazQJ5sU4LsU5HGQM+tdbf+MbzS9SVY9Pae0RwJZHQq7gjJZRwAMHv
+1pkU0TxzXwBAnYy4PU55A/LFeVmOKdKmlHdux6GGpc0tSmZraLUlglYDfhQCMDI4x+R/Suc1+9tY
+NTRYZczKMS4HGe34461pakEvLkOcAdfSq2paAl9ptxdLEUMSeYJNp59ifengI9eyNMSkvmN0TVle
++hXeclh0Fe8J/ql+grwPwhot1eXybEG2Nxliele+qMRqPQV6XNc5JKxERzRSt1ooEPU8VheIIlmU
+bhnFbSnisPXtUsbDAu5fLz0yhOfyFRUfujjucnLZLn7g+prMu9Hiuv3ZBGc8p1rZfxJoRY5vUUe8
+bf4VBJ4i0ADMWpRCTsWRsD9K4JN9DcwtO0yOSIYh2TwtsY45DDv/ACP411NnqFxb7BPHvKjG9RyR
+7isG21TSo57mdtdh3SvvCJCwGcAYJI5HHtWmviPQ3QZvYxnsQeP0pKpJMTimax1PRZYRDfQNtwVC
+zxEgD0B54/Gq11q3huOM7xCqDjIUgCoBrmi7eL6Ij0IP+FU7698M6ggW4vYht6YB/wAK154y+KKf
+yJUWtmKmqeFeZ4bV7s54WNSVz75NM1S51PxDALaGFbWz7ooxnHr/AICltp/DMVys66iruAAMk445
+5AHNbEer6O3KXkWT14P+FaqdlaKsVbqw8JaIumEAElicsTxXd9q5zTdQsZZlWKdWY9gDXQ54ralq
+jOpuNbrRTSeaKsgYj1W1DS7HVECXtusoHTJIx+VKjmpgxpaMDDfwN4cl+/p35TP/AI0wfD3wuOmn
+H/v/ACf/ABVdBuOKXcaTjHsF2c9/wr/wz2sXH0nk/wDiqY/gDw4nIspse1zJ/jXR7jTtxpckewXZ
+zi+BdAY8WtwB/wBfcn+NTf8ACB+H8Y8i4/8AAmT/ABre3GnBjiq5I9gu+5z48BeH16QT/wDgTJ/j
+Th4J0ND8sEw/7eZP8a3txo3Gnyx7BzMzrPQNOsJRJBFIGHQtM7fzNaRPFMLUwsaaSWwtWDNzRUJJ
+zRSuM//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0029/full/!100,100/0/default.jpg</Url><Caption>29376_0029</Caption><Caption>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Caption><Caption>Exhibit</Caption><Caption>plate 090</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FUwK
+cFBGR+oqTFGKiwyIikINS4qnPqNtA2zfvf8AupyaNEImwaUCq8dzJLyIgo9zzVtOeoxQmgAClxTs
+UuKdguM200pU2KCKdhlSQKgy3A+lM2K4JHPbpVwimlaVgKBgGen6UVc20VHKhk/UZHSiorIlrC3Y
+9TEpP5CpjVkmNqmoET/Y4mw2MuR29qbBaxxrv4yRyayplaPWLl3yWZz27VsQHzbdh3xxWb1Yx8cp
+z6irqSArk8YrEtZ9yjnp2q4spdwg/wD10kxM00ffyOlSCqMkhj2qOPWrcLCRAwOa0TAkxQaWg1YD
+KQin4pMUmMixRT8UUgI7H/kH2+evlLn8hVT+2bFpmiFzGsinBVzip3do9JLqPmEOQPwr591fX9Tt
+dQlLQ7RvPzMuR+dAmezaiyy30ckbqd4wSpz0q3C/2eGSR+NoJ+tcR4B1OfV9MaSZVBjlIBXvxXb3
+wIgjjDIGfJAc43EdBWbGULWxcoJPN2bhllx0ras7YIvmHlj0zXP+HYdSRbiPU1AleXhkk3KV9vSt
+bUdQSy2w78TSAiJfUjqfwyKlWEV9VvUhkWHeTJJxhf4fc1Lp+oiBPKm+V1OMGuc8SXkXh7RH1CR8
+zuQsZxnLH/8AVXOeFfH73mpiLU3ifI+SYgKVPoa0SvqF7Ox66lyWAIQ84x9DU+7jmucuNWuLbTbq
+eO33CCFnRt3J4PGPwFeaj4qeIFkOEtXUHoUxn9a0iribseyz3KxdfUZPpU4IYAjoa8XX4p6ncFhJ
+pdsT/vNzXdeCvEl3r4nE9vHFHEBjaSSSaclZAnqdbRS0VBREyAWZQn+DGfwrxvX7CMXUqpMZQSSy
+Ov8AKvZSoeMoehGDXFat4UR53n5Knkisql7XRUbdTkfDesjw9atCtqJIXff8pwRW5P8AECG4QxNp
+bSDBA34xWVcaOTcMsaSFB/s4FV30icv8sTH6DpWTqMfKdT4Z1uzWwCPNHbyLIxKPwOTnj2o8QBbm
+8g1KC+hMkAKKhGRz178ViR6PE0KC4Z1kz93AJNTpo1qiEswVh1LVCrdxOJmXXi65kh8iazt5ozxh
+gT/PIrgb6e0ttRZYYtk0kgAhj6Lk11PiOykV47eylQux3SbOSo7Vl2XhyaTWxOYi5QBz9ela05Nt
+Ckkk2X4PE2r22ly6eJC0TDZuIGdv93nPFc87mEkNEGYn+Fea6yTSnkk2eU4B/ucEVUfRWj3v5RyD
+1I5rsTRzKTe5iwh2AJUo3TBHNet/C5CLC8Zgc7wM4xXD2ug3U54gkBPIC5/UV6r4Q02XTNMZJU2s
+7Z+tEnoXC9zoqKTNFZGpEGp27IwRmq6MSKkBp7gONvA/3oUP/ARTRZ2oziCMZ9FpwNLmpaQERsLQ
+tu8hN3rjmqs+jadPky2mfoetX80A0uVAZg8O6Rs2rp6gD04NTW2g6dbMzxwYZ8ZJOav5pwNUopCK
+x0uyP/Lun1xzS/2bZd7aI/Vc1YzSE1QWQxYYUOUhUH2UU8mkJphNAxS1FQuxDdaKVwP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0013/full/!100,100/0/default.jpg</Url><Caption>29376_0013</Caption><Caption>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Caption><Caption>Exhibit</Caption><Caption>plate 091</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7Lg
+cAZpRbnaNwAPfFQ65eyWFj5kRUMTjJ7Vwt34n1aFDNDdLIQPuADB/Cs7A3Y9B8gUnkiua8J+NYNb
+BtbzbBfJxtPAf6e9deMGlyiuVTCKBF7Va21ynjTxBLpdkbKxfbf3ETMrgZ8tBwW+vPFFkhasXUfF
+2haZrMGkXFyWvZnCeXFGX2E9N2Oma6EW4z0rD8KeErfRLNZZx59/J+8llk+Ztx6nJ5J966jaKtDK
+n2cY6Un2Zf7o/KrmKMU7DuZ72nHyKufeo/sQOdyJ+ArUxSFalxRVzIOmQk58pP8AvkUVq7aKnlQX
+MvxLbfadMIzjB656V5+2leYjLuXrweleka8dujXD+Xv2rnbnFeVLrtjI8kZEkMwBIWQkZ/GlUlYl
+xuUrnRJbecziNgVORIr81uaXrN05EMoaYg7SyuQwrmrbW7x7t45vLaEnIJbbtFbVsjXM3mQRtHJ0
+OTzXPKpoTy9jubfVLu3tfmYMijhpOTj3NcjrYudQuJ9SvI0h3KqQiQjcAAcBV/3iDzTU1H7ZDDZO
+J2aWTZF5R2+YRklg3YDHJ9x3Nc946vY9L3fZoIRcx7GkmZiXZ+Rxnk42oc1UG2rtmijbQ9RHjW03
+7Fs7k47/AC/41oWviWyuXCsk0Oe8ijH6GvlxFlkt2mmuXe8zuZy5yuf5V6B4I1zUrTUrfSNXcyw3
+S7rWZzkg9dpPfocVvGdyXCSVz3SK+tZ/9XPG3tuqcsoGSQK5J4lUAgL071jXs0kbnyzMcf3Gxir5
+xI9G3qejD86AQehBry+31bW4XzG8hQHpNgj/ABrr/D2p3mozMZlREVeQvc0XuM6DFFOooGVtRjEm
+nTIQTle1eC+LNOeO/R4SMEdD1BzX0DLzCwPcV51q2lW7XjSKEJHqucVlVdtS4HmcenXV5AHhWdST
+iRBwPfBrodKR45fIu7uUExlCgKAhcfxHt+ea2JoPKtpQm8Aqc+WuW6dh61yFv4W1C8l3TGaOMOzR
+xhvujPBb1OO5rkt1bL0vY3f7MvLeCVrW7Mq/MFjDY2L3Axg//rqne6emtW7XE8U0ihcordQTjk+u
+BnjityE3dtZG2uRJK4wIj57RKuMDkpye5Oc1RvIRFplxcl5lVVDLMZiu5u20BgeOvzZyKuHvJWZL
+dmzi7Sxmg0eY3UcS+Y2IGAwZB9KuXVlcQ+GtN1DIJs3VsBsnaG5OKrRwP/ZsWtmJpJbR90iPnBQ5
+4A6DnHT1rX8JX1zqum3mksI7fT7qQsHlOSi5y2OlaxQ2zV1HV9Lt8C3LtIygx7H4Y/hVWx8RzG/j
+juIY5LUnDsI8kf41yGt2T6JdKbaV5LSUZhmGQHA4yK2NF0yQQxXDyEs4D7AMe9NRstyOXsdofEnh
+pZfLlVkIOObc/nXo+hQ2qWiy2mwxyKGDIBgivEbzSrvUbiKO2s5C4J3MSBnNenfDvTdX02ymjv5I
+TbjiJEbcVx1yauFwasdrRRRWhJHK22FjjOB0ri7iCR7qRyMgn7ortTypFYl5b+W5OBzzkCsqquio
+vUwxAkCgso54AFK+cZZUjjx3pk95FHISgMrj8hSLdJdQYMsQlY4AzmuKSNSnKIrm3kGSqOCNxGCB
++NecauBp+orYSmdIS+5EbJSVcADDdsY6H869AvbS6BMhBKj+L/61Yt5ZxajH9nuYRJESDjJBBHQi
+iE3F7EuNypBpjalpc0cEg8qSNkK9Mn/HIq9onhb7DZwxSkMVQBsdCe9auk6bb2dsUiDhSxYgZJya
+30ULEAqqR7mrU+w7HM6xpVtrFg9ncxH92AI2UcjtxWNpaXeizW+nXaxvvB+zygZ3BccH0OCK7CRP
+KmZiu8E/wgDFLFYxXE6v5fI6HHIzWqlfRjsJZSkuCsYD+uK7TSYkiswEQLkknHqaw7XTHRgVjbHu
+K6W3Xy4gMYNbU0ZyZLRTc0VoQRhqDsYYZcj3FQRMSgPtUoNIBsllbSptaFcewxVOTw7pUzKZLRWK
+nIySa0N1LmoaT3QylDpOn2rOI7b7/J6kf/Wpp0jTRljagZ5JxV/dS5zS5Y9halNNPsQDtgOPanCz
+s/LK/Zm2kYI2mrYOBwKXNUox7BdlVNKsVUBbdQPfrU8drbxDCRIPwp+6k3VaSHccSB0FNLZpC1NL
+UCFLUVWkkIbFFK4z/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0023/full/!100,100/0/default.jpg</Url><Caption>29376_0023</Caption><Caption>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Caption><Caption>Exhibit</Caption><Caption>plate 092</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJSj
+5h0I+oqULSlagZCVNJg0XdxBZWsl1cyrFDEpZ3boAK5K2+IdpqE7rpmkapewJ964ig+T8yaTaQjr
+MGlwajsby31G1W4tn3I3qMFT3BHY1Q1vxPovh6POo30cb4yIgdzt9FHNO8bXCzvY1MGjbXn3/C4t
+D8/Z9h1Dy/7/AJY/lnNdZofirRPES/8AEtvo5JAMtC3yyD/gJ5pRnGWzKcJLdGrtpCtT7aTbVkld
+lCqSTgDvUOUc7VZSfQGrpFMKD0pWGUjFzRVvaKKVkBZFISB1OKUVx3ibxfZ6TcG2a9WN84YKcsB6
+ADvQ2ktQOqmaF4ysoR4mGCDz+lME1vbxKEj2x9PkXAFeVP40tPPZolnmBHJ2Y2ntg9c1VPi3WJ2J
+tLG6B3AqTJj6jHvXNLERW4WZ3muGXSpvO024EH247XGzIDD+Ieh7Vy+q+FNMtoFvnaWW6dwZZZpC
+xf1rD1vxTqcVhby3dssMgmxEpfPbv0rDu/FOt6iAVj84pkbViJjHbrkZrkm3UlpsbwfLG56zYaVo
+scITybfJHtk1z3iHw1b2M8eqaQ32e8hO9HQ9D6e4rmdK8Xa+k0cL6XbGJhtYD5c1uaXr7azDcbgv
+koDjJ549apxjGN09hwm5M9E8L+IofEWlLOoCXEeEni/uN/ge1bTEKCWIAHUmvALnxRd+FNU+3aaq
+SFomSSJgdr4PHTv/AI102h/E+LxASJIVgmUZ8hicn3HrXdSq81PmZnUhyysj1XzYz0YU4YI4rjl8
+RAqCz+XkfxrkD8q6HRp/tNoXEqSDONy1opKWxFrF0iikkfa2PaigCfoK8A8V6npUuv3UiuwbzWBA
+jJJ56175M4jgkc9FUk1816vcWR1Gd1kAkLt8yg8g561jXeiQ4pdS1Z6vpyuv+kRALzgqcn9K6W28
+X+H3tQ0l0qSA4CyKR0rzvfZpG+wkkkZbb+lS6dbWE10guAzQkNklTtBI4ye1eZUows22zS66Hcpr
+Vh4juJbITxNbpjeMcH8f8KsGPSoB5SyKyRAARh8D24rziPTIpL64S11COCNGGG3E7h1xx6VEbFjd
+bW1DzQW+8CazWHV7KegXv0PVUt4UiztWM9gOa5PwjaST3+tWkFzh1nysZ4Z1GQcVTsA9upaDU9rD
+AEbNnP0z0qYaKs9000zmMMd5kt+JN3PfPetaKUeaDe5S0d0V/ENktk9wZJt0qnBXOdg64+tYfh6R
+P7bjumJWK3JbI4LH0qeTR72PcR867iSrPktn1qnhrW6EMkYQkBiMEZ4GOlehTso8qZFSTvdnqKav
+bTxZfJcjJ74Neg+CZEl0iQohUeZ1xjPArwiPEDjBMLAEbCxwx9fWvYPhXNcS6Dd+fJvAn+T2G0cU
+6UeVkN3Ozn++OO1FSSAFufSitxC3C+Zayp/eQj9K+Zdbs3tdQmVsArIQCeD1r6czkYrynx54JuXd
+7qwiaVHJJUckE+1ZVk7XQjyULGG+c9f7pqRWWOVdhZSRgEirTaXdabJ5VzbSpz1KHFDQMWPkpvAH
+WvLqVPe5WOxClvaTOytkSEfKx4w30ot4sH7RkAR/Lz1Y46U8Wq8k/vDnBXOcVbit47Z0Vk2jOeTk
+DNZudhWLNlpwEMtxtDS7WOAM7RgnIHetS10g24SSW/MqtuIMqlMptyCo65zn2qjazOt04t5GV9oC
+umcCkvtT1e0IjMzSE/xcAL9OM1vSqXVmXFpIk1VXgFvMG2GXrEByf8KxFme5uQ0igso6kY6Hj8qt
+vdm18y8aQTTyfLGp5Cj1zVaCCW4fcF3McnCrnJ966Kc0xSbbJNkQcv5aBm6ncWIHtXtHwvjCeHJS
+oIVpieR14FeX6LoOpatOFh06QDoXxtA+te3eGdJbRdDitHChwSzbemTXRT5m9RGq65NFKTRW4hgN
+O3e1QqaeDQAS21vcLtmgikHo6Aj9ar/2RpmAP7PtcDkDyV4/SrOTijJpOKe6AovoOkOctploT1/1
+K/4VFJ4d0WQKJNGs3A6ZiU4/StPNGaSpw7Bcz4tC0iEfudItE+kSj+lOPh/R593naTZkng5iU5/S
+tDNLmj2cewXZkf8ACI+HvlH9j2mFOQPLGAfpV6LSdOt8eTY20eOPliA/pVrNJmmoxWyC4iosYwka
+qPbilJ4pCaaTxVABbBoqGRiGopAf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0027/full/!100,100/0/default.jpg</Url><Caption>29376_0027</Caption><Caption>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Caption><Caption>Exhibit</Caption><Caption>plate 093</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3ERYH
+AGaeE4GQM96exCLk1CbqL++v51Fh3HlaTFQG6jzjzAaq3GoKqkAdP4ial2RNzRxRiueXW2t5Mk+Z
+H3Gen0qdfE1oTgowPpTViedG3Risk67G2PLhdqtQ6h5nJjA/GqHzFzFBWoxdQ45OKlV1cZU5FOxV
+yGRXA+RQx9zimhHIO5QPoc1axSEUrDKRhyaKtbaKVgC8LC2JTg1y9xfLbN++uY1574rpNWQvpc4B
+wducg4ryS+sYyzfNL5jMOWOcCpnPlRLOpPiS3GcShz/CAvX3qlPrwZsvA/J78j+dcfFbmKd4WcsU
+IKYPVT7/AKVsf6SdOdYEVrjG1Pr7Vzub7itc3VvUuEAEkak9FK4z+dQyE7/mjXcOR1FcxHqt3Nbm
+G8hVSpKM6nJ4AySP8Pyq7bSzwwFEcyLgkZOcfSlCoKULPU6myvxED56ABR6j/JrROr2YjO0sHHVc
+ciuBku1Kb3MkRToACetWrLUbRVA3SSZH3tpNdMZ3Fotjon1a+SfzFVWhJ4U9R+NXIvEAUjejIfY1
+hNqUbxbIztX1INPF1bMgDMjevFXzFI6qHVd5z5uR6Hg1tW0yzx7gc1wkM9krDbNt9ua7DRJoprVv
+LOcHBOKOZMpF/FFOxRQMqaxJ5WjXcnXbETXj1hrf2q8uRNEoWIDbnnmvZr9Fl064R/utGQfyr57Y
+R2mszB2ZYgxBUZw1YVtNRN2H65qb3N1FPp8e1lJygTkD3ptjrGs32pwxWiDyom3SMRgN7ZpYlg8u
+e5huAs5bCx4ySOcdfpXQ6YmnWHh2B4kVbgYkaUHHI9T6VxzlZbbmlKN/eZk6tBqtvLcXE0Uce4gj
+y1DhBzk5x1zisZNYuYEMlzcnyyec4XNW7zXby/vpIxFPKM7fvgrj+VSjTdNuLZ7q9LszIFihVuVO
+P15qYy+y9hOPPIsweJEv4c2zjapCu8ibQCenJrZ0++SZv3kcDOh2nb1B9Mis7S9LaztkkWFQk0Si
+SFxn5lHX696n0+5sLTYNQm8qUMTGuwZI9Scf4VUVGPwlOCSNzFu6szQkfSQ1LFb2bpt8uVT7tUVr
+cW9y7GKRMdhnrWlbusQZoQpcAMck4INaKfZkJElrpcRTeqygDuTXYaTFHHa4j6Z71hadqklzIIpI
+gnr3rp7cARcAAe1dFJ36lSSQ/FFLRW5BDdrvs5lAzlCMV41eaOlvdSEWzySEnvXtDZKEDqRXKS6L
+qEtyzABVJ68VzYiLdrK5UbdTzq30qad/khSJRweeas31m8FoYZYmkiIxjaAuPQ8Zrsr6wewDtiSS
+QLwAvGa55U1LUJo4WVVJfIQMM4rzasXsjReRycVqQ4jiQpEOgA/w5qci6jjV542jRWwm/nP0716H
+eWFzY6cREs3mMP8AllHls/U9K5AaJf3eqJcXBkc54inAJH48Cs/ZSTsLl7GTZxXMc5FvJ5WecjIz
+9c1WvLcXE+94ITIOCUcLn8q6G4iNvOVurh5ZA+0pwAP0FPuY7SJ4ZYrONpdrMcITyBxk9OtVTnLm
+sS9DEtLR0UfJJGD+Nbljd3mnHakkhHXGwkYrS0aC9v7bfLbHYeceQVJ/H/61aE3h2RIPtNslzFIO
+qIM/pXYo3V7FKxX03xVYXNwkU7eTJnGQOp989K9GtiDApHpXJaLo0d63mX2nRAjjzNuCa66KJIIh
+HGMKOgrrop2uRKw/NFNorYkjR8qD6jNODH0H51UtHLWkJPUxqf0qwDRcCTg9QDTRFErbhGgPqFFJ
+mlpaAOOD1AqJkUfMYIz7/wCRT80UaAVzZW0hLtZW5Y92A5/Snx6bYqdwsrdWPXCD/Cps04Gjlj2E
+OWOONdqIqgdgMUvFNzSZ5qhiknsBSZPekJppNAC5oqPNFK4H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0024/full/!100,100/0/default.jpg</Url><Caption>29376_0024</Caption><Caption>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Caption><Caption>Exhibit</Caption><Caption>plate 094</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7NH
+/wA81/75pREikAIBn0WrQFLtqbAV/K9h+VHl1OVpCKVgINlKFqTFG2mkIZtpdtSbaAMGmBFsoKVN
+ikxTAqFgCRh8j/YNDR8Va200rSGUmgBPSirRWikIsgUuKBS0wEppFPpDSAYfWlApcVBcXH2W0lm8
+tnKLkIgyW9AKVxEV5qlhpzIt5eQQM5wiyOAW+g71m3mttLdiz06PzLjvkgBfc/5/CvN9ai1LUdeF
+1qNuiTySKI4VblcAbV56dyfTnpxXbWk1npGjOscge5cbpXT+JumB7DoK5/bN3vojVwjG3VnQWk7x
+WRkuJxMyjLFVAAPpV/GRmuWtLxFWKFmDM7CQqGGDjn8ADXRxSCQBjJn2HSt6c1JaENE2KaRUmKaR
+WjEVpZVjbB9M0Vi67O8V6iq2B5YP6mipA6YVT1DU7XTIw9y+0HpxmrYrnPE9tBctGJi3yqelEpWV
+xlxfEli6hk3sp5yBQ3iOy3YAc888frXKxhEAVHYKBjhR/jWRNd3LSlmuBCmcKioN+B7iuOri1AuN
+Ns7u68T6fEvLMfYp1rmPEniWxit4bmzujD5WXURfLvY8Yx0P+fSsW61DSbZ080y3ErYxGZCxP4Z4
+rD8RXmm3sAa0hZHh+cRuOBj+X61zyxMpFqi1qXobueW4e+vJjnBAVedoPP457mntqjxYWW1m8ksC
+sgx0J4OM5q9oU+kX2nRtDNErMBuBb5lPpg1rnRtMMDeYxkU8EvJxj0rPWT1LjGKWurMG31ARyCYu
+Nx4GGHAHb2rorX4i6VahInWU/wB5gO/sKypNDtYUJgIWM8gAcVy+p2scd4ZGjBUcMemfTFdNF8vw
+kSjc9V0/x5oeoXcVtHcuJpThQyEDPpXTHpXjXhgWqa7akWByJB1GMH16V7MelddKpzozlHlZz2tx
+b71DjP7sfzNFbE0Ecr7mXJxiirsSWRWdrN1aWdv5t0+xfpmr4NVNTsVv7UxkA/UU5XtoCtfU4uXX
+tNm3rbNz03FgMfhXOSWdtNM8s2pKCxO1VcV1cvhKDcS9puJqKPwbBn5YSnv1rzqsJzd5HRFxirI5
+SbS4Li3DT30AIA2tuBbHbpXOXOmhCRDKswB7OwOPpmvWD4VslTDQkn1xWdc+DrSQ7lzGT6c1kqMo
+sHUurHl1hZwvdGMReVL164NdDPYST6eiXN267T93zufrXVJ4DglKyM7bh3KircfgtY5AQpYdzjmr
+9nJ9AU0jkC17HZ+XaXalQMAshYj8TVGPw7f6o/8ApN+5Udo1xXqI8OoEwFfNWLTQ2gbIDYPpW0KM
+gc0YfhbQltp4mZWkaM/fdjmvQT0qna2SwfNzu+tWz0rrp01BWSMJycnqRnrRQetFUIjSTcoYdCM1
+IGqjYOWsLZj1MSn9BVsGmBMGPcUZqLdS54pWAfkE1GzbRny84oBpc0WENWYt92In8amViRkjB9KZ
+mjNMCXNITUeaTfzTAkLH0/WmlqjL89KYZPakMeTzRUBmwen60Urgf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0040/full/!100,100/0/default.jpg</Url><Caption>29376_0040</Caption><Caption>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Caption><Caption>Exhibit</Caption><Caption>plate 095</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3DYwx
+tXPrzT9lSgUuKkZDsNBU1LijFS0IhK470balIB6gUYpWFc5bxnqPiHTNKibw3pQ1C9llCbW+7GuD
+8xGR9OtcPN8QvG/hra/ijwxGLY9ZrY8D8QzD+Vew7aZNHE0LCZUaPHzBxkY96fKUnY4Cw+LnhS9i
+DS3Utq+OVliJx+IzV6L4k+EppRGmrx5Jx80bgfqKwde0jwK8kkh0KIvuwDbv5QY/ReK5K/0bwjcQ
+zJa6dcwPgiOaGcsAffPBrH2qva6NEont9rc219CJrWeOaM9GQ5FKUlz/AKoY/wB6vA/AeuXvh3xQ
+tjLKzQM+xlzwQe+K+h1KsMggj2rSEuZBOPKUjb5NFXSoop2IJSdozgn6VUnu5V+4qgf7VSX15BZQ
+b55RGCcAmsNdTs9SlaO3vI2ZRnAP+NaqxEmR3mqX8Eu+KUN/sY4q3Z6/LIuLq0MTf3s8Gsy8vLbT
+mPnXKBgMncR/KqL+JLGZvluYemPmJH9KtpPoZXaOyj1K3kH3sVMLmA8+an/fVeZf8JLo8m4f2nFu
+T7/BH5cc1BdeMtEs4ldbrzc/wqrEn88VnLlXUFKfY9VN1bqMmZP++q5PxZ4mSxiMUc8aKw+ZmIwR
+3rzu98YavrH+j6RaG2hP/LZxlse3YVlv4bJKz6hPJPK3VnfOK5qtWNrJnVTpTestCC41G0u5W33q
+eWhJVXOCTU8F7F5DszRrEBkMPX1NWtP8N2V3cNGUGwA5OKxtf0GPTnDwDIB7iuVcuxv7HzJ/D1r/
+AGl4lN+4228R8wswx8q967Dwd4muZNfWE3E3kTSsSu3cCT/KuUvL1v7Ji06wQRiRFaZweXbGcfQV
+b8GWU0XiK0DSBZFkUkbgDg11QpytzGVSSvyroe/Yop2KK3MznfG0U0mh5gVDIrggt2FeTRymJ2Aj
+Y3GclyQcH6V6z401COw0cGQA72wM15lbXtpc3OI9obqc9zRKbSsibIx703HmS+ZIZHUFmJ+ao302
+P/Rjvlubi4OBFFgfqaXzZrK4ulviGjuM+UYSdx55wuM+2falshcR6nZXMVuy25YyggdAMjFc9SpL
+qbwpxTLN/wCGLa2tA80Xlynqu/d+tU49FtVvI8rlcitnVdVhvm8lc+Y3HTpXPyXk9nI3m8rGRz6j
+OOPeuROTdjZ2PQ7eyjjtkEaKox+Vc7rU5EvkI2T6g1PZXt7eIimVbaHH+tmYKMfU1KieH7Njcalr
+NlnqF80Mx/AE0QpyuDmkP8OuYLWXzR+9OPmPpz/hWd4rObfIGas6l4htzHE2nWbHT2T5rkjBx1BA
+9AetYmoai9xCAVWSFhlJFOVb6EVTi07lxdzmdT1L7KY4Od6xqfpnnH5YrQ8L6j9q8WaUqfITOqkn
+kYzWH4ghZZmvkUtC4AcY/wBWQMYPtxwa2vhxdaa2t28UlnLcag9yi2/zYRF7k9yRXpw1gmjhndTd
+z6fHSigdKKkDzH4z6mdP0Sz/ANGaRHkbLg4C8cV4b/aM01w0duGZSCDhvvHH8q+l/G1tHc6XH5wJ
+iVssAMk15Dfrb6dDJcRWqqVU7UA5J65PtVcyXTUnlucrb3c9j5pgIFyQCfw/h56Ctaz+IDaQhtW0
++OZJPnw0vCn2OM1wk99d3ckqxElnfJb1NXbLQNQnKNMsjLuyT0OKznCmtZ7le0ltE7/R9ck8SXr3
+NzawW0FtyCg5P+8e/WuS8UeIJdUv/Ksi6W0TYDjjd710o04Jo7afp8UkRlP7xjzx/jVNPCkNrGjT
+uPbLck/yrijKKm5Jehc23FRTOJd5pn+dJZiO7MTWrp+jXF1E0hjliAbAxHnj1/WvUdAs9Ps0BuYl
+O0cFwMf/AF66G51fRIIA2EPH4Guj6xJqy0M1BXuzzeK6httDWyjS8kkWJoyrRZ3E55GOnWs7QdO1
+qzkVsC2hYYKShdrfUHqa9DTU7GYk20Ict3UDj8ayr+C5uJFkeLZsztKvk4znB68VKm1dW3NN2vIw
+9e1W0t7WaOK3QSH5QQODxg/hnmqnw1tg3jTTmKnPnA56YpbjSybkySRNK7NnOM4/oK9A+HXhc/2m
+moP8qxHIX3xW9KKhG3cVSTlK56/RSZoqiCje2kN/atbzZ2N1wcVyd54EDk/Z2gcc7RMDxkYPr2Jr
+sVNPFNrqNOx5zB8JbG2JaAxK56tt/lWhH8PEiX5Zo93qVruAadmocU3cLnIr4Eh2jN0Q3fC9arXP
+w9guWXfehNp6hckfT0rt80YDDkCs3Ti3qF7HDyfDm0kj2nUWx2OP/r1WX4TWbTb5tRldQPlXZ/Pm
+vQQiqMBRTs8U40oLZBdnIw+Aba3i8uO6YD2QClHgK1yS97MxPsBXW5ozWihFbILs5iHwRpkTAyO8
+g9GOAa37a1t7OLyrdFRR2FTk0wnimAuaKjzRQB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0001/full/!100,100/0/default.jpg</Url><Caption>29376_0001</Caption><Caption>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Caption><Caption>Exhibit</Caption><Caption>plate 096</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Hyyo
+yAT7U8JxUoAA5qpc6pYWkLTT3kEcanBYuODUWAm20bajjvrOaHzo7qF4v76uCKes0b4KyKQehBzm
+pshXArxSbTVPVZHtxb3A3COOZRKQeNh4OfoSD+FLqOtadpRQXlysbN0HU49fpS0W4Et1cR2cDTzO
+qRrjLMcYqFtSs0sxdtcp5B6PnrXHeK75Yopmn1OKSzl5CD526dh0H4157qXiWd3ighaQWSY+Xpgd
+PpUe0fNZILnvkTJPEskbBkYZBHeq81/ZQTiCW7hSVuiM4BNc34d161vPDssNvcqsoj2R7perY7el
+cDeWv2a8kvNRczXO7g7j2NU6iSQ0e0MBg4+YjsOtRgbzjY4+oryPwzr99D4kXdPK0TsA4kc4b0r1
+21v4byRkiydvU1aaY7jTb5PeirhUUUrDEvtws5Cpwcda8R8SRs1/MFEnlnO8uMDPbFe0a1OLXRrq
+c9ETNfPupeKVF1KsrkoRkEpgf41NSLbuhI2tGmS00/bPPIzyqdqqeAB61oaJ4viaaKxtIpmEBJO4
+devv71xOlahNfXRuUIVGUh1Y8cdMCk0nUJrLVmm+ykRsecHkc1i5WuJxPcYtettWs/s0v7tJo2jK
+uQG3du9c/ruoaXqGjwtfKjXka+XJyeq8Hp78/jXIpqsrREiNFJJPXmqzagsd0kt7Duifg7SWKsOh
+x3B/oKlVefRicWR6tfx3Fklss+xQAoIOT9BWBcwXEEXnwl5EjI3cZ3duKt6hJCbr7RARLhshSCNo
+/HvUL6jMqu0duA5xyzDmmk1sCT6jbEXen3CzI37tnVihHIPXHv6Vq69qxnDY3MzE/KhwB+dc42rX
+AkifaUkjOd2QR9MVZlv/ALZLE8sRA43FVwD16fpWqi7pspLoa3hieZtQy20RvgMCwJr2jwujedIc
+ttA46YNeHWd5b2WoLcWNrLJKB0kPy5+leufDq71K98+S8VEjAwFVe9aq1x2sju8UU6imBn+IRnw/
+eDsYzmvlvX4pZrtgijYDgEHJNfTXjBgvha9ySAUH8xXz1HZteantUjYDudicACs5y5WOKvoHhiy1
+HT5Bei1eSIfIUI4IOOKNZ0m5iWe+VbmzUMGNvIWAweRgk+xrutPuYoReWeFeBSrqSOvyHOD9VFcq
+3iF9eguxfD7VHaAiJXJwCSOeOvOMZOeTXMpuTbZrKKSsc9Bf6jNcSLERGqEgkDOB+NaMJt5jiW6u
+JZT28w/0qlcpdwXKabIsUfnfMgjHy9SP6GussH02PREgl8u3v7fl3dcFgR2+tS0riVkc29sBdsDL
+OkUf+sR5d2Bj61qxroF5D5UV+lvcr08wHBNS38SRW7BJBMynez4++T7/AJVzVxo8ImtLm9WSOCRO
+Z0BKhsnqR0rVRT6gpeRZ1rRL2zC3G4NH/E8Yyg9CKxib1EEhLNGTwytkfpWrq8+peHdSjsra8kls
+5lDRlgGBFOWO+t7Z76VIp7ZhiRQMHH4Vqm0lcOVN6FWw1KWB+GI+vNe4fC6/N1a3CnG7gnnr+FeC
+uI1ZnhnUoDkLIO31r2H4K3kdyt6gLF0xg4wK2SXQzdz1aZ9j49qKScLvGfSikSZHjP5vCt4uQMqA
+M/WvBZCbfRmkbIHnkyso5KqM4r3/AMS2Zv8AQriEZJxkAd68D1ZLsRPpcNu/7wlWO35VGeTnPPFc
+9d6pGtKyuzmrTXdYF28lrM6WrOWEDAMu3056cHHFaH9oHQrmS6hSQQTLvfYqkDPYZHHcVq2mkvEy
+Lbxkt0PFWNbtIViMFw2xHi6FSd/Pb0NYe1UpaIq3dnEajr8t7qRmjtUTLDaoJJGPQ11F3Ytr2hLd
+LcCG9iQEb2xvHpx3rF0jR/LBd43Jydo28kdq6izsL7yWENu2xxhlYdR+NTOtFStHoSlfcxdPmA0m
+T7RLIqRExssnOSRyAaZo2utL58MrM9ptYxqeoPrV3V9EvZ0gtXJS26sh6g5yT+OetX7Dwii229Vy
+OhC/41arQa7hZpnOWscmpTQrPN+7tHZFXGcc+tbsumRPGEQt3zjPQ1tabpCWkuFs8qzEsxf5snv0
+rqIIdNVRA8aRk8AP1JqXW5paOxSWh5onheFFJik3E8lSf8a9U+FVoLRbpWhKv03Y7U9NCgVsi3ib
+PA+QfzrrNAsDaRMxXbu6Cuim5N6smWxqTq7OCvTFFOc/NRXQZCZDDB5BrOk0LSpXZ2tYt7dWxzVx
+T0qQGk0nuh7Gevh3TkGFhUA9gMVSufBunXMgc7h+RrfzSg1lKlCW6HzMxY/CWkxqAIAfepRoNjGN
+i7EX0wK1s0hAYYNJUaa6C5mYp8NaVJIHk2uewJFW08P2EabEiVV9ABWgoC8AU7PFXGlBbIOZmZ/w
+j9mM4Xr7UkXh6xiff5alvXaK1M0ZqvZx7D5mV1srdMYUcVONqrhcY9qCaYTVJJbCI5JNrY9qKrXT
+ESjH92igD//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0034/full/!100,100/0/default.jpg</Url><Caption>29376_0034</Caption><Caption>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Caption><Caption>Exhibit</Caption><Caption>plate 097</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2KAbQ
+BtJ+lXlXiq8C4q4orNLQoAtP20oFDukalnYKvqTimAm32o2io57u2tYfNnmjjj/vM2BXKQeLbnVf
+EkVvpsanTVbYZWGTMe5X0A9aTkluNRbOv2j0ppUelS4oIqiSm0kQz836UjIM1ZIqJhzSGRRLzVnc
+EQsegqGMc1Y/gP0piKF1rljZ2ouZJl8rdtJB6V5b438S6jrHiOHSLGYwWONzsp+Zu34D/PSsLV9R
+lnvdSBlaSKO42hWPBbPOPof51ajtX+1rMzhTcv5jH0jQAKv4kGuSVRy0N1FLUtasbbR1DXN3PdMs
+XlpBvO09OP0/Ku/8DaNdQ2g1XUoliuZ0xDbr0gj9Pqepri/A+kxeJvGV5qk+ZbOwYLEr8gvzj8Op
+r2WtKUPtMmcuglIa4H4jeLbrTNPu7DSX23yQCbeuCQocBgPcA5rD0vxDd/8ACYT6hc6pONJh0pbh
+AxJR+PmJ465zW9zM9YIqJsZrlvAXjm38b6bcTJF5NxbybJI854PQj611D4zQwGJ1ov5/sumXU4/5
+Zws/5AmhOtV9bG7w/qK4620n/oJpdBHhuhKl5eLBcqVkMgkfd3+bcT7/AFrX8UXFpCymFiWC7EVe
+SeemK5PRzIYvMDATrkqxz0Bzgn6c10nhmz+2NLqV0wcgHYD/AAj/ABrz5+4zeL5hfBt7ruk6bcw6
+e0UEcj+ZJJJHuKn3PSrt7488VWMnlC8hmL8BvIHy+/FX4Pn06dVTavmHfj1IHNYen2C3fiAxXMix
+wxDexLfeX2rONefNa5pyxtqdP4S8IS6lc22sapI7SxTPP83O8uACD7ZGa7bxBoemajoN1aXcKpbF
+Mv5Y2kKDu7fSrmlT2s2mxPatmHGAcY6VYumRbWUyDcgQ7hjORivSh8Jyt6nk3w88U6PfeNrrS9B0
+tbSwFrjfgBpChGCQPqeteqv1rxf4f6hpmo/Fm7k0rSmsIFtJAyucMzbhzjtXs0pwRVXEhoZU5Y0l
+00ctlNG3KuhU49CKz9WmEFqJWkkQKc5TFc//AG4/kmRJpQhB+8orO6tqS5a2PIbe0mM72ybTF5nz
+AnBwMgiuha7hhltxax/Z7QDbM235R+NU4EW2vrmbzTFvISOTAIDZ6nPbv1FW4jFbW97bTubgeWZF
+KgYYknB4Jrzpy5pXOmOiKVz4klvtbGn6XJJFaQA/MoOJH9W9q5668aXVprZAWNTEWiDMMt6EkdK7
+bQdGg02wOQGkc5kfH8XUj8K4XxB4etotTe4Visjku8QO7B7n2roioN2aI5maQ8XNb3aMxnmnQh0D
+yYVT1yAOK958J+JF8RaAt1IFWZRiRB/Ovmu3jhinae5XdIf4QcYroPDPj280vXIYrVo0tGcLMhHy
+kd61jK2iIep23hfxHZ638YLmOxsEt4Le1li8zZh5W3KST+XFeqyHkVzWlaXolprEur2loI7q4X5n
+DDGDzXSSHODWl9BI5bxpM0OnoQVHP8QyP5GvOH1ktHJDIUdSDtXZxn9K9R8T6c2oWSpkhQeQO9eR
+apYL9vS005SctsLjnJ7n6CuOafOWkXo7e5ktd8IwCxban8agYxzn1qppGmahHPLFd2piEvCEEYAF
+dbaRrpdhFCHEjqDg5+WsfU/EFxPut7dkIB/1y8c+g96FFNDbZcmuVgj+zWocueNwXlfwrhvELrbT
+MWkDSEYxuztHoff1rWOvW2naW8bzI107EZAyQPr3ridRu/tk5ydxJzyK0jB38iTPuJyx2qT8xyTj
+rWhoOlSXdwGUERA5ZzWhpHhq4vyJnQrABnJ/irpE0ZrePC7kX+6honUUdEOx1/hi6t0uILdJX2ph
+RuQZP416axG1cdMV5L4Xtliv4yyORkdVNervwqgdMU6bbiwtqRXVr9ttnh3lN3GRXN3XhaS1hZrW
+MPKFxu7ke1dZGasqciuh01LUm9jxHVU1G1mMLwk7h5YJU5J46Cs+706awtmjeCSW5K4Xy1JVfb6+
+9e/MiN95VP1FNMUYGViTI6cUvZoLnynd6Jqs0iytaSkn7qhDgVq+G/AmoapqiRvC64w0rMOFFfSp
+C94V9uKegx92JVz17VXKx3OHtfB8NtZxwLHkIMZPennwkMAJGgPqc13BppNZ/V4j52c9pWgrZEsw
+AJPIB4rVkxkCp2JqtMfmHNacqirCWrFgJxVpTxRRVR2Ex+aTNFFMQoNLmiikAhJqPcc0UUwGN0qn
+MTuooqZDR//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0017/full/!100,100/0/default.jpg</Url><Caption>29376_0017</Caption><Caption>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Caption><Caption>Exhibit</Caption><Caption>plate 098</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tYQo
+zzTxGGUEZwfUVMBS4pWEQeVTTFVkisjxHqyaFoN3qLFcxJ8gboznhR+dS9NQM/XPEul6DLHDeSOZ
+5BlIol3MR6+1SaJruneIEkaxlYvFjzI3Xay56cV5PYW1x4hkuLya7Ml/kSbpOmf7vsMcV1HgnRNR
+svFAvfKkFrcQMjnsD1HT3FclPEOdSy2NZU1GOu56R5XFAgqwFpwWuyxiVTBSG3q5ijbTsMoNAApJ
+zx6c1F5Ks2MPz6qRWntpCopWAyzZAnvRWgV5oqbICcUp6U0uEjLk/KBk1lyeIbGN9hkG7uAelXdC
+Zq15T8ZL9yNL0tWwjuZnGeuOB/M1d1fxVqNv4xgntbwHS1jAkhGDuOeQfQ45BrjviZq8Gr+JbCSB
+gUSDaRuzg7if8Kwq1E4uKeppCLum9ibwcrQ3cysDhiDmvVNBhSG6kFtGwgKASM5wd/Xp9DXm3hq6
+g8iR2A3RNjr6V3mm+IrUF5/NjE1yFd4y4+U4xiuHDNObbNa+h1mOacBWG+o3UgzG6L9OcCmW+qzf
+aWjmY7B0cetempq9jlN+lrNN1csf3LxsMd+tRrrG1tkiZfp8taLULmrTTVIakCu4wt+dTwXcdzwm
+QfQikVceetFKetFSMpX2DoUm7vEM8+wrxm9tkM0pM79T9017LrAJ0K4Cjny+K8Lu5giyTMQAhJPB
+6CuPFN3SRpTKTWvk3CtFKwI5+bqaTU9LF6I7mNwkwPzA8A0WuoJqZ3wHgcfMuOnf9afe3Is7bLAs
+2flXIO4/0rhbmpW6m3QtWluLa2lWKYmSQgnZg4Peo7zTkkkUrPNNtUbixGT+QrEhTUb9i3m+UrH7
+qHbW/pXhR5ZlkuZ5GTH9/rRrF3ciWmyW31SazjCRXMitj7nmZFdNpfiu3KIt4WWXb1Ukg1yX9lwQ
+63tAURoN2W4AI6U6C6t4Lh5Fhku7g/KFjTCJzkZPetqc5JaNkOCvqd1/wkVkJRh539z0/wAac3iX
+Tov3qzSDrgAHP5GuNnjcWzXF7IkK8naDiufGuz3l8YdMtkcRKcyyk4x9K6KdSq9xOET00+NJSCUj
+kKds4Fa/hbVby/1XDxgRcknPtXkEPiV7e+EGpW4jxjmMkD8q9g8F3EE7K0Me3jrWkXVcld6CcYpa
+HbEc0UtFdBmVrqJZtPkib7rJg/lXjuq+G1M52MUjBI45Jr2UjfCV9RiuavtLySQAV69KzqQUlqVF
+2Z5YPDscCl42ZFXn5ep/Ksi6kR9QFiRvXIUNjJ3eor1K4sFWIjb0rEbSQqh44QpByOK4KkHc3UlY
+4PU7iO1nSFGxsYFyPatFfFd29rHbWts3mZBDEY57VtR+Emkunl8xkDnO0L0/Gt638PRRwJGkYZkA
+wzdSaiMFZXQpyu9znbKCXWczX1qsLKRkKCMkd8Gt2DT44IyY169SeTViW0NtKiO6jPJOc1fjhBgB
+jGcjOK2jFLYVzivEenf2jZtGgb5fwqj4NtoPD3mNfWjTbicsuOK7WS1iu1fbJvZThgvUGq6+HzMw
+LK230Faq9rD0OA1/S21zxBJd2sDw2x/vDk16r4AspbeNNytgD+IYxxTrHQlUhRGMemK6zTrX7Mo+
+UD2ArWClfUibVrI0M0UmaK2MiGNvlFOwrdVqCMkKKlBoAR7S3kHzRioX0q1c5Kc1aBNKDUtIZROk
+W20hQVPqKrnRrcqEZ5s4xmtfNHWs3CL3QXaMM+HdOeVHYSsyjGWOavpptoF2CJgpH0q5gDoKcKqM
+I9g5mZcfhzTIm3RW/lknJKEjcff1/GrqWFvGAAuQPWrNNJq1FILsaI40+6g/AUbvbFGTTCTVCFLC
+ioWY560UgP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0050/full/!100,100/0/default.jpg</Url><Caption>29376_0050</Caption><Caption>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Caption><Caption>Exhibit</Caption><Caption>plate 099</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0012</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EQj0
+pSiDGSB6VMBQxRRlyoHqagZCYR6UwwD0q0cUzcKWwFfyB6UnkD0qzS4piK3kD0o+zj0q0BS4pgUj
+bD0pDair20Um2gZnPbKoyxwKj+yq4ypyK1CtNKCiyAxm0yNjkqCfpRWvsFFTZDuTCql3OiTLG4yu
+0nH+fxq4tcj42vX09YbhQNuCpOamo7RuC3N03sYVED/LjGfas69161tQJPNGCMkZry2fxnLEjLHJ
+uDZz9awzqmpauWhgjeQp2HYVxyrSexXKe822uWk8YbzByPX2q5Dc+fhkIIYZH09a+dU12eOAESMG
+UbSOevpXpnhjxbbpYRC6uY0O3lnYAL7AVdKu5StIlxsekL70pwBk9BXNr430KNC0l8No43hGK/8A
+fQGKydf8aafMbSCyvVaORm8wgH+78v1HX9K6XUilcIwbdjsbPUIL8FrfeyDo5UgH6ZqzXCR/ETwt
+oxFg145mGNy+Wc5x34xWvZeONGvyBBMxyeCRxVKStqwaOkpCKqR6nbSnCMSfarmQygjvVXXQLEdF
+KetFAh69K4v4haadTtIEFwYdhJBCbs59eRXZr0rnPFEqKFWQ4XaTjA5/E1hiJctNsuCuzxCXQ301
+282QSr13Dv8AnWtoniez0gSQpcm3ZmBcSRjNQa1qPmMyR2F2Fxkg4x/PFZ9z4bc2D6ncGERRLkxH
+nI643eteeqjfxaG/LbZGhrh0fVfKxf2doVbcZI0bLjPchsfjiubGr2GkasDbRLqCbdrGVd4H0zWy
+mkaK9pHdDRL4wMgYuG65GcDA5pbLTdOvJWjj0W6t4wpIknc7Sew4WtEratmfNd2SOi0XxfYvCY2m
+jhjccw/ZVUZx6kmnw6NZXNtI9gokRMnLzDjvx8vFcFLfx2OqLbNBDJFnnyiSQPrnrXcPp8EtgBBc
+sIyu4oj5/wDHaPZ3V0y1Oz1RkS6JFqr7baeJ3i4lkz0+mOtVW8OX2mTeZaXio3YAYP5ZrXtp/JUN
+byeaBnLIuGHqNp61oQamLqHMdvHM6tgjzdpP6cVLVSL90ttSRa8O6zqGnMsd/wCVdRt/EPlZfwr1
+q2kWW1jkT7rKCK8eXxI1vJ5cmkMJAPmxIGH8q9Z0m5S70q3nRdqugIHpXVhpSbakY1I21LLdaKD1
+orquZAp4qhq1sLiLlQQPUZq4pp5KkYNKSurAnY861S0AB84sYvRUzn/AVhppmmOCqhVGc7W9a9Zb
+T7SQHMYOe5qi3hnT3feQ4Ocgg15lfB1JO8GbxqrZnmd/4fEkG5ppQMZ++cYrkr/w3cuga2nMjZ4A
+fkfga+gP7FsvL2OrMvfJqB/DekO257dCTg9KVOhiIrVpkuUD5ug0HV7a+WSQXSsp4YsRivQdIW++
+z4mxISP4kU/0r1EeHtLViwVsHqCSR+RqddGsPuogGP8AZH+FdkKc2veIcl0PJZ9I1Bt89vGgcAhQ
+Bjr9KzfDnhvUYLueW6tgpfoQxBHr9fxr3FdIs1HEYp66ZaKeIxV+xGqjtY8iubfVhfR29us/lDGR
+GVBP4mvWtKhaDS4In37lXnecmpFsrZH3CIZ9cVPkYqoU+V3CU7qw0nmikJ5oqySJWp4NVQTkc1Kp
+PrTuIsZozUQJpwPFTcLD80HB6im0uaOYQ4YHSnZqPPNOqrgOzRmm96SmA4mmFqDTDSuMYzHNFRSs
+Q/BoqWx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0020/full/!100,100/0/default.jpg</Url><Caption>29376_0020</Caption><Caption>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Caption><Caption>Exhibit</Caption><Caption>plate 100</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0012/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0038__xz111ffbb66842f49d5f2e023e5131778d.xml
+++ b/samples/data/s/sclaudubon/S_SCLAUDUBON_X_B6719890___29376_0038__xz111ffbb66842f49d5f2e023e5131778d.xml
@@ -1,0 +1,2891 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SCLAUDUBON_X_B6719890___29376_0038__xz111ffbb66842f49d5f2e023e5131778d">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">medium</Param>
+<Param name="fq1">Lithograph</Param>
+<Param name="sort">istruct_caption_image_title</Param>
+<Param name="rgn1">istruct_caption_image_title</Param>
+<Param name="select1">any</Param>
+<Param name="c">sclaudubon</Param>
+<Param name="q1">American</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">4</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sclaudubon</Param>
+<Param name="entryid">x-b6719890</Param>
+<Param name="viewid">29376_0038</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0038</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>cef2ec201abe7e1eb1a46d571eeacbc8</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:umscl-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink>
+  <CssLink>/i/image/css/imageclass.css</CssLink>
+  <CssLink>/s/sclaudubon/css/imageclass-specific.css</CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+<EntryId>B6719890</EntryId>
+<RestrictStatus>access3</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>authorized</Status>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SCLAUDUBON_X_B6719890___29376_0038</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SCLAUDUBON-X-B6719890%5D29376_0038</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SCLAUDUBON-X-B6719890%5D29376_0038</ItemUrlEncoded><TitleForTagging>Canis%20lupus%20%28Var.%20Albus%29%2C%20Linn.%20White%20American%20Wolf.%20%28v.%202%2C%20no.%2015%2C%20plate%2072%29%7C%7C%7CThe%20viviparous%20quadrupeds%20of%20North%20America%20%2F%20by%20John%20James%20Audubon%2C%20F.R.S.%20%26amp%3Bc.%20%26amp%3Bc.%20and%20the%20Revd.%20John%20Bachman%2C%20D.D.%20%26amp%3Bc.%20%26amp%3Bc.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sclaudubon</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sclaudubon</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="4" name="S_SCLAUDUBON_X_B6719890___29376_0012" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012</Url></Next>
+<Prev><Url index="2" name="S_SCLAUDUBON_X_B6719889___29377_0002" marker="111ffbb66842f49d5f2e023e5131778d">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719889;viewid=29377_0002</Url></Prev>
+<Self><Url index="3" name="S_SCLAUDUBON_X_B6719890___29376_0038">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=American;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038</Url></Self>
+<TotalResults>18</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'c'+'l'+'-'+'d'+'l'+'p'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-Mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632776098</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;q1=American;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SCLAUDUBON_X_ISTRUCT_CAPTION_IMAGE_TITLE___AMERICAN___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;debug=xml;size=50;q1=American;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>John James Audubon's Birds of America and Viviparous Quadrupeds</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SCLAUDUBON-X-B6719890]29376_0038</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/537,416/0/native.jpg</MediaLink>
+    <res>4</res>
+    <w>536</w>
+    <h>415</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_source class="fieldsRef">sclib</m_source>
+<istruct_caption_image_master_filetype class="fieldsRef"/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_flm class="fieldsRef">2014-12-11 11:23:16</m_flm>
+<istruct_caption_image_master_resolution class="fieldsRef"/>
+<istruct_caption_image_master_dimension class="fieldsRef"/>
+<istruct_caption_software class="fieldsRef"/>
+<m_fn class="fieldsRef">29376_0038</m_fn>
+<istruct_caption_image_master_checksum class="fieldsRef"/>
+<istruct_x class="fieldsRef">24</istruct_x>
+<istruct_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</istruct_caption>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_iid class="fieldsRef">29376_0038</m_iid>
+<istruct_m class="fieldsRef">29376_0038</istruct_m>
+<istruct_caption_color_space class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_caption_plate class="fieldsRef">plate 072</istruct_caption_plate>
+<istruct_isentryidv class="fieldsRef">S-SCLAUDUBON-X-B6719890-24</istruct_isentryidv>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<ic_collid class="fieldsRef">sclaudubon</ic_collid>
+<istruct_caption_image_id class="fieldsRef">29376_0038</istruct_caption_image_id>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_caption class="fieldsRef">29376_0038||||||||||||||||||Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)|||Exhibit||||||||||||plate 072</m_caption>
+<istruct_caption_scanner_make class="fieldsRef"/>
+<m_id class="fieldsRef">B6719890</m_id>
+<istruct_isentryid class="fieldsRef">S-SCLAUDUBON-X-B6719890]29376_0038</istruct_isentryid>
+<istruct_caption_scanner_model class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption_image_master_filesize class="fieldsRef"/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_caption_purpose class="fieldsRef">Exhibit</istruct_caption_purpose>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_caption_image_title class="fieldsRef">Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</istruct_caption_image_title>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_caption_image_digitization_date class="fieldsRef"/>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">6642</height>
+<modified class="imgInfHashRef">2014-12-11 11:23:16</modified>
+<master class="imgInfHashRef">0</master>
+<levels class="imgInfHashRef">6</levels>
+<size class="imgInfHashRef">7410676</size>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sclib</collid>
+<access class="imgInfHashRef">1</access>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<loaded class="imgInfHashRef">2014-12-12 17:07:40</loaded>
+<filename class="imgInfHashRef">s/sclib/pairtree_root/au/du/bo/nV/Q_/v2/_1/5_/p7/2/audubonVQ_v2_15_p72/audubonVQ_v2_15_p72.jp2</filename>
+<u class="imgInfHashRef">1</u>
+<basename class="imgInfHashRef">29376_0038</basename>
+<md5 class="imgInfHashRef">80667950baa159b01c3906d16885b082</md5>
+<width class="imgInfHashRef">8577</width>
+<use class="imgInfHashRef">access</use>
+<HighestQualityLevelAllowed>4</HighestQualityLevelAllowed>
+<Levels>6</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="6"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=6;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=6;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:6/0/native.jpg</Part><LevelWidth>134</LevelWidth><LevelHeight>103</LevelHeight><LevelMaxDim>134</LevelMaxDim></Level><Level level="5"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=5;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=5;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:5/0/native.jpg</Part><LevelWidth>268</LevelWidth><LevelHeight>207</LevelHeight><LevelMaxDim>268</LevelMaxDim></Level><Level level="4"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=4;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=4;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:4/0/native.jpg</Part><LevelWidth>536</LevelWidth><LevelHeight>415</LevelHeight><LevelMaxDim>536</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=3;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=3;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:3/0/native.jpg</Part><LevelWidth>1072</LevelWidth><LevelHeight>830</LevelHeight><LevelMaxDim>1072</LevelMaxDim></Level><Level level="2"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=2;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=2;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:2/0/native.jpg</Part><LevelWidth>2144</LevelWidth><LevelHeight>1660</LevelHeight><LevelMaxDim>2144</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=1;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=1;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:1/0/native.jpg</Part><LevelWidth>4288</LevelWidth><LevelHeight>3321</LevelHeight><LevelMaxDim>4288</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=0;view=entry;subview=download;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038;evl=full-image;quality=0;view=entry;subview=detail;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:0/0/native.jpg</Part><LevelWidth>8577</LevelWidth><LevelHeight>6642</LevelHeight><LevelMaxDim>8577</LevelMaxDim></Level><MaxWidth>8577</MaxWidth><MaxHeight>6642</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="default" class="default"><Field abbrev="item_id" searchfield="false" sortfield="false"><Values><Value>B6719890</Value></Values><Label display="on">Item ID</Label></Field><Field abbrev="istruct_caption_image_id" searchfield="false" sortfield="false"><Values><Value>29376_0038</Value></Values><Label display="on">Image ID</Label></Field><Field abbrev="istruct_caption_image_title" searchfield="true" sortfield="true"><Values><Value>Canis lupus (Var. Albus), Linn. White <Highlight searchfield="true" class="hilite1" seq="1">American</Highlight> Wolf. (v. 2, no. 15, plate 72)</Value></Values><Label display="on">Image Title</Label></Field><Field abbrev="is_part_of__work_title_" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=is_part_of__work_title_;q1=The%2520viviparous%2520quadrupeds%2520of%2520North%2520America%2520%252F%2520by%2520John%2520James%2520Audubon%252C%2520F.R.S.%2520%2526amp%253Bc.%2520%2526amp%253Bc.%2520and%2520the%2520Revd.%2520John%2520Bachman%252C%2520D.D.%2520%2526amp%253Bc.%2520%2526amp%253Bc.;select1=phrase" target="_blank">The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Work Title</Label></Field><Field abbrev="comments" searchfield="false" sortfield="false"><Values><Value>Imperial folio edition: volume I published 1845; volume II, 1846; volume III, 1848. Each contains title page, leaf of contents, and fifty colored plates.; "Entered according to act of Congress in the year 1845, by J.J. Audubon, in the Clerk's Office of the District Court for the Southern District of New-York.".; Illustrations are hand-colored stone lithographs drawn by J.J. Audubon and J.W. Audubon, with many backgrounds by V.G. Audubon; transfered to stone by W.E. Hitchcock and R. Trembly; lithographed and printed by J.T. Bowen.; Plates LXXXVI, XCL, XCIII-XCVIII, C, CII-CV, CVII-CVIII, CX-CXIX, CXXI-CL drawn by J.W. Audubon.; Originally issued in 30 parts of 5 plates each.; Error in foliation: plate CXXIX misnumbered CXXIV.</Value></Values><Label display="on">Comments</Label></Field><Field abbrev="creator" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Audubon%252C%2520John%2520James%252C%25201785-1851%252C%2520%2528illustrator%252C%2520publisher%2529;select1=phrase" target="_blank">Audubon, John James, 1785-1851, (illustrator, publisher)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Bowen%252C%2520John%2520T.%2520approximately%25201801-1856%253F%2520%2528lithographer%252C%2520printer%2520of%2520plates.%2529;select1=phrase" target="_blank">Bowen, John T. approximately 1801-1856? (lithographer, printer of plates.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Hitchcock%252C%2520William%2520E.%252C%2520approximately%25201823-approximately%25201880%252C%2520%2528lithographer.%2529;select1=phrase" target="_blank">Hitchcock, William E., approximately 1823-approximately 1880, (lithographer.)</Value><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=creator;q1=Trembley%252C%2520Ralph%252C%2520approximately%25201817-%2520%2528lithographer.%2529;select1=phrase" target="_blank">Trembley, Ralph, approximately 1817- (lithographer.)</Value></Values><Label display="on">Creator</Label></Field><Field abbrev="date" searchfield="false" sortfield="false"><Values><Value>1846</Value></Values><Label display="on">Date</Label></Field><Field abbrev="date_notes" searchfield="false" sortfield="false"><Values><Value>Plate undated</Value></Values><Label display="on">Date Notes</Label></Field><Field abbrev="item_dimensions" searchfield="false" sortfield="false"><Values><Value>72 cm.</Value></Values><Label display="on">Item Dimensions</Label></Field><Field abbrev="medium" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=medium;q1=Lithograph;select1=phrase" target="_blank">Lithograph</Value></Values><Label display="on">Medium</Label></Field><Field abbrev="repository" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=repository;q1=William%2520L.%2520Clements%2520Library;select1=phrase" target="_blank">William L. Clements Library</Value></Values><Label display="on">Repository</Label></Field><Field abbrev="source_collection" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=source_collection;q1=CLEM;select1=phrase" target="_blank">CLEM</Value></Values><Label display="on">Source Collection</Label></Field><Field abbrev="subject" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=subject;q1=Mammals;select1=phrase" target="_blank">Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="scl_type" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sclaudubon;type=boolean;view=reslist;rgn1=scl_type;q1=Book;select1=phrase" target="_blank">Book</Value></Values><Label display="on">Type</Label></Field></Section><Section name="Image Metadata" class="image_metadata"><Field abbrev="istruct_caption_purpose" searchfield="false" sortfield="false"><Values><Value>Exhibit</Value></Values><Label display="on">Purpose</Label></Field><Field abbrev="dc_ri" searchfield="false" sortfield="false"><Values><Value>The images in this collection are in the public domain and may be used without permission. Kindly provide attribution to the University of Michigan Special Collections Research Center for these images and where the original materials are held.</Value></Values><Label display="on">dc_ri</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Value><Value>The viviparous quadrupeds of North America / by John James Audubon, F.R.S. &amp;c. &amp;c. and the Revd. John Bachman, D.D. &amp;c. &amp;c.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_su" searchfield="false" sortfield="false"><Values><Value>Mammals</Value></Values><Label display="on">Subject</Label></Field><Field abbrev="dlxs_catalog" searchfield="false" sortfield="false"><Values><Value>http://mirlyn.lib.umich.edu/Record/013470827</Value></Values><Label display="on">dlxs_catalog</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/res:0/0/native.jpg?attachment=1</URL><Filename>29376_0038_sclaudubon.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sclaudubon:B6719890:29376_0038" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sclaudubon:B6719890:29376_0038" canvas-index="17" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">medium</Variable>
+<Variable name="fq1">Lithograph</Variable>
+<Variable name="sort">istruct_caption_image_title</Variable>
+<Variable name="rgn1">istruct_caption_image_title</Variable>
+<Variable name="select1">any</Variable>
+<Variable name="c">sclaudubon</Variable>
+<Variable name="q1">American</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">4</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sclaudubon</Variable>
+<Variable name="entryid">x-b6719890</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SCLAUDUBON-X-B6719890 29376_0038</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>The viviparous quadrupeds of North America... Vol. II; [title page]</Label><Value>29376_0025</Value></Option><Option index="1"><Label>The viviparous quadrupeds of North America... Vol. II; Contents</Label><Value>29376_0011</Value></Option><Option index="2"><Label>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Label><Value>29376_0002</Value></Option><Option index="3"><Label>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Label><Value>29376_0010</Value></Option><Option index="4"><Label>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Label><Value>29376_0006</Value></Option><Option index="5"><Label>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Label><Value>29376_0007</Value></Option><Option index="6"><Label>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Label><Value>29376_0004</Value></Option><Option index="7"><Label>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Label><Value>29376_0008</Value></Option><Option index="8"><Label>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Label><Value>29376_0009</Value></Option><Option index="9"><Label>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Label><Value>29376_0005</Value></Option><Option index="10"><Label>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Label><Value>29376_0003</Value></Option><Option index="11"><Label>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Label><Value>29376_0052</Value></Option><Option index="12"><Label>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Label><Value>29376_0039</Value></Option><Option index="13"><Label>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Label><Value>29376_0014</Value></Option><Option index="14"><Label>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Label><Value>29376_0051</Value></Option><Option index="15"><Label>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Label><Value>29376_0018</Value></Option><Option index="16"><Label>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Label><Value>29376_0046</Value></Option><Option index="17"><Label>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Label><Value>29376_0041</Value></Option><Option index="18"><Label>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Label><Value>29376_0012</Value></Option><Option index="19"><Label>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Label><Value>29376_0019</Value></Option><Option index="20"><Label>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Label><Value>29376_0044</Value></Option><Option index="21"><Label>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Label><Value>29376_0021</Value></Option><Option index="22"><Label>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Label><Value>29376_0035</Value></Option><Option index="23"><Label>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Label><Value>29376_0038</Value><Focus>true</Focus></Option><Option index="24"><Label>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Label><Value>29376_0016</Value></Option><Option index="25"><Label>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Label><Value>29376_0037</Value></Option><Option index="26"><Label>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Label><Value>29376_0033</Value></Option><Option index="27"><Label>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Label><Value>29376_0022</Value></Option><Option index="28"><Label>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Label><Value>29376_0047</Value></Option><Option index="29"><Label>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Label><Value>29376_0042</Value></Option><Option index="30"><Label>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Label><Value>29376_0032</Value></Option><Option index="31"><Label>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Label><Value>29376_0045</Value></Option><Option index="32"><Label>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Label><Value>29376_0036</Value></Option><Option index="33"><Label>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Label><Value>29376_0049</Value></Option><Option index="34"><Label>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Label><Value>29376_0043</Value></Option><Option index="35"><Label>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Label><Value>29376_0048</Value></Option><Option index="36"><Label>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Label><Value>29376_0015</Value></Option><Option index="37"><Label>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Label><Value>29376_0031</Value></Option><Option index="38"><Label>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Label><Value>29376_0028</Value></Option><Option index="39"><Label>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Label><Value>29376_0030</Value></Option><Option index="40"><Label>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Label><Value>29376_0026</Value></Option><Option index="41"><Label>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Label><Value>29376_0029</Value></Option><Option index="42"><Label>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Label><Value>29376_0013</Value></Option><Option index="43"><Label>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Label><Value>29376_0023</Value></Option><Option index="44"><Label>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Label><Value>29376_0027</Value></Option><Option index="45"><Label>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Label><Value>29376_0024</Value></Option><Option index="46"><Label>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Label><Value>29376_0040</Value></Option><Option index="47"><Label>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Label><Value>29376_0001</Value></Option><Option index="48"><Label>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Label><Value>29376_0034</Value></Option><Option index="49"><Label>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Label><Value>29376_0017</Value></Option><Option index="50"><Label>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Label><Value>29376_0050</Value></Option><Option index="51"><Label>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Label><Value>29376_0020</Value></Option><Name>relview</Name><Default>29376_0038</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0025;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2ZE+V
+fpUqpzSouFX6VIBWNihAlOCU4CngU7AM20u2nHhScEkdhSIxcZKMvs1ADdtNKD0qUikxQBAyD0qF
+4we1W2FQsKLAKn3R9KZKlzvzC424+6QOtSJ90fSpVoAqlb1WG1lYZPYcDIx+maN1/n7ijr3Htj+t
+WJbiK3AMr7QeBxR9qgGMv19jTAjBvN/IXbkccdKdKboMREARnjPpj/GnpcwysESTJYZGPSk+1W8W
+FMwJPTJznmgRCWviOI1Bx6j/AD6Un+nbv4cZHGOnHPepxe2zAkSjAGack0Uv3HDfSgZTDX+PmjXP
+4cfrVh6mNQyYpAIn3RUq1EvQVIKEArwxylS6htvTNM+xW+7d5fI75NKIkLEkHJ9zTmiRjk5/76NM
+Q1bOBHDqmGC7QcnpTF0+1AH7rGOnzHip/LXAHOB70giXH8Q/GgCH+z7XGBHgY24DHp6daVLKCJw6
+IQwGB8x/xqXYPU/nSFAe7dMdaQDieKgcVL0GKhc9KGMUU8VGKkFJANWLGfnfkY+9TxHgY3v0x1pR
+ThQIaI8fxufxo8vjHmP+dOKhhgikESjbjPy9OaYCbCAfnbn3ppU5++3WpTTaAI8EDqT9ajepmqCQ
+9KTGPFPFMWnihAPFIY1Y5OfwYilFOxTAaIl/2v8Avo/40vlL/tf99n/GomtwBlWfI9ZGxRHEXX5m
+YL2wzA/jTAk8pQc5b/vs/wCNKaFQIu0En6nNBoAY1Qyc1M1QSHFJgPFSColp4NAEmQBShh7/AJU0
+GnA0wF3D3/KjePf8qM0ZpgIXHv8AlTdwP/6qUmmE0gBjVeU1IxqCRqQAshz2p7Sso4AoooGILl/R
+actw5OMLRRTEThyfSjeaKKAAsajZjzRRQBCzHmqs7sF49aKKQz//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0025/full/!100,100/0/default.jpg</Url><Caption>29376_0025</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; [title page]</Caption><Caption>Exhibit</Caption><Caption>plate 001a</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0011;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUHp
+UixD0pQtSAVmUII1x0pwQelOApSQuAQefQU7AM8sZ6U4IB2oEinnD9AfunvR5i+jd/4T2osAFR6U
+0oPSnhgxIAPHqMUEUAQsg9KqXMQKjI71fIqvOvyj60gJVFPApq9KV1Up8wBxzzTAkGPWnD61iyso
+uTngY7Y9PrV63CdViBI6FdvH5GmIuc5o57kUveq8wQJuIXODyceh9aAJ+PUUhrEilxhU2sT0zjit
+KCZNg3Tx9Pu5Xj8jQBMagn+6PrUyuki7kZWHqpzUMwyBSYyRegp5+6aYv3RTm+6aAMu43LMxz1IH
+U+1WLUgHafMHqwbr+dV52P2hhx0/p9as2sW5RvQNnrx/9egReVNpJ3s2fU5pkufL4J7+voakVQow
+On1qKb/V9uh/kfcUAZON20Lkk+5/xq/ag527XVQM/MTzVBGbcMbSRzgkD/2ar8Hn7cYCg99oI/8A
+QqALRFV5hwKn7VBKeBSYx6dBT2PyGokPyj6U8k7DSuIzpZCs77SM46Ej0qa3lZcOXQj0GBVefP2g
+5fpg4yc/+hVPbA7BtkJyecbv/iqYF9ZkYgBhk9qbMcR/n3x2NOjXYuMknvkk/wA6imJ8vqeh9fQ+
+4oAzl3OygHI7/Mf8a0oGzHj0981nQAmQkSYxjpk/yaryzkKAVYn2H/16AJSagmPAqQPuz8rDHrUU
+rcCpYx6fdFPP3DUafdH0qX+E00BlzsFnY5GAB3H+NXLWLzF3Fk68BVFVbhsTtyeMdz/iKtWsnmIW
+dpDg8YzTAu1BPjyxnHQ9ceh9anBBUEVFLny+M9+mfQ+lAjIBRcbjlcZ4P/160YFVl3bB7Nx/SqCy
+HcMFlPTIJ/xq7Ddx7Qhcu3sDSGTtUEo4FTk5GRUEp6UmBIh+UfSpB0qCM/Iv0qYGqQDWtYnYsdwJ
+64NSLbxLjCDI70oNOzTAWmtGrj5gDj1pc0meKAIRZwA5KZ+vNKYYgQQi5HTipCaaTSAaxqGSnsah
+kakAkTHYv0qdWNFFCAXec0u80UUDF3Gm7ziiigA3mmFzmiigBjMcVVlds0UUAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0011/full/!100,100/0/default.jpg</Url><Caption>29376_0011</Caption><Caption>The viviparous quadrupeds of North America... Vol. II; Contents</Caption><Caption>Exhibit</Caption><Caption>plate 001b</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="3" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0002;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2JIRj
+lQfbFTLGABgYFPVakArj5UakXl0uypcUhwAalpAM8ul8uohdKCVPUGsDxl4kttF0WUm5MUsi4V1P
+Ke/tUOcUriOiYIgLOwAHcmsI+MtAW+Sze+WOWR/Lj3KQGb0z2/HFfOuu+OdV1AeQt7czQqx2tLIT
++hrm3mubgiSW5lY9sseK2jCTs9kTzH0dq3xAk0PxBJZ3lvbS2ZwYZYZPmYe+cjI/Cuit/Fmh3Fvb
+zC+jQzglEf73HXivkp43PzGRyfXNadnq89rEsM4M9sG3FCcEfQim6U1dp3GpH0rdeONFs74Q3Mrx
+QNkC5ZDs3Dt6j69OK30ljlijkibzI5FDK6cgg98184w3VtcxRN5s00UxI8uWQsqHHbPSvZvhubk+
+E4EmJZYyyoT/AHcnAH5/yrKEpNtSWpVzp2TminsPmoq7IZaWnVHI+yMt6Vg3OszI7BU5HP4VRLdj
+oiwRSWIAHUms29vZYwuyCQgnAYgD+Z/pXOSa3dTbpE2HZyBv4+tcT4k+JmotbSWml20vmgc3DoCq
+j+8Of51jJOWiYJnV+JfFNjotqZbi9SK42nEKMd7fQfnzXhGv+Jb/AMS3Aa4kZbYHCpuLY+pNZ969
+1JcvcXlxJJPIdzO7ZLU0CQhmH3Rgnjt0zVU6MYvm3Ym3sM+zswZCPmXv7VL5QVdhXkDFLKzQy7GB
+yR19amjieYdcZFdKJ6kTYSIE4Cn7opqoHycDGOaZKWL4PTtUttuAkB6lCBWnQSJdKb7PfLBKSYHb
+jnofWvof4b3Q/wCEd+zzTpvE7rCjMAxTjt9c/lXzmBvtxICQynNekeFNYvrrVdHeAEyPIsbMcY64
+P6VjVT5k0WtD3UrzRUpHNFTYsp6rcraafJM3QD8685udbmkBcSqzA/KcYxXU+P7hrXQY2BAQygE5
+56H/AOvXlSX8c0XzMV+TK56kevQ/5/CuWvKSdkS7Fi41S+e8aZCjQE5dGA+Ze/8AnvV61t9fuHMy
+XMUto6lQMKAF/mDjtiuWvrgNCVhiYrklnBwB+J6fT+VYkepSae7SWt9Isv8AdViR+PGKdOnUtqSp
+WOg1fwrGkUaDc0xzj6nH6cH865+8tvsMEhyMFfLB9TnJ/TH51r2PjErGx1K2cy4Kh42Bz6jaTkdO
+f8iuc13UZNW1Dy4EKxDgZ4Jzz+FbU09mNtWFggfVctGVVUfG+RgqhcdST9Kt/a9LsiIUWa+kxh5Y
+jsRf93IOfrVQWDzRw2kKsyg7nK/xN6D2FdLZeHobW0d7p1RguQuf0qpzSe44oyFh0q7j8tYL1WJ+
+8zLhD65rEXzkvXtkYSFGKhk5DfSun1ePSLm3tovtaW8UTHeioSXPrkdfSseCa2sUdVUSucjKngj/
+AAq6ctBtXIGjeF5ojtPfjkc10vw5uZY/E2nRlvkFyOPriueMrXM0kjALhAMAYrpfh5bCXxXpyqfm
+88N+XP8AStXrHUnqfSpHNFIzYNFYXKOK+KkbyeCpHjzujlR+B714zpc8Ijvbu9Ym3gC4iBwznkBR
+6Z9fQV9CeIrBtU8P3NojBTInUjPvXzTq1pJp2pT2wbzFiKmXZ25PH15oVm9SJLUr31/d6jc7WGyI
+fdgj4RBWlc6Hd2Xho6jdNHBExCpGE+aQnOKd4bextrx7q8aJ02N8sg6H15/zxR4k1m5122haCNxp
+tkpKJswuc4z/ACpO7YWSRnaSzQaim5Fm4BmeQb8E+g9e2PatOHwqUlF3NIiR7txB6twM8dupqrpk
+n9mQPdXgR7mU+YA3UfhWXqGvXd0dnmPtHQZrO8nJ8uw9kbd3q9vp4xGqO+MZ6jH+FYd3rlzdysRI
+3zdQKom3nki81wxyegHNN8iXkJEyj0wSa1hTW4OVhCGeUeYxAPrV1MJgKQT2z/Kq8drck8RN/wB8
+mrUFpPLK0cakuvDN6Vvyi5x3mGRvLXnJzIw9fQV6j8IrCOXxAblk5hjJXjoelcHp+g3kzAJFk9gK
+9i+F/hvUNKe4urtTHHIuFU96mWw0z0ZyN3SihgM0ViWRI25AO2K4rVfhjpepSyGKaS2jnk8ydU6t
+7A9ua66N8oKkD+1IRxEXwo0uBk8p8InOGGST65qyPh3bQ6c9rE6uuPkV8hR+A6/jmuy8w4pRJxUN
+IDxm/wDgtq+oXZlk1W02n1DZFaWlfBC1tCHvL0TuOgC4Ar1YPmkKgjAyPxprsI4uL4Y6ahBdg2Pa
+rC/DfSkfcFH4jpXWBVAxgnPXmnhgoAA4q0LlRzH/AAgGmfQ+wFU9N+HFlYXN/IZRItzP5q/LyBgc
+fnn867TdmlLc1aYcqMKz8H6TZyCQQhmHrW6AqLtUYA7CmsfUUwvjOBQOwE89aKru53GioKP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0002/full/!100,100/0/default.jpg</Url><Caption>29376_0002</Caption><Caption>Lutra Canadensis, Sabine. Canada Otter. (v. 2, no. 11, plate 51)</Caption><Caption>Exhibit</Caption><Caption>plate 051</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="4" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0010;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21FO2
+nbTt5605BxingVlYoy9T1S10iATXbFUOeQM4AGSfpWH4H8Xp4ws764WMRiC5MaDGDswNpPPXrVX4
+hSmJbcZDF0eFY8cncRuP4AfrXF+F/EsHhbXba0KQrb3QENx5edsbZ+Vgfx5rB1Fz8pXL7tz2fmnC
+lxkZpQtb2RFwxml20oFOxTaC5WlnggZVllRGf7oZsZqQAEVg6tZLLJPO1o0xCkbrp/3ag45UVraZ
+btb2KI0aRt12o5YfmazjJuVrFEzocEqAT70wxkr8wAPtVgikI4q2BSZTmip2UZooAmUdKkApq9qk
+FMR5t49Fzd6lHbBSiqP3ZA5bPU5ryXxTpUthb2NxCG/0gyKcghg6nBB/Svo3xDpy32nMcYkj+ZWH
+UfSvIPFNhfahaRRXV8rRW7M6DYqsSRjkgc1wVJKnV97qdEY80NOh2Hws1rU9a0djfajBc+R8hjKn
+zU9Nx6EY+tehCvmHSNR1jQb57zS7h4HYBWXGQw9x3r0fw98X/wB8lr4itPIJ4+0xD5fxH+FdUJrY
+wkj1gCq0uo2kF0ttJMqysMgGpra4gu7ZLi2lSWFxlXQ5BFQtpdq941y0eZWweT0I6Ee9aO/Qkdeo
+JLGcbiuY25HUcUQrcCV/M2+UMBO5981DfXtvaqILidFL4xuOCRnn9KsQ3CXESSxEMjjKt6j1ounL
+cZIRSFeKfQRxVMCuRzRUhHNFADxwM1Tk1a1hcq7MMd9tXP4SK5+/gDSE9faolKyGkav9qWEo2faE
+y3GDxmuG1vQ4jdzAxgNkkH61cuvIjx5pC+nrV0XsWoWLQyAmVFyjkdRXHibzjdbo1pNRdnscHBpU
+UV1g44B4rK1fSAJT+7BU8gkdq6+0snvNae1GEZFJJY+ta1x4dkhhJdlkAGcY5rgpVa1+ZrQ6akKa
+0T1PM/DXjS+8E34ibdPpUjfvIT1T3X0NetW/jjT79BdWAe4h2dRwMk15J4uFnGBbxIGdueOq/Wsf
+wbfzWeuf2YJcQ3J3AHsw5r1IVHKF0cc42dj2PVL+K5MshsovPkXaZGG5gPb29qpR63dKMzTupztw
+GwFGf0FQmURowAwCpw552sBxn2rJguGu7qdCAUbCDHOD3/Os5VHfQdrHWpd3i/OjyYHJJY811enX
+JurQM33hwa4c34hkTPypux9B2rqdAuEl80IQR7etbU5tuwSWhsYopaK3uZkcr7IHfOMKTmvKdW8W
+XsTy/ZxM6BsbzgD+tepzAvbyKOpUgcZrxDxEbi11R4ZGIkLEhT8o/AGuavNxSsa043ZXl8UaxKwx
+Z2yAHIkcN+vNbHhjW9UvGv7i8lgW3ih2hY1wCxPX8gawbSDUNYj8p7clWbJJ6FfetK7u9O8N6LDa
+uytJIS0qRqcuR0X+n41xObldW1NVFJl3wz4jin8RSQzMFuWYGOQn/wAc/L9c16PrV0bTRp5V/wBY
+qYBz0JIH9a+d7a9vbrWFvI7dQ+/dhQeDXsy6lPqWmRrLbMLhk2yQOcCQEc4Pr3q1aMeVbkXvK7PM
+NVzB5ssilpZMkknJzmsDToJRqkd3sZdjfJjqTXc6mI7S5EFwiMSPkdsbx7ED+dcvaaxbHWHmaBzE
+hwrDkce1a0ajatbYdSnbW+51kVvrWqxBPMNrbkchT8zfU1Zg8MTQZMV1Msg7hzmoI/G9hbwkxQSb
+gPTg1UtPiMj6yqXMSQxbCWJPT0rSLk9kTZIuvezRB7S8yZI/mSUd/rXd+BJ/tMcjb8hBjHua8f1H
+xA2sahMbBCwxhTjqTXqnwvsb630y5mvo9jOwCYPUdelaKNpIhnfZoppPNFaEkCvWTq/hiw1mQTS7
+o5uP3iYyQO3NXkc1KrZFKUVJWY02tjm7rwZHI4MEvlqBgheM1nX3gD7XayRO6dMqUGDn613Icil3
+msJYamyvaSPJtG8D65p8sqrbQbQPkeQhs1en8O+JbqNkuFKtjb+5kwO/Q9e9el7qYy55yQfY1n9T
+h0bH7V9jx9Ph7fG4xcaZI+OBKZ935jio7nwLfBytvo0iBQQCeQa9kRARkluf9o1Nu4prCrpJh7V9
+jwyH4feIMpt06LYp5DsRxVm1+ENze3rTahbGHecnbOCP5V7VuNG81tGhy/aYOpfocppnw50PTYUR
+IOVO4HPOa6qOOOCIRxgBQMACkLGmFyBxWqilsQ5Nkhbmiq5c5op6CP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0010/full/!100,100/0/default.jpg</Url><Caption>29376_0010</Caption><Caption>Vulpes Velox, Say. Swift Fox. (v. 2, no. 11, plate 52)</Caption><Caption>Exhibit</Caption><Caption>plate 052</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="5" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0006;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE8DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dIx6
+VMqe1CDgVIiBegAzzxXOkaAq4p4WlAp1XYVxNtKRS4oNOwXGYppWpajkkRPvEZosBGyiqt0g8hvw
+/nUqS292SAVYr+lJcKBAQBgDFS0NEyDgVIKYnCipBTQmKKcKQUoqhDsUuKSloAZIQiFj2rndXvfJ
+i3E/M3vW1euAFUnHOTXn3iS+Ml0UVsKDk89hSY0bPhq5a51e5wflVR06V0tyP3LVgeC7Uppr3Tfe
+mbI+ldDP/qjUvYYqcoD7U/eqjk01DlAR0xWTfXjqxSOQL9Bk1POktRWuabXagkKpOKYL8q2CgP0N
+c1NfXka43jGOWIFNguJRAZnn8w52qobOTQqlwsdDd67bWiZckE9FAyTWSfGsavzay7PXjNURblpD
+JJ88h5OafcaerwsWAUYzT5hG1Jq1rfWvnwOCdvKnqK85vUN3eeX93zZNoBPOKx7rxhZ6JqLr9rUF
+SVIA3A/XFTeHtc07W/ERna9hGOQhOCfoDTA9jsIorSxigRgAqgdamm5jasy1urc7QvTtxWlKf3ZN
+JvQaFjGYR/u1x2prNHcufMePBPI5H612MZAhB7Ba8+8V6jdxzkQPGRnG3HJrjrytFFRKkMBnuW3S
+XFwzkDkHAH41vGNLa2QKuQgzha5+PV7Lw1pNu2uXwhmvHJRG6gfQdBXSW81tcWiXFvPFLCw3B1YF
+cfWrp3SuxNhBdRSKJGdR7V5t8RfHLyxSabpk22EZWWRerew9qqeM/GdrmXT9LZWcjDzxHhfYHvXl
+s9xM52uT16mtkSPVWuCWY555qrJLLZXSyRMUkRsqQcVdsgpRgA289MjrVC/3PMc8H0qovUOh9AeG
+tevbiSzdljELopBx7V6szZgB9QK+fvhrr0N7bRaa48u8thkZ/jTPUV77CS1lHn+6K5oNqUost7Ji
+yNssGJOMJ1/CvItSvo11S5up3UQwn7vdjnpXrjp5tg0Y7pj9K8a19fsmpNHJbeZ82SGYgH8v61FV
+K8ebYaPMPEWp3fiLVZ9QvJGaTdtjjUcRqOgFVILvU4rBraG7lSCQ/PErkA/UV6jHqWmQI7W3h+zj
+uJARJMxLbs9eD0rMh8OW8y/aLe2jimEgYHeTkfToK2daC6k8p581vOp2FSoGN2RjFadloUt8wZo2
+WJR94jk131joMSTFrqNXkP8AF6/SteKxgi+WOM7s4+lcdbGJaRLVO5xtto6WKKVjbGeuOtaFvpqy
+y5NqrNjrtziuo/s6OXbvcKnpTZBHZzHjjHJFefPFLfqbKkzKsvC0beILPVFhlhmi2j5Plzgnk/ni
+vbIBizj/AN0VwWiXYvLiKJPmKn5iPSvQMBYgvoK9HA1JVIuUvQzqxUXZCwf6pR7Vj6r4UtNUmaRy
+VJGK14D+6T6VOCfX9K73TjONpGV7HBXPw2V0xFcAH/aFC/Dy4SPat0uR0r0AGnZ464rH6lRfQr2k
+jiovBdwn/LZAMdOtQzeDdQlyivCgY/M464ruTv7NmgB8cuQfwqXl9F9/vGqskcKfh9JsOL1w54yc
+Vbh8CwIiiSd2wMH5v1rsc8dc0wnimsBQXQftp9zJ03QrPSkAhQbgMbsVdkPFSMT61DK3FdChGCtF
+Gd23djIGPlJ9KsAmiimtgH5pdxooqhCgmgMeaKKAELHFNJNFFAELsRVd2NFFSyj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0006/full/!100,100/0/default.jpg</Url><Caption>29376_0006</Caption><Caption>Mephitis Mesoleuca, Licht. Texan Skunk. (v. 2, no. 11, plate 53)</Caption><Caption>Exhibit</Caption><Caption>plate 053</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="6" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0007;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xIwB
+wKeqgk/KRj1FPjwVBHQjIqQCuexZF5Y9KXyh6VLilxScUFyHyl9KPKU9VFS4pHLKuVXd6jPNJRQX
+MrWNW0vQLQXOoyiKInAIQsSfoAaybPxv4e1AHbK64OB5kR56/wCFdHeWdtqlk8EyB43BBBHSvIL3
+R7bRNYSySNwULELnO4dB/Osq1R01dIa1PUtM1HTtZgaSycOqnawKYP5Grpt4/wDnmv5V5tZ6gNFk
+WSCePzONw2nB/wBnPpXpFjO13YQXDoEaRAxUHOM06FVVVtqNpoDChBBRSD7VF+5J2qUJ9BVzFMKD
+0rflQrlJoUz9wflRVgrzRUcqHcfZA/Y4M/8APNf5CrQFQWa7bOAHqI1B/Kp2dY0Z3YKqjJJOABWp
+IjMqKWZgqjkknAFc5deP/ClnO0M2u2YdTghX3Y/LNef/ABH8Q6rrJFppYnGjhiklzEDslf8Au7vS
+vN00uKIgXX7tScbz0zjOKwqVeVlxhfc+jLTxz4Wvc+Rr2nkjqHnVD+TYp9r4y8P3l7JaQ6rbechA
+w0gG7P8Adz1r5xj06CC7m2qJWQbh3ypHau38KeFE8RzSXLHbbx/I+xgZG4HbPA9zWartuyQOCS1Z
+7XI3kusyZKNgOAePrXDeN5Db6vb3kGnm4Zh5TSKD8nGQc9vvY/Os/W/E8+i3Nvp+mtIllaLiRXIY
+v1ySecjp0961Z/GumWGjnUdQwkcigLF94zL6Y/kffmlKUanuErR3Mbw5orapfRz3FoY7SCTzmeQd
+RjPHrzXcWMf9uot9OhSwK/6Nb5IyP77Y7nsOw9+nAf8AC6NEPm2cmkXdvaupTMYTIBGM4yK6/wCH
+viG31fwzHGrfNZjyWYjAYD7p59Rj8a2o0lTjYcnc6LTkkWyQSb85O3zM7tuTjOec4x1qwwrH1LxX
+p2nahFZN5kkzrvIQfcHvWjbX0F5HG8LZDg4HcY65rTni3yp6isxWXmipSOaKLAPXgYFcF408WW3k
+XWgeU7zyxFS0bDAbsP8AH2zXejpXhuuG3tPiJftPbh0dyQpPQ9zjv/8AXrOtKUY3QR3HLquu3EqL
+qIeSBVAW3sWXEYAHBX0+mafcWMV64nfQb0nPAZPl+uBWxFrdvGBHG8cOVBGEKgjn/CnPq0KRs0uo
+nr0Qkn9K8qdWT3/U1suhz9zpisjD+z54CRjcARxXOrquoaTrEaJeG1ZUK7ljCuVPqcc/jXT63qUk
++ms9nvUYBaVs5A7n24rPn0q3u9AWRZIGl3BiyINwB7g57fWs6NRqQpLobf2KJ5TbzzOzqN6zvht4
+6EY6V5x4tmlj1v7DcSyPFaxbIuMKGIzwO2eK09GMkV3LNctI7x8pvkLc45PP+eapXNlNJO11cLtN
+zKHeR1PBzwqjBJ9K7KEXCb6iS7jNC0mHVdAvZGkjF6ZkSNXYAnnkDPc10HhWfXNEt5prC5gMIJEk
+LjIbHH1z9Kr6fpF3phiurVkR5JPMG7+AYIB56H0+taZltLKKR7i48+YnJCnIH5cCtqlS2kdyl5jL
+CaSZZ7qR2Mss+92dyXVAc4/M/pXoHgvVVfVZbZUP+kDfjj5Qvc+5zXkQ1aZ5Z57eIttOF2Hken8j
+Xo3whme/a4neRj5KlNjDkEmlTpS9rzktqx6oaKU9aK7SAWvEPHtnND4onlMaSAvvTOQcemQa9tU8
+VyPizQBfTrcrCX45K9RWdX4RxtfU8v1C9e+tonS28iVRtC8c9iBzz/8AWqnN4h1qzLQpFEuOeE/+
+viuw1TRYk02YLbh5FXfhsk8cnHvXEalepuWOFJGEah2IOQPpmvHnG0lFRvcqV4vQiuH8VayQFDhC
+MjBCD9OtMuNL1Szgjhcz+dbkSHugBGfoO9dT4eubprdZrqO4CEna7LwB+VbdxBJdN+6gMrsAdxOB
+gdK3g4xdkrFWvqeY6ddypA01wGSYHKns6kY/SugF6EtVukINwBlS3z4x2rZv/DoMAFybe2iyABjG
+SeBWY/gaWzie4tpZJSo5TdwR3/SrXLJ3DlMi78QNcMqxRm4nkBYlzwuDj8elYV5fy6hMBM7RQ5wx
+jHyCtpdMu7O7EyRsYyuz5s5xjPfoP8a1df06xh+HcAigjS9RwZQrBick5PHauinZPRA4i6L4LeVP
+OEpZZFA3oeCPYivZPB2hW+h6NshjCvI2527mvEfBF/rVtqMWmxFpbdhuEWOg789q+iLNPKsokIIw
+o4NawT5ncmb0JCeaKQ9aK1IIkfipMhhg1TjkyKlB+v50rhYrXOkQXDb1wrHr71kt4StI3MkVnb7z
+/EEAroQ+OOadvrGVKDGpNGENHnVVCqgA9qyda8N3TWU1zYoyX0aFozGACx9K7TeajkBYghiO3BrL
+6vAbmzyO28Ja/qsQ+22UiSNjc80mdvP8/pXdwaBP9kWGdd5AwSe9b6I4bmRsfWrCnAA5/GqpYWEF
+ZCUmjiL3wK8z+ZbvGpIGUlQOvH6/rVST4f6legQXV/BBa5yy2sO0n8STivQ91G6t1TiPnZhaD4P0
+nw+hFnbgO33nYlmb6k1vk4FRE+5ppcgVasiXqOLc0VXMhzRSuFj/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0007/full/!100,100/0/default.jpg</Url><Caption>29376_0007</Caption><Caption>Mus Decumanus, Linn. Brown, or Norway, Rat. (v. 2, no. 11, plate 54)</Caption><Caption>Exhibit</Caption><Caption>plate 054</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="7" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0004;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2dEGP
+pUqAMoI/lSRjipgK5kjVgFp4WkjZXXchDDkZFSgVaQhoWl204ClxRYCF2jjI3sq54GT1o21wHxQe
+6t0sZ4ndY8sDtOPm4NWfh54qOsWr6fdSbrqAZUk8uv8A9asFV/eODRq6XuKaOxcpv2559KieMVcY
+VC4rZoyQyMcCluTGttJ5uSrKVwOpz2HvToxwK5nxdrf9npAICzS+cEbaMhMkE5+o/nSuoq7GQ+Br
+1ornUtFmMitbymaFZfveWx/x5/4EK7NW3Oy4+7ivLNW12S08ZWGoWUKi6I+y3EbZAIbpz3xXplrL
+iPfMQsknzFR1HAH9KcZJ7Ay3S1EJoyQASSenBp4bJxg/iKsgxvFekLrOgXNttzIF3x/7wrwPS9Um
+8P8AiW2ukJXyZgsg6ZXOCK+lmxtOelfMfil4rjxNfx2/zK90RGF+tceIjaSkjrw8rxcWfS6sJI1d
+TkMMio2plhG0WnW0b/eWJQfyqRgM11X0ObqMj4UV85+LvEt9deK7qC/ykMVwyjbxjBwM+o96+inM
+gt3MKq0u07FY4BPbJr5z1SU3usXlhqls8F0JWHz/AHlJPQnuPespq8bMa3OguLst4bs7mMHfDcI5
+LEHGPmI7HqBXuVrIksCyRhQjDIxXzrFcX1lokmlywLJbjc0cmeemMH1/+vXu+hanbSeGNPvJJo4o
+pIUwXYAA45H55opaKwSNkqGGDVW/1Kz0q3ae9uVijA6uawfEXjvStDQxJMtxdsuVjjO4D0JIrxXX
+dRvNc1uObXLyWC1LfMY03lF9lBonVs+WO44wT1lsdv4s+KsE0MtnpUjRoQVaXHzMP9kdqofDvwVP
+quox63qFqYbKNt8Ik+9M3r9K6XwN4a8CTxC70iVNTnjwWe4OXQ+6EDH5V6L0GBwKiNJuXNN3LdVJ
+csFYaahfrUxqF63bMUEfSuX8a+B7XxVaieIrBqcI/cz4+9/st6j+VdPH0qYVCegHzcLi6tZp9M1G
+NobmI7Srjof6j3qG/wD7St7RIH8yWxDF1gzlVJ6sv5frXrHizwYuu3vnPK0bIz5kHJAO3bx6fe/K
+uM1XRNW0GLZcobyxXj7RGhwPqO1YyWhcZWdzn7OKxFqsqBo3LhiJPQVj6/qaXU+2LayqclwOn410
+h0ganCkkXlTKg+4z7Tj+X6VR1FrMeTY6np0duYh+5uok27fZgOGHv1+tYRfK9eho9ShYXN54au7P
+XNOcrLHguueJF7q3sa+ldC1m18QaNbanZuGhnTcP9k9wfcHivmq8jup53tlIIVQxCYKlexz711/w
+y8VReFFuLPUXkGn3A82IgFvLcdRj3/pW9KqraszlF30PdWqFjVXStZstc0+O+sJhLA+cHuCOoI7V
+Yc81s2QLGeKmFQR9BUy0ogxsyBkOQMYwSfSvLvE2ua3ZzlY2EFirhFDDcrAdhxXqpAZSD0IxXB+J
+PCJ1C7KxPNI7AuWdshQBgAD6msq8ZNLlBHIwWtjeP9r068SzvHAY27cJuzyDj7uaZO8N5M+n6xaL
+DcdPnGM/Q9/qK2bbwvPpmtxBrJrm0ZgGdQQUIPPT6Ctrxb4ZXWJZHjg+ZMIrsWyGPTbg4xWMYyau
+0UpWPK73QxpLSfvJBCy4DKM/L/gPamaZ4fv9TRY47i2uTPuNusThslRyCO3XvWxeLfaPjS9ZhEiH
+mGTsR3GfWsu9srmyuodS0Wd7ScklTGeCfrR7Nu6kzZSSs0jsPhroHijRNake7tVhsJVZZU+6Nw+6
+wHr/AI16o9ef+AviNJrd1/Yusx+Vqij5XVcLKB7dj+ld/Iea6oxtG1zKTuxY+gqYGq8Z4FSjJ/iN
+WkSyYU4VGDQdx+6+PwqhEoAGcDqaKgJlB4YEfSnDzMcuAfpTEUtQ0PT9UV0vbdZo3xlG6Z9f1rzj
+xF4Jm8ORS3mjtJNp7czWzncYx6j1H616qCQPmbP4Ypr4YYPT0qXFMpNo8/8AA2gweeNWkhZZo12x
+seOCOa7d+tPxt4HT0xULtzSSsrDvcIycCpgaKKEITzDntThISegooqgJAeKM0UUAISaYSaKKQETM
+agkYg8UUUmNH/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0004/full/!100,100/0/default.jpg</Url><Caption>29376_0004</Caption><Caption>Sciurus Rubricaudatus, Aud. &amp; Bach. Red-tailed squirrel. (v. 2, no. 11, plate 55)</Caption><Caption>Exhibit</Caption><Caption>plate 055</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="8" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0008;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2wLgZ
+NPCggHFOUU8CsrIoiKU0r7VOaZiiwEWz2pQntUuBikwKBXE2YpNtSdaXFFkFyHZzmjZUxFJxVWGQ
+MoUEsQAO5qIbHzsYNj0NWjTDigCqQc0VKRzRUDLK0+kWl5qmIKjmljgiaWV1SNRlmY4AFSV5X8a/
+Ec+laHDp9tM8bXed7KvG30J9/wClZyY0rnVP8QvCaXS251y081mCgB8g59+n61zGvfGPTrW8ksNC
+hXUJl4NxvxED7Y+9+lfOls0UUkc1yjmLfn5BktjnHPrxS6RcNBeqCcAnPFN3swSVz1K78c+MZ52m
+GsvCM8RxRKFH5jmt7Svirr1lEn2+3g1CPHJH7p/zHH6VwqXglXAUZ71HHJuUpnDKcDmudTkb8sT2
+vT/i74YusJeSzWEvdZoyQPxXNa4+IXhFlyNfsiPZ+f5V813qAnkjI7msqMSqrDIGe9bRm7CdOJ9g
+2Gq6dqsfmWF7b3S+sMobH5VaIr5A0jW77w7rFvfWdxJFJGwJ2n7w7g+oNfX8Egnt45l6OoYfiM1o
+ndGco8rIyvNFSleaKkQ8dKTcOxzUF9KYbCVx1C151P41ubIuxcRIDgmRDj+VDYHpMs6RIXdgqjua
+8X+N19aX+l2Yg3NKJChY8KBjt71cuPFc2oTLHcXwYuRsjUYByccVna5pkOqWMlvdSbQeRjnae1Q7
+dWF7HhzyKQVBJ9Af4ajhZopxJjp3xXSaZ4Ue41hor6VIrWIks+7h/YfWu9l8JeFb9/mCIxH/ACyl
+2D8ulXzx2IvqcFbXeYxcFgcDnmqxvnQO2SVzgHPTNW/EXhuPw9qSQ2t2s8UyllwQSMdj2qPwtZ2u
+rayLe/bZB5ZbltvIqVBdDXn6le/vUfasecY4NVB5zAMAxXON2OM+leryaF4WWHy1ggLY27w+SPeo
+/E0NhL4VkgtEiTymV0VMDnOP61ooKKH7S7PMbK2e+1WC2Y43vg5r6u8F6vNqPh7TxdKonNshOBjP
+A5rwfVvDscfhe11W3Tyb22VS+0/eGev1r2PwPLJNFZNIVEhgXcqjAB2ildJCk7nbkc0U49aKRJm6
+5HLNol0kIBcocAivnDXoJg0kLzxRktllIzn+dfTowykHoa5LVfA9rfzvKI4vm5xtxWVVSWsSoW6n
+z5DNJFBIpvgeMKpibAP5UhuZWt1jNzKhxyY425r1DVvBd5as32fR3lA/ijUHP4VhJ4X8Rmb5NLkh
+Ddmjx+dccqkuq/r7jRqJz1rrCWiKogeXAALNCCW/E1qL4oVvlTSUOO7Db/I1q3Xhm9tUVrtXVmGA
+oQnmo18K3dzcBRbzhiM8oRn3rm9om9Ux8pxurXEmratA76WhihThQxAJ5PJ4rO00y2N7NdrBH5hJ
+CRsCQAT6CvU4/CFxCG86N2/2AvWoZ/D4ihYJbmI7ucqc598dK6FiGo2sHItziv7a1+Zj5MMcIPZI
+8fzqWSfVmVVnjSVshx+7BGR2OK7bTfCly0TXDBXQDIVV5P41j3Yuo5cw2tw5UnK+VgfnirVZvoUk
+kZUupapLYTx3dnbiBkKnCYIz6YNeg/DfWHudQgtzp8ilUAaUSkjp1IIrnrLRdW1mBkt7K4U5yDIm
+APbJr0HwR4Ql0qY3t7A0Nyo2jE24NnvjHFaU3OT2Jny2O6J5ophPNFdZgRI3FSBj6iqaucCpFcmq
+0EWwwpciqu80u81LQFghW6gH6imNvUnaFx24qPeacHJqeUB21z1Ef1K1J5cRySi5PXio9xpdxqrI
+CQJGowEUD2FJ5cY6Iv5UzcaCxzVaBqPwF+6FH4UjMQOcU0saidjTQCM/NFVpHIaigD//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0008/full/!100,100/0/default.jpg</Url><Caption>29376_0008</Caption><Caption>Bos Americanus, Gmel. American Bison, or Buffalo (male). (v. 2, no. 12, plate 56)</Caption><Caption>Exhibit</Caption><Caption>plate 056</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="9" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0009;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2pUz2
+pyoTnK4weOnNSKMA1ymqXd3G7Kl0685BB6VhJ2LOo2jOBjNLs9q85ub29ilF3b3TiZeG5J3D39a6
+3QvEUWpW6rclYrgDnPAb3H+FSpJgzYCCnCMelKskbHCurH2NSYqroRHsFGypQKMU0BCYxSeXU+KQ
+iqQyuycE4yfSocMTzEyj1JH+NXCKaRxSYFIrzRVgpzRU3GSQ5NspPUoD+lcdrAZbnPauxgO2xjJH
+IjBP5V5trGv+VqEySwl0UEjHXpUz0EiZ49vPBVh09ahVSrbVGM9q5r/hNJI/MSWJU4wpUZ2n3zXM
+SeIr43Erw3kgkZWAHvWDu2O6Ol8R+Nv7EJsrGQSXqkF2HzbPbjvWz4N+KCakot7mURXfTypG4b3U
+n+VeKSMk4laMnJG9i2ck+hP1rPZpYn3oSJUbIcdsCrjGwM+vYfE9kV/fFo2H+ySDUZ8X6duwnmP6
+7VrzHTtXkvrWB4hk+UGdS/zE4B4HetiKKd18xIlYEcYzzVKoKzPRE1m2liWSN1KsMjJ5/Kq8uuRR
+9WIHqFNcPBeyWpxJG6rnlcZq+txHfAqkqdMbScMPwrVO+w7HURawsrDZKrA9mGDWhb3Hn54xiuUi
+hSN1Zh04HvXTaUoMBOAM+lMLFkjminleaKiwC42wkei14r4omjXW5N2NpbjBr2pwfJfHXaa8N8Rt
+FJqs/wC8RiHPJOaVTYk5jUGy3yKGUjKkDis2KMiUM0bBicjjvU91pVq9zldQdE7oCSB9Khh0zT7V
+t/2xt6nOWJ/lWEpRSC1znp4ANRYKdw35HbB9KpuyzSOUDfP1Gc4PHStG5s1N3JJ5rtDnCkLtyM55
+zVq0jt7aLMSKpHO5gGJ9+at1Elc0UGzVj1W8sZ4TbQysOgU8YGMV3OneMNT+w+T/AGZEzKnyMGwB
+7GvLdT167lIjVvLkjPLRgDcKu+FtY1e51u3sxMZI3OW3rnCjnPFJwUlzMmzjoeg380l1ELq+v3ty
+OCkL/IPzFVrW2spwZYb3zixzkyZx/hXMazqUl3qksJbbbQHaADgMR1Nc7ftAMsnDZxxVU03oXy6X
+PWYbjULaddk8pVTn724fka9L8JasNQtTG6FZVHPoa8R+Gd7LLLc2s0rNGu1kDHOPXFe0eGI447lt
+p5weKu7UuVks6cjminHrRViGHDRsOuQRXzr4qMlprFwpfYoYgDd059q+iR0Irw/xtod3/aV3N9m2
+oSShI5c1jXkoq7Elc81vdUEe1Ub5j3FUYNTZbwO+GTHII/WtM6M89r5l3HtkCkgA4Oe1Yx06VTuZ
+GLEYwCDisk4S0ubx0R0VxeWV3bBQyg4rmLi5aM+WoODx+FMkimgcKquR1BxVk2V3dAFYcL2LL/Wn
+CEae70FKdzNacs6uTk5xmux8LTjRtL1q+RN1xs2wvtBC4BJ/mPyrJ/4Re9k+ZlRc9c4XNbuiaDLD
+ZPE8g8t2ywzkEdDTqVqfLuZ2dzEgspdYmknkk8sM4wzZ2nOSTwPb9a6Oz0bRU0q5WfzJbt94j25w
+vOBj8v1rXEenQxRwggeV2Tj+VNWawHCQFvmznPf6ZrP6zfZF2NDSTplhqSXIfy1a2EU22MgNIMfN
+0+teneELiG4uWMEySLjJIPI+orzOKS2kWJRbA+mTivTfBWmm2WS58sKHXg+tFKrzTSsKS0OuPWim
+k80V2kEatVHU9EsdXTF1GWIGAQxGKlSQlQfanBgf4RSlGMlZhqjirj4UaZOrhby4Xd0+b7tMj+F9
+nbRYRI7lx0MrFfzwK7sSU7zDXO8LT7FKckeVXfwx1aZmMBsrcZwAnp+IqWX4U3i2hEd6ZpsYUPJt
+A/Q16j5hqJ4t5OGIB68ms1g6aB1GeRR/DXxREDuNjJjoPMP+FPg+G/imZh5wsI0UHAMhOfToK9aS
+BQcnJx7mrO+msHSvcOdnltn8KbhZo2u5YGUj95slYc+w24rQt/hVBFemR7xHg7IYuc+uc16HupC9
+arDUw55HIW3w10aK486WSeU5zt34H6V1sEEVpbrBCu2NBgDOaQkelIZDitYU4Q+FCbb3FL80VA0m
+DRVXQj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0009/full/!100,100/0/default.jpg</Url><Caption>29376_0009</Caption><Caption>Bos Americanus, Gmel. American Bison (female, and young). (v. 2, no. 12, plate 57)</Caption><Caption>Exhibit</Caption><Caption>plate 057</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="10" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0005;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2hEOw
+BeDjqRU6qQo3dcc4FNhB2LnripwOKwSLKsF9aXEojiuI3cgsFB5wOtXAteL6402keLtR+zXUkEyT
+GaKPkYBGcr6jnkdK6vw18SI7+4NrqiQxFVH76MnBPqVPQdOeaUZpuxTi0rs7/bRtoWWNohKHUxkb
+twPGPXNZV1renyr5cGpxxzhgV7gn09xVNpbk3NXbTSvBxXNzazqJ1poPKEMcg2wb+QFzzIw9PQVr
+3l/baDpHn31yWWJeXb70h9h6mkpJ3sBOBKT8yKB3w3/1qjkiDdQDXMeFfG8fiPVrm2YxRnbuhiU5
+O0dya61hVAhkHMSnpkCrCioLcfuUz/dH8qkmk8m2ll/uIW/IUlsB5L8Tre3i8U2987sCIApVTjcc
+ng/hXnFvti1u0hWUx28r/OxP3F7n8K3NG0vU/iNr+tqLtY3iXzlaTON+7AHHQYz+lYuo6Zd6Jfmw
+1aBoZ4/X+IeoPcVlHXXuavTQ9SgvPFXhgqscL6jpzjck9shkRl7HA5HFNPiXRtYU/wBoW97HcNnd
+Ak7Ku4eqk5WuQ0HxbqOlhILW/wDKtx/A7FvyHSota1u78UanBB5Uclw52owRVY/UgZpuV1ZohwXR
+npeizQ6jpVwLnybC0t1Cj96TIQDnlieR7VwvjbXJ9X1VkMjusn7qyhU8AHjJ9/U1Z1DR9R8MfZLT
+VIBOlyPllRtyh+u05/nWf4XK3HiC6muLiOJrAAxPKudvPYAcnpihNRV2S1bqej/DzwRH4Y0z7Tc4
+fUrgZlbOdg/uj+tdk3WsTw1qNh9nj0u2kuZZIlZ2eWMruy2Scn3attutXGamrpgNgGI1HoBUrIJI
+2RujAg0yPpT3kSJC8jqijksxwBTWwj56We6+F/xLmneN2spTslA6PGxBBHuOPyNe2avoGh+NNIiN
+1GtxC6h4Z4zhlB7qa8v+MPiHRNTtobW0dJ7uJjulTkAY6Z7813Hwt862+Hmnm+fb94oXOMJnjrWd
+OSu49DSd9zl9T+DmkaVY3upf2petHbwPKsWFBOASAT/9asDwLoT3Xi+yaMNsi/euSQcKMH/AV6jq
+fiqxuZbzSTY3VxGMwzOiZUKRgnjJxz6Vy/8AaC+HraSy0qCKK9uY97XRlLssfUE5xg+g/Gom1KSU
+Xp1FGaSdzR+IOq21xJDZIQ6WjGaeRT9xsEBc+tcB4M8OXniKfUr5JTbxeYhSQkjJDcfy/SqcV/Pq
+lydOtc/Zy26Z3G4nHJPua9F0/V7Xw3pGnQCwnitZlDeayAb278A5Pb8M1Upx15tDI9CjhjgUYVVY
+gBmwAT9aRuTXm+p+Plt7q01OAy3OnFmilRQFbdxzk8jH4d67vTNStdW06G8s33QyDjnkHuD70Qqw
+k2olEl5cSW2nyzQpvkVcqvqa8U1qPxt4rvWhMVx5W7CoBsQCvc0xgVIMY4FRKPO99C1Ll6Hjvhz4
+MuLhLrxBcB0X5vJQ9fYmtPxb4g0/7LbyxLst7dGSG2I4foAdo7VS8eeNL+w1SfS4LlFkQjzJF6R8
+ZCrnvgjJry2a7+y3W4lpGdOWZsnP41jUu1yrYaTlqzrPDniC8h1r+0ftQ3Rws0jt8xPAAAXOOuAB
+71Z13W5JpZJdqS3cwCOGOSc9/wCVc94eheyefUZ1MUYGc44PfFW/DOn3Xi/xgZbKAOFfzJZZMiNF
+zzwOv0pwbXuoU431PYfAHhkaVpK3l2iteTgOSVGVGKTxnos92Im06BJJ4lcrGTtG5sfhzg/l712K
+LsjVeOBjgYrAuvEemG6uLGOZXvduY4yCBIR0APQ88VrVUHDkn1IRxPw9+H9/Z3Oo3viS2j2znEVs
+WDAerHHHtXoOl6Va6JYJY2YYQISVDHJGTnr+NW7e6jmjC7080KN6BgSp96VzzTUYxWgIWP7oqUVE
+lUr83F3OlhAHjjcbpphxhc/dB9TzTWw2eDeOY7SPxZqU8swZvOZgOu8Hpj/PauUty8t2gihSdzyE
+wT+ua+i/Ffw/0fxRaQJKPsstuMJNEBkL/dPqK+fdRsLnSdVuRYJLPp6yFI2kXG9RxnAqfZM0UzT8
+ULNa6LFbeYC00uWCngccDPfrXqfgHQNa8N6CFt9Ptm+1IJDIZtrjPQYx6V5v4X0XUfG/iCxt5LZ4
+7C0YPMxBAVc8j3JxivpNVCKFUYAGABVU6fKtSZyuZCajfxxHztHmXA6RyK+f615J4st4B4gk/wBJ
+ECFtwWWJlaH2Br3I1zkeiWOsSXVxqemIHaXCrJ1wOAeD39qwxNF1LJEo5bRfCFvqEEV/Dq13BeOC
+XkhLDf7gk55GM89a78goqqTkgYye9VtIjs4LaS3sIBDbQyNGqjpkHnH45q0/WtIwUVoND0qUVAhx
+UgY5+6f0raKBlDXGvmtUgsYd7SvtkY9FTv8AjXn2u+Btb1KeKJI1EIOSwcZ/WvUwaGYjoufxp21u
+IyvC+iromjRW+398wDSHvn0/Ctqq5ucdUI475pVmdhkRn8TiqETGo9ih2cZywAPPpSqxK5IwfTNI
+TSGV47dLdAkICJkkj1JJJ/U02Q81IzH0qBzzUMaHqTUgJoooAcCadmiiqAWkyaKKGAhJpCTRRSAj
+c1VlJ9aKKljR/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0005/full/!100,100/0/default.jpg</Url><Caption>29376_0005</Caption><Caption>Sciurus sub-auratus, Aud. &amp; Bach. Orange-bellied Squirrel. (v. 2, no. 12, plate 58)</Caption><Caption>Exhibit</Caption><Caption>plate 058</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="11" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0003;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21V4o
+XDDIB/EYpyDipAKysiiPbS7akxSYzSaQEe2l207bTsUlYCPbShaeBS4qtAI9lIUqQ0lFhkEm1Bls
+/lmmYDAkfTpVk0wjiiwFUjBoqUjmiosMsIKkApkYqWrZIyk45HcU84PWqVxceQd+77hwwP8AdP8A
+hUSdgEa4WOfax/dqM7vQ+/8AnvVrcBgd65TVtZigt5ypVnCuSrdHHII/AVGniZFuIozICwXABYbm
+9Tjv2rCNVX1Bo64OpIAIOaeSAMk4Fcm+tiW2e6iOJUlHA/iXdtI+vX/Jrjdd1q71kJKS7NNJ5dta
+hsBQehOOp7k1r7VDjG56lqOowabbiWXcxZtqJGMs59AK5i88cRyTnTra3mttQHMi3KbTEn97HfOR
+j61wsd/rOiapbpFcGZFG2P7QxdYyRyQM8Vi+IZ5Y9YsdQt5XYvvWaeThnJ5yfrzgemKfO3sXyJHq
+Gh+J4z4jvLC8uBlkR0Zm+XOTx7V2SssiBkYMrDIIOQRXzx4X0WTxj42FtNIRZwr5lxtON6g8Dj1J
+r6IhgjghSGJAkcahVUDgAdBVQT5dRTsnoMI5oqQjmiqJHJTycCmLVC6vEhl2z7VB6Eng+lDYiae9
+hCOu8EgZxgnj8K5bWNWjihYhy8Uina+c8Y5H+feszxBrZs5RLDPmMnjnODnDDPcdD+Vcvd6nJr15
+LHBILe0Rt8sgPLvjBx6D+dclWd0VGLbshNR1WJmAafZz8pbksCPT8awNNu501hJ7iTey7mdj1xjA
+UfnmrclvZWM0u+6t7SV4zs+0N8z+5Hb8cZrnrq5AuEgWUuqjLPuBLH14rGEbstpRj5nWTa2kVxGV
+YgOu1iD1P+f5VHfXotBYXZmKyCNlUAHnK4z7GuTe42yxMXBMZB5/iA/yalnjv5xBcRQ77feHRQeg
+9PbpW8aexNOWjudReTRaLpizfLJeyr8q4yE3evqQP61x19fedGqzTM3ljMjZ7npWjq08NqizySiV
+9uFj7Lx1P41j+G9Oh1fV0ivpCtmWDS46vj+EVvFK1yr2O4+Eugatd6uusxzPBYed+8JJXzgBwoA6
+9fpXvlYmi3lm9hDBYxxpCihUjVfuj+lba5xz1q73M2MI5opT1opgNXpXnXiOSTW/EWqWgLfZ9Lt4
+2ManG+Rucn1wB0r0NTxXkfifRvEaa7fXMN7MiXSqj+V8u5VzjOB71nOzQ1uctqM268a2gXy5G+6v
+RWb0I9fepbOSDRdKuLxi0k6jb5T/AHSe3681E3hjUseeJbgSA/eJJNJJpF1fgR3jO7jqw4z746Vy
+uG2ponZPucncTLcXBeaUtLIdzueSxPrTBjd80hHAXcBwQK7G68Gw20CTCMHIz83Wlh0AyIFaBQOg
+yOtUrLZmXKYGi2EepatFBKymPIBOcgDufyrt7jUdLllntYFQQW6eXGQQBx1Nc7PpE9pKWtA0cuMN
+heMelVWsJltWhTmST5WfB4z1P+fStLXKSsczqt+by4kj+Vgsp2MvZPSremTi3AzwqkHOa1dK8EmW
+aaS5ZkiB4CjLN6/Su+0rwPpMVoCulzXDEZyyNmtHJJWRVr7kHhTx7Z2JSKVJl5/hOR/+uvZNPv4d
+SsY7u3YmOQZBIxXmmneEI59RSOLRpLeLGWmkQqB+dem2tulnaR28eNqLjinHbQmSsPPWikPWirsQ
+RI9OOxvvID+FVUkzUu81IyQW9uRgwpj0xUK6VpyuXFnCGPUhBTt9OEhocUwuNfTNPf71pE3sVpPs
+liODaKMf7Ip5kNL5lTyILkf2KwkBBsUbvygpRo+lg5Fhbg/9cxUgfHQU4SGrURXEi0+yh/1VtEv0
+QVYGFGAABUIc0hkNOwXJi3saYzUzfTGY4pgKWGaKpyylXx7UVN0Ox//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0003/full/!100,100/0/default.jpg</Url><Caption>29376_0003</Caption><Caption>Putorius Erminea, Linn. White Weasel, Stoat. (v. 2, no. 12, plate 59)</Caption><Caption>Exhibit</Caption><Caption>plate 059</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="12" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0052;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2lVJb
+7q7cdc80/wAunoKfisLFkXl0FABmpgKbI2xGYgnaM4FS2BUtLq3voBPayrJGSRuX1HUVY2VgeFNS
+bUraa4a2jt1dyY9qbPNUEjftz1yCPfGe9dJShO6TEyPZQUqSlrRMCLZSbBUppMZpjIWSq5SXPzbM
+e2aulajccUAUWXmipWX5qKLIC6g4p+KYX2JurGuvFFjBerZG6gS6f7kbOMk1N7Dsblc342vJLbw5
+dQxxzBriNo1lQDCE+pzx9aSXxIYePNiZvTH+FYXiPxVdSaNIIo1U71Xb5e4S5O0Lye5I5GCPUVlO
+SsFjH0LxlhF/4SGMQ63p8LLAxYf6QNp7epBX64q5p2qyar8JLrUGuZbu8eSSZ0SQlwwkyqY6gcAY
+9PrXJ3Om2etXsOpxsVmddymRjlAF2lW9xjOcc49q5XTjrHg/U1maQf2fLIfM25cdcEjHeslK97D8
+z034f/EX/QZ7TxHfxqYVRraefEbSqc7hngHBxjvg16Jp2vWOqf8AHtKrKRlWBBDD1zXhst7p2t3U
+M2iRwzTyq3nxMwXI4wQhPBz17VVtV1HQZJnsbj7O6MTJZyDKt7gH+YqoVmtJI2lRUtYM+iY7qCWR
+oo5kaRfvKG5FNkvbWJ9r3ESt3BYcV5Zo3iOPV9M+3RILaZfkkUNyGHv37GuY1XV7iPUHKTvuwcHd
+6HkGtoz5ny2MLWPoHIIz2prDIrgPAvic3hSG4ldjMoABOQhH9Oleg44rRqwiow5oqVl5oouBwvxT
+v5LLR7ZopniZS0gKNgkgcdPrXkseqG402aKRhJcA/aludvzrKOTlu4616X8XraG8sbUPIUeJWI5G
+DnHGOvbtXjtteLFIYpXeJD8oKdOnXP8ASoteOhcXZnTvqut32HN5DAwUMBFCCCPX5s1asfE087Lp
+2sRJHKCBDMi7VlOc4Po2fz9q52w1+6skZGsIbqPdmQyA5ZOnH938K17m20zWbG5u7K7kxEqtLaTR
+/OgLDo3/ANb8a4588fi2NrQkrI05bye3gSaCRUlVi2P7x546H/8AXVtJvt1jLIluJps7bm1PXOOG
+TPfH5/hXMpb6ho0qW+tLLHEwLQSSkZHHTd0I/UVZivXs5Y7uO5RJM7Y/MO0yj2B+8PcZH5Ulq9Nj
+BpxdjC1bTWtX+36TFLBNavukJz8mc4xx09vrWjcavJfaHaXszMk++T5SeigYI+hJ/SumS9XWYoCk
+jxXKuBMiqWVmPHzD8ufqM1y3i7TJdODtHEptuqbBwD6Ee5rV+9aJpTaTuVvDd7dm3ltrVDveUuzs
+PkQEAZJ9eKl1J2guo0abzlkIQkrggmqWhavbQWFwiymGQ8vG56MOMj25PHbFOkSJ1E4uN5EgYknj
+jsK6YR11M5yV9DrPCVysFxhm2yqMJxxXq3hfV47q5uLEsxmjUOcjivBRJli3nctzj0Fd58MdXuv+
+EpFpLIHjlhKnvyBkHP4GqkSj2EjminEc0VIzzz4l6L/aFvbzLcGM4K4PQ147Hod5b35SPbNHJ8rK
+y5BBHX2xX0nqOnx6vpvkuSpIDIwOMGvM/E/hfVLVV+y2DTucgOBmMe7dz7Cs25RKSTPP9Rmt9PlE
+Mao5RcZkGQcY7f561Q0fxEkLXSSKqxzRmJsEqcZBBBHQgjitTVfCGrX7Bmt5YhnLERnj2GAKgTwV
+M+nNDb2Nx9o3hjdSKT2+6BUOUOWzKad9Dq9E1OW90z7PNd2moR7uIL1Q3T/axjPPXBPX0rO17UdT
+uNUjhl03TLd3UeW4h81iOgw2AB04wO1ZOl+F9U0+53JZyz8dGidAD+BrZRru0CteW9v5gbh1UsR7
+bTn9CO9c6UVK8R3dtTDW51nQr9LgWwypz5ikk/lmt+LxTpes33kzKiGRSJU2lVLgH5sHpxnnvVGK
+/wBTkndk0Tzo2bmSOQbx+FY994a1nV77zdP0a7ijH8e0kmt0ubci1tihr2kRw3e2CUPKjdjnI/Cs
++3uQo8u4Rgqtw46fiK3ZPAvigv5otLxJCOcoTk/XrWrp/gDxRcSfvtGlkRv4nULj866Iz5VbcLXO
+ftLmOKffujYYIB3D/Ir0X4UwSz+LxNGVEUMLGTbznIwOenetDSfhC82Hu0jtRjo3znP0BH869J8P
++GtP8M2PkWUYDNjzJMYLmnzX6BLTS5qseaKYTzRU2ZJVspC9nAwPWNT+lW1Y9yKyNKcnSrMnqYU/
+9BFXw5q9BFvdRuqvuNG44paCLBbjggGomkmU/wADD2U/40wsaN5FLQCZDNj5mjB7fKf8amDcDJGe
+9VBIacJDQMtbhSFqrbzQXNNATlvQ0xmPcioi5pjOadwHF8Giqxck5oqbjP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0052/full/!100,100/0/default.jpg</Url><Caption>29376_0052</Caption><Caption>Putorius Frenata, Licht. Bridled Weasel. (v. 2, no. 12, plate 60)</Caption><Caption>Exhibit</Caption><Caption>plate 060</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="13" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0039;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rhc
+4z9Kcqg/Njr6jmnIOKkArGxYzZRsHpUmKXFS0FyLYPSkYKoJbAA7mmX95Bp9o9zcOEjQZJNeGeNP
+H2qahK9vAzWtufuoGwzD1NQ7IaTZ63qPi7w/peReanbxkdi2TWbF8SfCM0nlpq8IPuCK+X7pJ7ue
+SWZzgepyTVeOzaRsfNVpID7Js9TsNQUNaXUUwIyNjA1b2V8hadJqOlXAmsryaFl5+VyBXtfw8+Jb
+alKul6yyi4/5Zyk/fp6D1PUSlQOyBtpYbvSrmARkdKjZaTQrlNl5oqVl5orOxRZiyUUnripQKit8
+/Z489doz+VTityAxWLqviSz0x/JAae4/55R8kfX0qh4u8VQaLatDHIPtDDBYEfJ/9evOBrtvcI0e
+8/vMhmzyT65rKpPl2KjG5uatrs+pvI19JEiIfkgRsgfU9zXj/iC5xqjzuxKnge1Sa7Le6ZfvtmaS
+BjlWJzWA85vGw5zWUYtvmbKeisT20iS7jsPP8WecVbNsFAIcIuOgHNQpGlugx1NaMqoYMAZ45rVo
+SMqabGMk47kU5JpVEd1C5SUMBCqfe471XMoErIy5U8EVJBFJBIUjx84+WRuwquUEz6V8DeLYtb8J
+peXkqRzW/wC7n3MBgj6+tXdJ8XWGrX89jhoLhGIRZOPMHt7+1fN9rqd7p1pNDZTOsbMGf0OK2/DW
+uyy+IrRbpI5WMqjzN23vQ+bdDSVj6PbrRTuoBx2oqSSvq2qxaLpct9MpZIx90dzXmusePtXuNNlv
+rWeC2hXOyFTiQjOM89eewrsPiBdJaeC7x3VWBwoDDIyTXiGk3FtBpEmqX9tJdtFc+XFAW2ou4Zye
+PatbMRnajc6hqINzf+e4c8EtgZNQ29i8jrHaNL5xOBtbdz7jArrb3xdc3dta+TokG+NHlTnK7QNo
+OO+3J/ECsu61rTdYjjnjt5rC/XC70PyOf5g1Mr2GmZGpm/skW21W2CSOMqSQQw/CuZaFopSyj5c1
+p6vLJPMqMW2RHjcxYknkkk/54qrD97B5FSlZaA3fcYLrB5zitO3uXmhyPuYwahn01VWOctiJuvsf
+Snx3AOEjhby8Y4HWq0a0FqVJ4S7GRc1Yth5sIDKzGM5wPSt6y0mS/jPkwt8v3mYgAZ7c027tYdLg
+kiLK13JwEXnYuOuR3OaL9B2KI3PgRxFI+mcVL4ftWbXLdoxumSQMAe+DUkQu5rQB5EjhHqan0l1t
+tWt59x8ouFZs4wfWi9k0ho+m49xiQsMEqMiii3bdbRN6oD+lFSIivtOtdVs2tLyISwsQSp6GsbW/
+BenajorWFpbwWgyGHlRAAkdMjvXQxniqOsa9Y6JbmW6kOcEiNBlj+FadNSTyy7+H+vxAstpFP9nQ
+pCscuwOOex78nv3rhb62v49TLTab9mVWHmRq2/aw9wK7nxL451nXZms9ODWVoCd3OHZfVj2HtXF/
+2XJbEy2187l+XMZOD+dYucU7XL5Xa5j/ANnT6lcuVTagOWY8YpzLp9iMK4uZugEYyB+NbR1KT+y5
+NNjgCJITuCDJPTqTySeaoXc2n6fAjrGfNA+6OQD6elTKfQLEcKPfRhZIdsAOdoGc/wCFaqWtstu5
+VYUCsCMsMgfWuVufEV7cA29um1JCPlj5ye2P/rVqWfgrxdrsqQwaXcqdmfMnBRR+JoUZvfQaaRtN
+LBbxopuQzMnJ3EAE9ucVQurm2muGkaRCxbr610el/A3X7mJf7T1O2tgp+6ilyf5VZ1X4NTaHo13q
+X9tCUwIZCgjKgqPQ561ooNdSudHGRS25dpJljaNTj58jJq5HPaXcyWqRiGN5F+YdevpUfhrwzeeI
+754NPiYqpP7xzwB657fWvR7T4PzWlzbTLqUOI3Duvlk9+cE9afKJtI9OtUEVpDGpyFjUAn2FFSY2
+gD0GKKRmRxPxVW80rT752e4gVnZdpbvikhmyoNWVkNXdNBY5mXwBYG3mWG5uC8i4zIwYZxx2rAHw
+zvwiqb6AhTkKMjP1OO3p+tej+ZSiSs3CPYd2eVX3wr1h+LTUbeHI2kqDux9e34de5rI0z4F3Ukkb
+a9q6rEvUW/JPsCRx9a9t8zijzaSSjsJ3Zz+j+BfCeh2ohtNNtj2aWX53Y+7HmuojMYXahXCjGAel
+VSVD78HNPEvtVKQrFnNQ3dtBfWz29zGskLjDI3Q03zaDL9avmHYg07SdP0iJorC1jgRjlgg6mrRc
+diKjMtRmb60XCw5m5oqu0vzUVFx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0039/full/!100,100/0/default.jpg</Url><Caption>29376_0039</Caption><Caption>Procyon Lotor, Cuvier. Raccoon. (v. 2, no. 13, plate 61)</Caption><Caption>Exhibit</Caption><Caption>plate 061</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="14" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0014;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Rmn
+7KVVGMEZpwQKMKAB6CosUM20FakxRikBEBTsUMQm3cQMnFQ+eouZI8jhQfoaWgixijbTYW8yFH/v
+KDUmKqwXG7aQpUoFIaYyB1VQSxAHqaiyj52OrY54NWyoIwRkVGUVeigfQUgKbDBoqZl5oqdBllBT
+8UiCknnitYHnnkWOJBlmboBVCHYpK5MfELTLm7mt7GGa4MWQz42rn8aRPG4cErYlgPR//rVjKvTW
+7KVOb6HTzwNOhTzSncFQMg/jmud1Cwl0+/W7lD3dnKvlz7Vw8JGdrgDtyQce1ZU3jPWJ2k+yWdtE
+qjP7zLH9CKwW+LeqWSyRXmiRSzKflaGQopHuDn+dRGtTk9GN05o7y0122tUS3vbiNSiDy2ByJB25
+7HHatuC5huQTDIrgd1Oa+c9S8S3l54lGpXcNtbSsUlSKIZRdoOM92POfx6entHg7XtS1i3BvNOEc
+W3K3KKUV/wAD/MVrCom7ClTaVzqqSlxRWxA2mnpT8UEcVLKRWI5op5HNFQMmXgVx3xHvRB4SurhB
+IzW5D7V6N259smuulbbbuckYU9K4HV/FOhi1uBdSM3ylWhK5L+341VotNSJu01Y8n8NauLUBrlio
+lJ3OfXvmuw0PXLa4ini8xcQsRuJxu+lcDJa3Mk0FrBEEWd8xlhxjPB+g9fau4XwRodmFkE82CBuU
+TMFc9zxyM/WuGVD2l3sdEqqhZF+y1NLu7nVG24XqehrkfGcoRontmDSMjhlU5xzkZxVO+ng0+/1S
+bT5TFbQoiqjOzFmJ5xknj/Guw8JtplqqSOsEtxIo8x5D82e4GeMVNLDPn30FUrpRvYl+HPw0mmKa
+34gQ/MuYLdupBH3j6fSvSNU8U6XoOpwWN7LHCkkZYMDnZzgbgBwDzg+1V4vEVuif6wrjsSK808f2
+tsyS6x/aD3NxcTbcdAqbThePQgfnXc4uCvFGMZqbs2e1QXSXNoLiIOEYZXepQkeuDzXNXetTWt0N
+kwDM23Dn5a8hT4heILu2htFlYssQRyzcOAMZx68ZrPivtRMmyTcGPRj82KHUsUoN7H0BpmtLPGVu
+WG8HG4Dg1tAhlyCCPavndrvXNP8As5+1yxjOdynIOe5H+Nep/DzUrm/sJRc3XnMjEDIwaammS01u
+diRzRSnrRQMqakJG0u4EJxJsO2vD9WtQ99C0p3yAM7BeB1GM/jXuky77WRc4yp5rxnXtPt/tDtuJ
+B+UmUlMcn5s46daxraWY4nPywSxzw3ETyxkEqHXjGf8AOKsrPeyMVe3jl7bgxDH9aLa2tmZ4pNQL
+RkfdV2IB9RmnQaLe3Uok069mlCtg7iRj8c1wyqJjcGzntSMckVyfs75dt249MAjHb0AqS0vtsYRo
+p8ZB+RsYx07Vt6jo2pWSeXKSY2wBHgZ46c4yf/rVDZ6bqd3KY/OgGOqsnT69KFXVhODbIJrgtbr5
+QlUKO8gGP/Hakk1Gb+zpoTBE3mjADZwfrzUl1oWrRZVY4JcYPC9c+3eqN2l3HOILi3jWQfKcAj9a
+0Va+gcslqJaCJLyLAXCKAzBshfUe+Oa6GPV9FRZJvtULOCQsQPJNckbQOzlo1yvpzWlF4Xa+jW4k
+gfy+7LwB9TWnuvVs3VRrSxl6vftcIt0qKt1LIeFHO6vW/hXeGf7RH5CcE7pkbhjx2rgrfwhY/aFA
+vWlxx5EfX8xXr3gnQ7fSrNnhtZYd3GZOCR9K1pzi5WiZ1Hc6s9aKaetFbmZCj8VHcWtreRNHPErK
+wweKajcU8PTaTVmIyz4P0MhB9lIVBgKJGxj86d/wiWkDb5MTwgNuxG5AP1rU8w04SGsnQpb8qHzS
+7lG58P2FzEkcit5afwjHP6Zql/wi2hYfbA67uT8zZ/WtvzKQ7W6qKX1ek9XEXNIwV8JaDsKSJNKD
+/eduPpVux8J6TaKdsckyscjzm3bfoTzWmoVOi1J5lWqVNbIOZmHeeB9Av3ZrizDZHADFdv0xVnTv
+C+maXEYrdZTGf4JJC4/WtMSUF6pU4LoHMxkdnZ25Hl28aEcjalTbgelRl6aXqkkthXHFuaKrtIc0
+UtBn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0014/full/!100,100/0/default.jpg</Url><Caption>29376_0014</Caption><Caption>Cervus Canadensis, Ray. American Elk, Wapiti Deer. (v. 2, no. 13, plate 62)</Caption><Caption>Exhibit</Caption><Caption>plate 062</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="15" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0051;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29elO
+TDruH8qci1n+IdZTQNHlv3habYQoRTjJJ9aydkVc0ttGyuEs/ifa3DIH0+Rcthirg4H5V1mm69p2
+sKxsLlZWT70eCGH4GoU4vRMLmhto20ryJHEZWYBAMk+1eRap4ovb3xLHMl7NDDEdyRRyFQRnuOhp
+SqKO4m7Hru2kK1zuleLrCSyDajfW0U5cKse4byCBj5RzXRiRXbCHd647VcWmrjTG7aQpU2KQirAq
+SOiNtYkHGelNKgqGHQjIq2RUbDigZRZTuoqVl+ailYC2gqrrVlHf6Pc28q7lZM4x3HIq4lLKWCfK
+AfY96HsI+fdXszol8ZI8tbyfeH933rT0bUEsZV1G3m2iJ1JIyQfUHHYiuv8AE/h8XcMrJCjITwFz
+uH1rzzTreTQ9Rmiu0LWVwNhOOEOeCf1/OvLkmvVENWZ61f6/aXvhe8uLO4V4jFnIblc9frivHhMZ
+9U2xtuDpyFPPBJIq/dx3GkT7bFFkhmbLRbhtI7+2CKyo4v7Lub2dU3RHaEIbJVd2SD/LNEKrmm3u
+TJ3O18JaPZXPib+1PNUyeWv7piMg4wCB9QPxr0O21q1t7qayuIpLeVHCqWGfOJzyuPpXkGn3oTzP
+JSJyjlSXP3R1HI56k11Nh4hvY8zsYFifoSg3P/tewrWNTkLizutU8TaZpEqRXU4Ds2MDnb9fSr0L
+rOom++rcqRyoHt/jXm01/pky5u1t0fuJkHB+pGDUp8T32l2yLaSxPa5wpRQdo9Bjito17v3kUj0s
+imMOK860XVtU1TW7aWS4nFsXztDY3j/D2r0fHFbwmprQZVYfNRUjDmimMlTpXn3iTx5i/ksbGYQp
+CxWSXAyxHUD0FdjrcNxcaDeRWtwYJmiO2Qfw14xaeG7C6Ejm4MzK2GJkBx+AqKsrKxDv0N2Tx6I4
+dwvGkk244AJ/lWdb6rd6jbPdC0imiBw4dsN9SOlO+w6NYhYnePd1WJcMzHsMCq8y2eoxzWhmWzm3
+Bdu8byD3+lcMn0BJt2LcfiHQYbNPNs4jMF2srKDj/wCtUT+ONDtIg0ltBGpB27lAz68VjXfhzTIL
+dGuLNBCrcmEhmP6c/wA+azU0rSbe6kjuIWQE8I8ZUEf8BGf1FOME5f8ADDcLEWqeJ5Ly4LWIWKJz
+n5IgMjrjH07n9Ks2aXutXMVqZJXnkOBk4C8jk+2M/lWls8LtGlvFpVxJNnCvCcNn2zn9a6Lwp4du
+rG7kvJI3jikBESSEFx8p644rpcUti42Rx/iDS7/Rwqi58+LrxkgnPTmrGheIFuLrbeFTA67WwMbT
+68dq6HxLayzny5Ihs2n5uvPXp+f5V5wiG21FossvOOnWqUFONmNq53gvr+wupPs84VUbkYB5POfx
+r0jwPrV1rFhc/a8b4nG0jupH+INeMRi4HluqsWP3iTnPavWvhtaSRadeXEiFfOdQv0A/+vVQiomS
+vc7JhzRSnrRV2LuQ3QZ7GdUGWMZA+uK8DvdHvINVX7PEI5yxyVbgHvXv5J8pgOuOK8d1iTb4guop
+HaLDYLEc++P8awryaSsIgY/Y1/f+TJNt6xoAQfyP51i3fhqWYG9aJwzNljIwz9c1qS3MFtbFLZRN
+KxyR157ZPapBMj2Si9vsFh/q84/CvNdVwd0wUblXT9btbGIxypcMSfv5VyPpkZq6ms6BcZdluW2H
+DPJETyfoKzWsbaTDECNc4XJ5PFOt7N7Sc3EKKkBHzs/3WHpiiOJjfVFNSNMT2cLi5tbyFGTkYjbc
+OehGOa1YvF11dW0RXT7uWQEMDFCSG/8A11zDayss8giheWOUAEIvMZzyM456A1r2DNBbs6vdFf7o
+TBUdsnPPXH8sV1RxEVuCTZp6wj3VjFdlDbseRHLgOvsRmvMrrSdV1S7dra0MYbgyyEKMeors4LiB
+7oNLGN4PG/5z+takk0ZhaaJDJ6OF4qlimvhRXKY/hjw2mnxoJ5WuHYhid3A+ley6SqJp6KibFA6V
+5Voh1W4ngb7IojEn3MEHHpnFeuQZW3UFNhx930rWhKU5OUiZKyFbrRTWPNFdJI1G4qN7W1mJMltG
+5PUlAc01WIFODmlowK6aDo6SmVdNtlc9T5YqO78L6FfLi40y3cYx93H8qvBzTg5xUOnB9EF2ZA8I
+eH4YFiXTVMYIIXLHGOner32LTI4lhNlEEHRSgqwXNJvLcHpSVKmtor7guyodI0eaMoNOi29wqY/l
+Vy3sbKLJitY04x93tTg5pd5qlCC2QXY1dPskkLrawhj1IQVKYoghXy02+mOKbvNIXOatJLZALHFD
+CMRQog/2VAp7NxUW800ucUwBjzRUBY5opAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0051/full/!100,100/0/default.jpg</Url><Caption>29376_0051</Caption><Caption>Lepus Nigricaudatus, Bennet. Black-tailed Hare. (v. 2, no. 13, plate 63)</Caption><Caption>Exhibit</Caption><Caption>plate 063</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="16" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0018;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29AcU
+/bQo4p6KQMEk+5qChu2jZUmKSloIaFpdtOooQCbaNtPFBp2GM200rUlBFOwEJWmMtSyKWGFcr7gU
+zaQuGYsfUigCqyndRUjKd3FFIC0nSn0i9KdTAKSnVBJd20M6wSXESSuMrGzgMw9h1NJiJcUCo3uY
+Yzh5UU4zywFMivra5VjbXEU5XqInDY/KkIsUtc9a69Lc6hcRGMJFAPmJ53H2pzeKLZIpXZQCnq3W
+mpIDeormJvGlnEsUgAMbHBJOMH0pl74nTzVMMoEbAFSDyaHJFJM6gimkcVjW/ijTXgQyzFGztIYd
+Pc1sRSx3EYkicMh6EU9wImHNFPYc0VBViVeFz2qvdTsqoIXXduBYZH3c9ald1jgd2+6oya8+1XxH
+pUQlmRVm8scKvOfQUTnyoSVzsbrxLpdmJPOuAPLALEDj8+lec+MPH/hzVEFqmjvqLD7ssh8sKfZh
+z/KuQ1p9Z1tjJclYYs5SAdFHv6msX+zxApBClz1OODWEqt9ClC2pPdxWD6l9rlhkkieMfuZbluue
+zYyRjtSy3n9nywX+gwtY3KMMvDIzIwPY7v1Bqlc6TuUSsvyD/a/pWWyPbKWhkEa5x8pxURd3oy+Z
+rc9Estfa/eSSAM1xjEhRgdp78f8A1sVTv9ZEYKN5mV4OOpb6VyOkyrG7TNbXEx3Da8dx5XPucEn8
+K6lLG2/tWz1BLO4McYLGG4l80B+Np9x14PoM1ra25MUmVrbVDcwSrljsXJRxhh/9alTVpX0nyckM
+hKqQecdf61Jq1vcaldWt3LaR2dw6kPJE2xGIPOB2JFZccMFqX32s0j/3o32A/hjn8apWd7lOKWx0
+dpq//EvjEsRmYD5tzdfy5r2LwnfQ6h4fglhj8vaNrLuzyPrXgMGt6fbsPtWn3Bz/ALf/AOqvcPAO
+p6PqWhsdJVUEZAlXaQQ2O+a1Rm0zpmHNFDdaKkBskYmtpI26OpB/GvD9c8C6hbXEnlPtjDl0ZVJY
+f0r3FDxWR4h028v7XFk6CTvuqZptaDg0nqeAtpmqLujNzuAPJYbaqHStR3kpdJn/AH816Ze+BvEc
+il4p13ema5aTwR4ve62OLnyx/EozXK1PqjZ8nQ5aew1gIInlQxsem7Jqu+jIqbpJmLAEkFcV3C+E
+fE0UgH2C4kUfxOST/hVPVPD+ryTGI6dOsgHRULnH4DFYTqVIWDkizlbPU/s5XcimKP7qjtzXQW/i
+VpjhYUVB0DcmsaHQtQuL/wCyTabPAS20Obdhn8AK7Sy+Fl2YC83nbSMgJHtP5Hmt/dnqC00Moaz5
+ifNFjnjoaz7u784feUHHQGu0t/hQ8qNn7RH6ZI/woi+EWoKCxmRyAcK/H8q0jC21x8yPMZEaW4xl
+mI71738KrGO18LvKo+aaTJP0FYegfDG4iumbUrW1iiP9x9x/WvTLCwt9MsktbZNsa9BW0LvdWM6k
+k1ZEzdaKa3WiqMyON+KlDnsB+dU1c4p4kNUSXA3HNLuqr5hpfMOKQFndSMxHRQar+YaXzDSAd5mW
+4gU+uakSSUkZjVV7/Pz/ACqLeaUOapAWd1JuqDzDQXOaYErMe2PxNMLHHOPwqMuaaZDigBWbmiq7
+Oc0Uhn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0018/full/!100,100/0/default.jpg</Url><Caption>29376_0018</Caption><Caption>Putorius (Mustela) Fuscus, Aud. &amp; Bach. Little Brown Weasel. (v. 2, no. 13, plate 64)</Caption><Caption>Exhibit</Caption><Caption>plate 064</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="17" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0046;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2mOMb
+R9KmVKaiBowDnGOxxUyrhQOeOOaxS0NGASnBKcBTsqGC5G48gZqrCuN2Uu2n4pcUWC5FspClTYpp
+FOwXIStROnNSyRFmyJGX2GKawpDEjHA+lTAVHGPlH0qUUIGKBWEoe48cFwH8u2s9uc/LuZs/ngVv
+YrG0DM11qt2TnfdGNf8AdVQP55oe6QLZm5RRSk4GTVECUhpsU0c6b42DLnGacaBjDUL9anNQv1pM
+aCMfKPpUoqJOgqUVKBik4UnrgVxlh4gj0g6Xpzo0k1/cOxKjOAXI/wA/Q1188git5HPRVJrzae5t
+rXxVoocn9wivJt5Kja7Yx1PL1E58skVFXR6ezqiF3YKoGSSeBWJqWtW9x4eubqwnWUZMYZfXdtP8
+jWL4311V0y3soCfMvDnZ/EVBHy49SxA/OuevhaaToFp4aWWVtXaZZGKsQGkY4IyOw3Y/CidTR2FG
+Ox13gUzT6VcXc7FnlnYDnoo6f1rqDVHRdJg0TS4rG3JKpklmPLMeST+NXzVwVopMUnd3GGomHNSm
+oW60NghksiwwM7HaFHWsRvFVjazslxeW8ZVC5Ejhfl65qz4kljh8P3bSlcbOAxxk18/XurRy3bwG
+2/dMQu5cMQM9jisJzaehSVz1/U/GcVzps72k6SwSRSBSEI5AzgZ68d/Y1i3Wr2sPxEn1IbdttZJH
+CW6B2IUH9TXELc6HPBHE93c2UqAqv7sEc9f51FJpt4ICLQyagJ/lLjIGPfOKxlN3uy0rI7uTVLbU
+fiJBLPNCIbYBUbdlSVGQwHfJYn8BWkiaVqXjq0uoHQpBJtDsfvbVPT33tmvPLXQtQisBDPbRo6vu
+iJkyfoevH8qim0m8n/dQ30Qc/N5LSDr3xS9qn16hY+hItUs57hoYbmJ2QZYK4OP84NMGqRS3Rt4s
+lvUjj8K+fVOq2TqWuFUQ9P3uBx25rcsPGGt6WvnsRKrvhV++Se+P/rVp9ZI5D3I1A55rhtF+Jlve
+usd/bNb5bb5mDtz+NduWV1DKcqRkGtVUUloKzRzXj4Rnw07S3K28auCzkZ/ADvXhN7eaat0PsKyS
+jcA0sxCjr1A7fjX0brejwa5pctlOoIblSexrxvVPAd7HdSM1qI7WPIVduS+O/tWNSOt2VFmTLqFt
+DItumlr55+cSnhWHUYPfj9c1pyvrFzbAwytGSR80Z6Duc/8A1zWdplu9ndSws0jJGvyxuCVQ8due
+2abLqmsyXEiwwFucjeMAVi4XlojVJWu2acVy9qC1zLCHB5JUFmPf5s4x7cmqWqeIrSdEi8hXaIho
+hGNgQj/ZHNZ7adfzlpr1sM/TYMc/jXS6bpj2VosgsLUEr/rDFuf65Pejks7tjuraIxI5Jr+VF3ZT
+IASP7zevNT6zc6naqEVVW0YbFRojtU8YOexz3rfttNhZo7mdJZZAOHIAI/KtC8sptSKo9vPIhTG1
+0yB+HrSXLfYl36nn1zcajcWvlSoVdioYEdSDkMO4PWvoDw+07eHrA3H+u8ld3HfFefW/g/UbieEG
+0k8gN8zHAOPxr0+GEW1tHCvRFCiumknbYzkWFNP+VhggEe4qJTUgauhEMhfS7CUkvZwEtyTsHNKN
+NsEXi0gAH+wKn3U7dTsgKp0/TmILWkBIORmMVJ9ns8bPJjweMbakZFbqKcNqjCgD6U7INRgtbdcb
+YIxjphRxTyAOwoJppNFkA1nX1qBzUrGq8hyaTGgDHNSAmiipQDgTTgTRRVALuOKAxoooAaWNIWNF
+FAEbMc1BIxFFFID/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0046/full/!100,100/0/default.jpg</Url><Caption>29376_0046</Caption><Caption>Mus (Humilis) Minimus, Aud. &amp; Bach. Little Harvest Mouse. (v. 2, no. 13, plate 65)</Caption><Caption>Exhibit</Caption><Caption>plate 065</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="18" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0041;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YDAy
+elcX4zl8Q291bX2mPHFZW3zyyvINp7FSvfr+tdshDKGHIIyKV4kljaORFdGGGVhkEVlKN0XGXK7t
+XPO9B+JYujp9rqNoRcXM5hMsYwh+bapA9yfwxXoDTxKxUyKG9M81iatbafb6po8jW0CrBMVUkBRH
+lTjH4j8Kx/EnmafqLXtuqeVIuRcod5ic9mX+6fas3zRXcb5W9NDprvWrGyiaW4uY4o1OCztj+dVL
+fxfol5eW9raXizyzttURnODjPPp0rDtrE69p7tqlrb+bgbZYyCJBjqM8j6VwGqeFba4e+bSZX8+x
+wzqOMHPY/hUxqO+qJaPdpG2IxB5AJxUf2mEcGRd2OQDyK8b8O/EiW1t103Wt5VDtM68Mw/2u5r1X
+StUsdUtUOmzxCLHJTGfwFbom5dN3bBlVp41ZzhQzYLH2qbbWHrfheLWb7TZnupI4rObzWjHPmEEE
+ZP1Fbg2QxktJ8o5LMeg+tNeZTtpYyta1ZNJS1JAZp50hC9+TjNX2KKcMwB9Ca8/8SeMdJi8WWRjl
+ErWaks6gkBjxt9OhPP0rt9K1KHWLFbuIDY3SpWrGyxweQeKKeRiigQtkMWUAPOI1/lUZ1WyVJ2a5
+iXyG2ybmA2ntnPrUsAMVlGMZZYxx9BXi/ifUGW7fUHi320rYlXrxnrjjkVUnYErnZeOv7WW0tLnR
+5d9xEjXSqvPmFACeO4welYeh/FyO/C22oaAxmIwWtmDBvX5Wxj8zW/pN3ZTjw5a6BfQ3QjjlZmkO
+SqkDO5R0OT0pNV+HaHVP7a0yeGC+yTLG0e2GQfQfdPvzUO9nbcHuY82vTjeNKsWsgzjZBIQ3JJ5x
+0UewqtqenX1rY3F7dara2txKuHS3jO5yT05OP0rkvFHjCwuLmGOygc3VtL88iSARsB1A7nt2qhqP
+i5dRWBSjptO4qTkk+lc0VK92NtFKawaW6KBi5BwDjrWlpl5e6DchbKR3nc8xKePxqK0ncR3d8ykL
+CpPPqe1ang+zaW5N3OVLSDJB611J6EW1L2oeN/F1lH5slzAqgZ2CPP6msXUfiRq+tWNvp6+YN7fv
+jGcF/YU/xorXepiGJfLjRMux6VkaJFHp0cuoyD+ErCTjk9Cad7rUtLU3tJtdR8TeJZNG0+OOxjYe
+ZNPjeVUAAnP5ACvbPD/h218OacLW3lnmPV5JnLFj/IfhXJfCO50ltFljhwuqNIz3BcfMwzxg91Ax
++NejkU0rA2QkDNFOI5opCGT+d9jk+zBTPsOwMcDOOK8E8Q6ndaffTWOp2MkM80jPJvAwwJJ+UjjH
+0r6BXpWV4g8Nab4m09rTUYdw/gkXh4z6g02rivY8PsrK50q4j1jQ7owXCDcY93yuM5K+4PpXqOhe
+PdL8TWz6ZeM2najKhjaGRsbiRjKN3/nXnWt6ZqHged7YSPdQJ84kZCAUPb3x3+tVN+k+IEWS5jaA
+hSwZU5bHpxzzWPO4svluemp8LfDtxoaWF7Yp5iE7Z4TtkH/Ah1/EYrgPF3wsj8NJDfaVK88G7bKZ
+zlk9CMcGtzwRrfiG3njgkuxPpucEXp+eMc4wRz278V0uofadZ+1efPayWyAGOONCSvPdj3x2AodS
+NtCOXU8i1OWwbRrC2sb2Kc3EoZwoYFcDvke9d5pWnww6ZGzgYTDZ9MVwXiXSYdHgi+xR7fLnYrk9
+c84HtW3Y+I4J/DrmWeRbnGPLzjB/woumlYaXczPE0yanrCWNqdu9suw7Ad6ZYWlr4g8S2ukwsq2y
+ARKxP5nHeuead4hcXCv+8uSdp7hc1J4KuHg8V2b8gmZV/WtoxuNux75a/DjStNSKTTnlhu4skTsx
+bLe46fhW/pcmqbXh1SGISJ92aFsrIPXB5B9q06Q1VibjCOaKD1oqQBelKzqmNzAZ4GTTFPFOOGGC
+AR70wIb6AXVlLGFR2ZTtDDIz2/WvPPEHw9Ouo+oaPcfY7hB5ccDoAi7cgqMDKjP+cYr0VraFjnZt
+PcoSpP5VmXBfRJ2vA0kllK3+kKeTEem8e3HP5+tRJJ7jTa2PDZtQ1fw1cfYtctZ7WXoJQeG9ww4N
+all4jn+1xyrqT3FseJIjww+le132n6frFmYL22gurdxnbIoYH3H+NeU+J/hBFZiXUtD1Q2kSfM9v
+PkqB3w39D+dYypdUFyv4outFfTEJmMsmS0YX5ixPr3H415vc3KCXy4zhnILAdh6fWuivLWx0Cyml
+vS8j3Z/duQN+F54HYf8A1q5PT4ra6uWaSQp/c55HuaVPRFM05CimQSx7ZQAuw/wAdqk8J2zz+IYD
+HGWKygkD61sG00W/tIjcx3C3IUh5Y3JEgHQnOevHNZ2mXOp+FbyNtOKyTyjJDp1XJwfUduhrpjNW
+sS4u59EaNPJbyy6VcszSQjdC7HJeI9PxHQ/hWsa8h0rx5qGr3NsZdKuor6EkK9v+9Vx3Ug8j8zXr
+MMvnQJJsZNyg7XGCPYimmDQ89aKaetFICJWqQNVCO4JH3f1qZZMnpRcC2GoYK6FWAKkYIPeoFk46
+U4Px0pNiItOsl060FrG5aJGPlg/wqTkL+HSk1PT49UszbSuyxlgWC98dvzqYkNwRTSinpxU+QHl2
+vfCW613xRZXNzqIk01GHmRgbSqDnaPr61U8Y/BmzmuFuPD6zWwZfmjQ71DeuGIOPxr11YlBz1qRV
+VPujFNJWsgPn6TwJr/hqxE0Wl3mqTkcZ27Y/fYCSa2vDHw71u/Q6pqwWKWfkRyEhlH0HT6V7RupN
+1PlRXMzM0fQbTSYxsjUy93xzWqTTCcnpTSeKei0EKTzRUTMc0UgP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0041/full/!100,100/0/default.jpg</Url><Caption>29376_0041</Caption><Caption>Didelphis Virginiana, Pennant. Virginian Opossum. (v. 2, no. 14, plate 66)</Caption><Caption>Exhibit</Caption><Caption>plate 066</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="19" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0012;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vYir
+9wY9lzTxGpAIUD8KkUU7FZWLuReUv91fypfLX+6PyqQ4FGKloVyPy0/uL+VHlr/dX8qlxSgUrBch
+8tf7o/Kl8sf3R+VSUowapILkPlr/AHV/KkMS/wB1fyqYiuE8TfFTQPDd41kWkvLpDh44MEIfQnpn
+2qlEdzsmjUZJUYHtUQMRYBQMn/ZrL8K+J4/FOmC+htZYIyxA398VukUmguVDGM/dH5UVMRzRU2GW
+QKXFKBS1oSxMCkZ0RdzsFHqTXjXi/wAW+MtJ1maze9t0tSxCi3j2Oy9sMw6/SvMLzXtb1q/+zzal
+NcqrFkjmnYqB1yeaTCx9a8EZByDVKbV9MgmMM2oWkco6o8yq35E18wHx743GklDr80dtEBGgjRVJ
+xwAGxn9a4yeS5vCJ5XaSWWU7nY5LGhIln1nf/Evwfp0xhm1y2eQHBEOZMH0yoIpLb4m+DLkgDXra
+Mk4HnZj/APQgK+XU0aRQqqS0rDp0AqBLBzNLDJ8rIR175qkkNJn0T47+KOn2mnNp/h68ivdRuVKi
+W3cMsAP8WRxn0FeY+EfAN54m1dSzP9mDbp7g5IJzyAe5rq/hl4D0nWbC4lv1lL282zajbA4wDzjn
+9a9psNPtdMtUtrOFYoUGFVRwKEytiPT9NttLsYrO0iEcMS7VUVYIqWmEUhEJHNFPK80VJRKOlGar
+X05trCaYZyi54rzeXxLrfnssLP8Ae4LsCPyH+NNyS3Eotnps8MFxEY5okkRhgq6gg/hXjPxM+H1h
+Yo2taGkNtOwKy26uqbx6oD39QK35dZ8QfYblo7iM3Jz5CFSAPr61weuCaX5Lg3Gp60xwysSVj46B
+f164H6VmqsHsynBo84u5DcRLEjN5sYx5WMBR6j1Nanh3wzf6vawT2ljPdRwkhxAu45PPP4V0Nt4U
+F4Vea6s7WVe6L5jj+Q/IV3HhkweGtJfTLDVA0nmFy0uOCccYBH86zeIprS4vZyvcxNG+HOvXWped
+LZC0t2TrK4DA544rM8YfDPxFpmqvd6fC9/azIBmBcshAxgjr6816S3iDU40IMB3EcHzAQT7fjVeP
+xXrCGIGyZz0k2yL+nNOOIgVyM8u0DXfFHhi4aD7c2mGZhuW7hO30zgqfzxXqmheMNX0e/hsfFk1v
+Jb3Y322oRMDGfYkAcfh+lM1OeLXbYw6jYiSPHSRlOD6j0NcI1rd6XP8A2W1uNR0aSQFVY58rPcEc
+qR+VXGvB9R+zfY92bW7JYw6TCRSMgpyD+NSafqkWo7wikFT3ryODVrfTLdbOzVVjTkKXyRk9ya0v
+CXisv4qis3ZDHN8oIznOKI1oydkN0mlc9WIopc0VoZFDWo3m0W7jiBMhjO0A4JNeGf2P4m+1HyhI
+nPO6UmvfJk82B4wcFgRn0rwPXdX8SaLrtzayxSdSEYDII7EVnVv0Lg0OWy8VWrAu00iL/tkfzqkJ
+tQ057iXyGa6nOWeSQZAySQPrUv8AwsC/NsIrmxaQ9GxxWRd+IPOUG3sdj9cuxauOUGac/kUdUju7
+y7V/OkikI5VWPT8AKrDSL93DJIxB4zknNLLqmoyAmSKNt3P3e1aNlq08bIPK6dumKEpLRWFza6l+
+G11HT9PzMnmv0UM+Ao96dbHXLiTEcaxgDmQuwCj65qy07amgWdSidSMkDitKS/js7eOIuMSfKqrz
+nil7PvuaKZnLY6tLDuOqsIscGMk7vxJrKn0y4gj3NcOq/wC0ec/QVsXt/M1gEgQLjt0xWVEkkrZn
+lYRj0Ga0inEq9ysIriPKZ3DrkxHJrc8GRXtx4v05bRC22UM527QFHX9KWxtL3WilvBZXRjHZYifz
+PSvW/B/hKLQ4VuZYwLllxz1UVrC7eqIm7Lc6uikzRW5zkYaq9zp9neMGuLSOVhwCygmlV6kD02Iy
+5/CGhXQPm6dFz3GQazn+G3hmRtzWkn0EpFdOHpd9Q4R7Du+5xsnwn8LOSRFcqT6Tn+tQy/Crw2Vw
+r3kZBzkOOv5V3G+jf9anljfYLs4iH4Z6DCxKXd+dxycuDn9K2bfwXpKAbfPyBjLY/wAK3wQOmadv
++tHs4PdD55dzmU+HPhkOWayZyTk7pDz+WK1rTw1otiALfToFx3K5P5mtDzPrSeZz3rRRiuguaT6k
+iqkahUQKo6BRgCkLUwyfWozJTEPLUVWabacc0Uhn/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0012/full/!100,100/0/default.jpg</Url><Caption>29376_0012</Caption><Caption>Canis Lupus (Var. Ater), Linn. Black American Wolf. (v. 2, no. 14, plate 67)</Caption><Caption>Exhibit</Caption><Caption>plate 067</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="20" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0019;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD24IWA
+G4j6VJspUHFSAVjYu5EwVVLNgAd6p2uq6fe3MlvbXMcskfDBDnFcB8XdfvreK10LTZTDLcKZZpAc
+EJ0C57ZOfyrK+Cui3q3eoX13IdlufIRc9WPU/l/OpcRXPYtg9KXYPQU/FRXNxDZ20lxcSLHDGpZ3
+Y4AApJIBxQen6UmweleV6p8T9Y1C4ePwxpKvbKcC6ujtD+4HpUOhfE7Wj4gg0vWbOHM5Co8PT/69
+NNbDsz1nyx6Cq95dWmnwNPdzRwxDqzkAU6/v4dO0ue/uDtihjMjfQCvlfxd4v1jxvrDASS/Zmk22
+9rHk59OO5rWMOYTdj6Hi8deGJ5zDHqkBbOK2URJlEkVwXQnII2kEenSvmtfhN4zgsRfrpgzjcYvN
+HmY+mf0ro/hj41vbLV/7I1EyBc7dkhIKn0xTdNW0DmPcWTnpRUuQwDDoRkUVhYoGvbew0oXl5MsM
+EUQeSRzgKMdayNI8feHNbvWtbC/3sDgM8bRqxzjALAZPI/OrepWMWo+GxaXC7onjRmB77cN/Svn7
+xlLaPqrz2IWBZAJHWNSBuwOfboDj+tbJJks7v4o2Utv4y0+/kTfaT2/lMxGQjKc/1rQ+FmqC3mvN
+JuPkkMgkXd1O4ZH/ALMPwFcd/wAJr4ggSxtNeuTJbWy4kgAKy3G6PK+Y4IJ5ZflBBIU5ya57+172
+DXZdStHe3SWRkhWQl8Ju3KuWJPGAfqKynOMdxqLex9SYryj4sapNealp3hiByscv+kXIB+8oOFB9
+sg/kK1fCvxV0/VHjsdZVNPviQiuW/dSN7H+E+x/OuO8bMz/FG6D5ytuixnOOMZ4/HNRKXu3QJa2Z
+WvrptMhlWFMJbxhQgOMtj/8AVXp3hPwVZ6bbwX97Es+qOgZ5W52E/wAK+gH6145rKt9medjuAn+c
+54wGx/Svo+2O+2jYd1FFKKKk2cj8U1l/4Vxq4h6+WA3+7uGa8V+C66fD448y5CM4iIgL9FY9T9e1
+fSWpafBqmmXNhcruguI2icexGK+Q9XsdQ8D+K57KUskttKdkgGNy9mHsRg12Q1TRk+59hYrhPE/g
+W1vdZg1e0iEd0GyzqMZ4q94A8Wp4q0RJyQZV4f611rKCOajYoowKRBGG+8FANFWSozRWZRyvjiG8
+uvDVvYWlylpHdyJDPcP/AMs4yPw6nA/TvXiHjFba01W5sEuFuktCIfNXjzXHXA9uh9wa+lruJ5rC
+aOIL5hQhNwBGccV5Hf8AgDQ9K0zSVlEx1W+nMkktzkkKqszJtzgfwj1NXdJXZFiC00/7dFp2o6oY
+X1NYAryy7WYnt6AEdO/51n+KdAkvIY/s8Em8HCuOAuepqbU/EMD2csYZEVMgIh447D2rlfBs97L4
+tCwEvasxMqOfl2dz9eleTWozu6zlt9x106qS5Lbmp4i8LoulLKq7ikYG7HXArCg1xria1e8kke6t
+gIWd2yWQfdPvgV6pr09nFphFy22NwdvFeK6zAlvdyvburRsm8Mp6HNLBzclyyCskndHWapc+f4fu
+QgJMjOfl7cgk/r+tfQ3h+Yz+HtPmJyXt0bP1Ar5itJmuNERVXe037tEHVicD+Y6Cvo651GHwf4FN
+9eDMen2YLKONxAACj6nA/GvSpK2hzSZtXV3bWUJmu7iKCIdXlcKo/E14z8ZLvwdruixXcOs2E2p2
+sgUC3lV3eMnBXj0Jz+frXmtz4i1Hxbey6trt2ZMEmOL+CMf3VHYfz71l6kqyN5EcKpLJ8zNjoK6o
+xsyLnb/B3XTo/in+zGfNvdrhc9d3bFfSB6V81/BrRo9T8bieeeMfYYi6pnlz04+ma+kvMRnZFdSy
+43KDyPTNTU3GiMjmilbrRWJQGRI42d2CooySTwBXlHxK8X6NdJZR6fcPJqVlcCeIqvyMuMMpJPcH
+07V13jiwXUPD+3yDNIrgoucc144/h1oZJjfxrA7AiNUJ4GP1I7VMqijoxqNyvf2mnXqSXcFwqiUZ
+8h/ldG9geuKv+A47eCHUJcobuMoAgbny8nd+Z/kKx/7F0yyKziea+lDcgMMA+jd6t3er3V3Gww0X
+lhf3YmIDDPIx7DNclZ+0g4R2ZrD3JczO516wi1PSol37gE4Ze/vXl/iSyFjbWUewEt8jerAHP+Fb
+lx4t+z2sUNvJbxtGMM3lDd78/wCelcvqeuQahJ5lxcSTuo+UZwAPYdKww1GpCXkXUnGS8y1p+qx2
+ep2Doke6B1aCKQEqWB+Xgc4zz71seMPiNr/iLSLrRLpIJ7N0WW5NrbsGjVWDcnJ28gdazfB8+hXH
+iywgvIPLheTLTMSMYGRjuOcCqPiK11bw9rOqabp6CO21LeN0LeYssRJIAY/XB7816tJa6nNJnOyX
+cAQQQB40YDJDE1owy3Wpn7KsYL/89Ox9/aqdlocoUtdssSZ5yea0LZ3t4rqKyYFZmDA90A7Z7VtK
+ore6KMH1L2mWX9lTpc3F5cW7gHYYZMOOMHkdM8/hXq/wd1mzk1LUdOt4SrSRicyM2S+045/76rxF
+p0jk/eN57DsM4r2H4GMlxe6tP9mWNo4kVWA6Ak5H6D8qxbbd2aWSVj2djzRTT1opEFS9jM9hLGqb
+22kqucZPYZrzDWfBvirXZTGsUFrA3DF5gcg9Rxk/lXpkdyrIDhsEZqRZlHQGolBS1Y02jyi0+C96
+JB5+rxQxjHEKsTkdOpA4zWzD8GtMhjCrqd4CM8qEHX6g16D9oHoaPtA9DU+zgNzkzymX4F20900w
+1MwBvvfu/NJH44AP4VpW3wN8Nov+kXupTnviRUH5Bf616L9oHoaaGi7JjPoKcbLQlts4KL4P6baX
+jSWMiwxYwoOWc/Vif5YqSX4dXKJIbaS2M7f8tHJznHY4OBXcgxjPy5/AVIkiIDtTbk5OBQ4RerGp
+NHikPwW1u/1EtqV7bRQbuWjYsxHsK9Es/hb4RtdPjtJNMFxt6ySyNuY+pwQK6nzxnoaDOPQ1qrBd
+nKy/CrwTLydERT/szSD/ANmrW0Dwto/haKePSLYwLOwZ8uWyR06/WtIzAn+L86Z5wx0P407iJGbm
+iqct0EfGD0oqRn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0019/full/!100,100/0/default.jpg</Url><Caption>29376_0019</Caption><Caption>Sciurus Capistratus, Bosc. Fox Squirrel. (v. 2, no. 14, plate 68)</Caption><Caption>Exhibit</Caption><Caption>plate 068</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="21" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0044;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3VY1/
+uL+VPCKP4R+VKBT8VIxmKSnAEDk596U0hDAadmkxSimAZoyaDQBTAKQ5p+KYyMScOR+VAxDmmMDU
+uKQikBWIOaKkK80UWQFgUuKBS0wEIpMU40lSxDaKWigQmKWloqkMKSloxTASginUhFIZERzRTyKK
+QDhTqaKdTEY194js7GZopGXK9fm/+tVA+N9M2htwx/vY/pXLeMY9Qi1d5luVjhzwHdQp/OuDufEU
+9vdOtuEmY8NySmPQZrz6mIrRk1ZGiinse0p4usJDhVc/7vI/MVm6n8SNJ07T57lQbhouBHG4JZuw
+9v6V4bdLqN9KZZJJAxOQsZ2gflUSaVNFEQskuV+8objJ6/pSji7fE0Dp2PZfD3xXttZvrmxuNLlt
+rmDBwkokUg4/iwOeayvEPxsXSNVazttEMix5EklxP5eT/sjac/WvJpdNktlYwrJt3AuFJHI9vxqG
+SA6gT9pDvsGE8znArojiE9VsChc+g/D/AMSbPX9MF3FYyxuG2PEZASrcHr3HI5rWh8VedMEGnyKC
+epkXivni0sLiZxIsyRAcAR/Lj8BXQ6fLeWsgi+2tMrnDKQT+R6/rSlXd9GUqeh9Do25A2MZFKao6
+LE0Gj2yOSW2AnJJ/nV+upO6uZDCOaKU0UgEFOqMGng0wOJ8T+DJtYunuImDyMeDK3Cj2Fc0fhlqE
+E3mqEmb0DAV63z60CuSrhYVOrRaqSR4reeA/EISQC3Z89FjZR+uaoQ+CvEhKedp0pePpskwGX0PP
+Ne8nkcHBqLEwP3lIrmWXRW0n+BTqt7o8YsfBurzTNDLo0iRt1Z2G0frmoJ/hzr0lw7R6fsHr5q81
+7egmz8zDFSqCBhmyfXFaRwEU7qbF7XyPI9G+H+tRxgXNvBFk/wB4Z/GtS3+H+pfbxJLPAkKtkADJ
+r0mkwf71X9Qp3u238x+3kMgi8iBIsk7RjJp9HakNdtrKxkFFNJ5opARq3FPDVWVuKkDUATZozUW6
+l3UASZpc1HmlzU3QiTNLmo80uapMB+aTNNzSE0xjyaaTTS1MLUAOJoqPdRSA/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0044/full/!100,100/0/default.jpg</Url><Caption>29376_0044</Caption><Caption>Condylura Cristata, Linn. Common Star-nose Mole. (v. 2, no. 14, plate 69)</Caption><Caption>Exhibit</Caption><Caption>plate 069</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="22" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0021;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABMAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3S1G2
+2iA6BBj8qnqrpribTbWUdHhRvzUVbxUjGnNJzTsHJ5GO3FIRQISjNBooAWloFFABk0nNLRzjjrTs
+Mac1GwNSAP8AxbfwoIosBWIOaKlK80VIFXQB/wAU9pv/AF6xf+gCtPFZ2gqV8P6ap6i1iH/jorRq
+hCUhp1Vb2+trCAy3EoRe3qfpUyairsNyYiiuH1Xxvvt57e0ikidgVWVSCy57gdM1yXhvxrfaH4hS
+z1nVnfT532g3z7mXPRg/btweK54YulOXLFlunJK7PZaUVQvtY0/T4g9xdRJn7o3DJrhdW8Z6hDdC
+5ttV09bSKQMYSnzSLnlScnB69K1lXpxdmxKEnselUleV6n8V5n0yG70y0CBnKnzPmzg4OK1fB3jW
+/wBX12TT9SktY9kBbC8EvuAA6+mTirVSLdkS9HY9AFIaI5ElXdG6uvTKnIpxFUMiI5opxxmikBX0
+kY0iyB6iBB/46Ku1XshtsoB6Rr/KrFMRzXinXJ9Lh22zRo5GS7jOPpXkPiXxM6/vbq9aaRueDwPo
+K6P4hasi6jKjy42H7uCa8wW1XUbm7mvmeNIxvVVH3l/GvLxHvTbnsjohaMbl+x1S6uYpntraVkcg
+GViABnocVmX9udRusO9vLcfdXzGYAH0JOADxXQjWI7DSZBJGkLkBIXEWVdeo+oqvdPbx2LzrJGs0
+hBVFbOz3GemcGuWE2pXUSXVZUstLlmhlgbV7m4nwqQojARq2cYLMc49Peob3TB5amzvJBGi7JFnd
+SWfvtxxirlne2FncXF2zsIux8xRjockHJPzcgDH1reN34d1XRENh5n2vdud5kIRF9EycdhyM11wl
+K92tCeeXc5a0CW2nR2Ydm3yDBY4wTzuAzxkdPzq1Ckulw3E0gcTtIdoVvm2nufSnWsLSzzmZW8vd
+lHYjZ1x1B64X8s1f8k2expZYZklYHbGyttJ6dPp0/Ot1O7sZW6nqfwnuzdeFpdz7mW4bIJJxkD1r
+uzXA/Ce2Efh+7nG3EtywBXoQO4/Ou/Ndi2BbEZxmihutFIoSJdkSr/dAFSVEp4p4NAHjXj+wf/hI
+5ZpLDzrcsGcl9vye3vXAXlnd3C7IDNHZZzHHnJwe27qASa+nL2xtNQhMN5bRzxkYKuuaqw+H9GhK
+mLTbZCowuIxwPSuWpQlJ6MG7nzBFpxtIZZfJZlQgYUZO7nb+v4Vs6d4dtrwq17amSYgFmd9zADn8
+Ca+jYdL063GIbG3jH+zGBRJa2O7D20Yz6JjNQsPU6PUcXFbnznrukWttZbIIY2Ocso/Wq8cc+pWM
+xVRArJtRc52Bf8a+h00HQ97sNPjYt94NGWH5GpIfC+hQszR6Xagt1/dg1UaE0rNjqOM0fPjR20CR
+tFsMMgMku4kFfYe+R06nNNSCbyVJwJps7ovXnOK+hpPDOhy/6zSbRuc8xA81ag02wtuYLKCM+qxA
+VqqOmpnZdDA+HulXOk+F1iu41jkllaUIOMAgYyO3SuqNGaQmtxkcmd34UVDO+1wM9qKQxytTw1V0
+JxTwTTuBPuozUQOaWkA/NLwetR0oPNFxEgwOgxTs1FmlBoAlzSZpmaQnmmMfmmlqaTTSaAKl5Ltm
+A/2aKz9WdlulAP8AAP5migD/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0021/full/!100,100/0/default.jpg</Url><Caption>29376_0021</Caption><Caption>Sorex Parvus, Say. Say's Least Shrew. (v. 2, no. 14, plate 70)</Caption><Caption>Exhibit</Caption><Caption>plate 070</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="23" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0035;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2eVvK
+iLliAPSsi816SAHy4lOBnk1o6pKsentJuUAkYJPHNeca5r9vaq5MyMysEZc8gnpXJJdi7mmnxAvE
+k/e2KbCeuSv4dakh+JMTzGOW1EQ7MX4/HivLtRv2N8JZZRMVO5YVPX2HpWFe3U13ALq6llgZJSss
+aMy7QVyox6e9TKyBXZ7n/wAJvcDJH2Vh2wD/AI0+Lx/Gn/H1DGgHV/MwP1rwePTb4xs8TTwqihmZ
+Zj/LPXmorCW4u9Wjtr68uJI2GMs+7ZzxjPfjrURa7j5WfSmm+MNJ1NS0dwAM43g7l/MVvxSRzIHi
+kV19VOa+ZtPcaf4gmtIJTHFIGXCk4Dr0P5CvQ/CHilE1qJLid4oQNkiMf4iMD9a2haSuJ3Tses7T
+600qfWoTqdiFDG5jAPAOamiuIJ/9TNHJxn5WBrTlQXEKn1qGQSg/LtI9zVrFMIpOI7lT58cnB74o
+qYrzRWdh3OQ8cLK/gi3CNhv3RJzjtXiV9BLI0hkLMX+Ykc817Z41Eg8EWpU4dUj64/uj1rxp7C5n
+kLebgH0pymovUhxbKEJEMTtIiudwXL9P0qKZGuIYyUKneEPH3x6c8d+9b8Olrbx7rmZjDIRknA2E
+dG/z61E+ky3lrcXEVlMVB3RSRjIb1LAc1zOd5XRslaFi/Hf2lx4bW3jgjiZWeMuj4R2U8HrjkD+V
+czahrfXIpJoX2oclNuD7CrBt/O0ttOYPbyrIZFBXg+oPpVmygv7DRLnzpTMJoQlvFwcMSOfbAzWS
+5Yp6lXd7WMyaO607XzcXURKFGmRM9SeP6k1uWd7HeT5iO109eCR2qnqtvcLoloAUdoQVeSQFRgnO
+0euDmsWK+QKp5Q+o7fpXbSqRlHc55RaZ67pviSKS3KXbLHKhxgjhh6irza/bW86XEF95cg4+5mvK
+dPuibcRGTewJIIPP61sJeXSlT5Ub4AGGXn8xWyXZgj12Px3bmJd6qzY5K5wfwqaHxhb3DoA6oCcH
+PWvPLW4a4t90trIjD24/CtCw3NLHsgQLkY3A/wD1qhzV7F8p6uCGUMOhGaKIFxbxggA7BwPpRQI5
+zxjZrdeEwmAGUIVOOnFeWppl06kRFZGxwPuge9ez+IoxJo0q8ADBrzKG+igvhAqKVXqfUVlVSY4m
+Dfi0061bz5lEwz+6JJJOO3p9a5Hz5L6JTAGgljbJaOQ8+3tXU+I4Y7jUY5EaM70ySvXqetYM0Mdm
+0eZFjDDlcEsffFc8IRjr1Kdy/pqPueZ7ySR9wdizk7/qe9XnZb+EyzTlQrbgkY2hSO3v+NcvGl4i
+P5UU0kQO+MnAxz35qrZwXGqXJS6uJBubAWMcAE46UnCN+ZglLax0GpCOUx/aGmML/wCq3gkNjjj8
+asWGnabfjyvKWd40w6CP5gvWrfh/SzZ6yvhrUv3tm6edaSD+BmGcjuOc/jVKSO+0LUb+1U+ZMScb
+h+RJ9uPWr2Vkxpa6k0nhvT2tEuLTzIpHUOoLbgO+K0rHxDdXASzeKBpUGM7AC+P61x+j6hdaXObK
+4LSW0h2qDyVYntV6ZLiO6W8ihkTawYEr3961u1o2KyZ3DS3Eg+eIIMfw5ot4sTRsxlKhgOH3f1rH
+tvFSCH/SLZ92OqkYNW9P16OS5gZrVh84IORUq63QM9si5hjI6bR/KiliIaGNh0Kg/pRXQQYHjbzT
+4an8osDkZx6V5Hbq8EuY2Zn/AI9wyFNe3awM6RdcZxGWx9Oa8dGt2cNyoxyzZO5a567aeg0RX4SV
+kuZkASOMg8HG0c5Jrhra5n1TVJZY7d5QThUUcBR0FehX2t6fJaSwtbtNFKpVtp/Os2z8QaRYjZZa
+e2QuOE2gfp1rl9rJRa5dS1ve5XktdVNnlLZYD3I64/Gq2lRQWlrE10XjgJJdYYi8hO7kE9FrpYvE
+Vo2zz45I9ww3oPwqvqEml3dtJHBM8byjErBNu8e9c8aj2ktDTmd7la5kfWdZi1a0kNtbWyiJFC5b
+C8gfX1+ta4u7HWVa9Zwt4ABKoODwP/1Vj2dtFDKEsr5EcEAfvM80mq2F/et5jpGZEX5JI0w5+pHX
+6fWt41VJ2EkvmZ2o2UNzL5iJL8pB+Yc8EfmT9BW7pmmu9hGHtpIpMfeM+7P/AAHJqxpElosbeXZt
+cXKKAwY8/wD1uh/Krc11KF8xtLUgdFBHy+1OpVbfKkOKsMNpKEWFrWORSOfk4P59Kjs9CjkvYgLK
+MMWHKyAf1p1xqpERD2Mm08kBiRU+grDq+t28KC6TDbiB0455pQu5KwSSPWoV2QRqRjCgfpRS9OB2
+or0jAZw4KkAg8EGuN1z4fWmoPJLahEZsnaxIwfYiurV+KlDcd6Ukpbgro8b1D4ZayuDZxYx280MP
+yqg/gXxBDCcW16sgI3BEVh9Rg17pvIpRIcVk6a7sd/I8CPhLxhAoENvO24knfF/+v0q5Z+H/ABfP
+DN9r0tXUdIjEFLE/XAxXuPmGkYlxySPocUlBdSX5HgieHNdVsTeEZww/igbb/I1estLvImBmstTt
+iOSjwmTP44xXtiod2TI59s1KrYGKHRjIak0eTW638cMnl2MweV8tttwp+pJJz+VV7jTddWZzBpt7
+O8hyRIvyD9K9i3mjeaI4aK3ZftH2PIrLwb4s1CT99ss4j/z0YDH4KK9G0Dw3baFb/KfMuWA3ynv9
+PatcsSKjLH3raNOMdiXJsUtyaKgZjmii4rH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0035/full/!100,100/0/default.jpg</Url><Caption>29376_0035</Caption><Caption>Canis Latrans, Say. Prairie Wolf. (v. 2, no. 15, plate 71)</Caption><Caption>Exhibit</Caption><Caption>plate 071</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="24" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0038;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3bHHp
+74qhPqXkvsERfHBbgVoOwjidz0UE1wDeLrK4Wd3Gx0yduRz9KzdkM7db2EqpLAEjpUqzRseHU/jX
+mVv43twJTNHIiqu7HXIzWnZ+JLS4hjljfYJOgfqKjmQHe7xnqKdmuSOqQCVoWf51TeTniq0XjC2i
+YJEsjknJORwKOaIjt80ZNUtN1GK/tkmQ8MMir2K1SAKSnUlFh3GEHFQlXz9/I+lWDTSKTQ7lcg5o
+qQjmipsBHqkiRaVdO5wojbP5V8/6rLFGJHhZtjc5C4OPeve9dRn0K7VSQTGcEV87zwyX+uRWCFpX
+kkCFj6k46UTVySbSNI1vxBIyWVtuhHyvK/CDP+eldenwx1RYAZdS+fr5aqSB+td/pOnQaMLfTbfC
+xRRAkAfePGT/ADq1qk81gRcpgpkB1YdB61m4odjxvUPCniHT5xLGGuFU5ZlYhvxrFvdQuVtpYSTD
+KX+bsQK+jY1W5iUsu4OvrxXLeJfh/pmvy+bsaKYD76cfnU8gWOF8I+Ljptoba6kGwnajFvuj1rtd
+K8UyvrEME7M0LjCSbhhvc+9eY+JvAWqaGBLau9xbL8zLj5h9PWs7Sdfa0Vd/ztEfkVj92tFdWEfS
+kcgfB6Z7ZqSvGNM8U3l9qVtOiybRIB/EQPXp2r16G8ikiDGQZxkgjH6VrGVx2LNJjimLcRMcB81I
+CGHBpsCPFFPxRUjK2r4Gj3ZOceU3bPavm621ExeIY71FRfIlD7cdcGvpDWJXh0a7kjjEjLExCk4B
+4r5nuYZZryRzbxxKzE4VqmbS3FZvY95Yx6pPYapZXAw2GOD1XuDTvEOpQm0NuCN0nybz93PTGfrX
+EaLcX1r4CjXTIUmuY7g+ZEcncp57YNZI8Z29xd3Wna5bwW1pcDDKjFzE4HBwM46CsnJFWZ6rpGpQ
+w2qQyvgqAOa2EuIpjmNwwx2r5/fxH/ZWpW8drqVzqGmrgt8pHHcc16ZY+P8AwzNGmNWih/uqcpt9
+iCBRGT2E0dZfvbeQVmIAPAP/ANftXnN98OrG5muNRfekcjb28kjbGOu7nrn0FdPc6za3dvK9tepd
+ISPnjx8nuSKzj4xjNyNK0yE3MpTaW8v90g9WP4dq0uFjhpUbw1qNi+j381zavndvXaCc8/Uf4V2+
+meLtPvoyOVdfvZXI/OvHdf8AEl1f6nMt1OPkkKhUj2KD0qTQdZbSr4XUbJdEoV8tnGKd7IfU93tN
+ZtXOUkJBOPu9K37G7iuVPluCR6V5TZ+PI0t8yaQytj7ysCDXYeEPEia3dskFrLDEkZLFlGCcjGMf
+jTU7g0dhRQaKokiuU821kj/vLiuGu/DtpE7NLFvb+HOK7zquKw9QjLK5Ks3YDoaxrQ5kXCVjzS98
+RQaLcNbw5g5BPJVPbJxUMMtvfo83n2AVs7iozn8e9ber+Fb28Dm1lBU5/dyx/wBe9eP6v4G8Q2N8
+0QhDbju3RnGea5fZRas3Y1dSS2R6d9it5toCI4x94AAZ+lWBo2kEBbxVDYzkxgivJYNOksJWgv5r
+mGZQNwiAYjPTPFdBb2/iKK4BsruWS3A/5eWyAO564H5VPsYrXmH7ZvRo7yyj0fRrsyaTDdSSOux1
+T5Y2HuDWfq93rEUM9xYwWuniVQknkhUdwO5ZvrXK3OteIZp5LTSTJcwrgtcIm4Bu4DYxge1LJ4c1
+6GOTUb7UJS7KXVPvsR6Zat4ppe8yeZN6IpXWhagV8ySyuGLEgPK4OTgdwT71Ti0C4e8+zCwlludj
+OYklRNoBxk55xyPzFUG1TxBrE5htZ754lbbnexC/j2rptK0690ZxPJHcyXU3BYsQMDn5j6V1JKO5
+ndvYzbjw3rMMcbyxrDGMNsi+bGemTXrvwotg0dxcC780xgRuitkA9eawbbwrcaraqbidzG5ybe34
+U5Pfufxr0/wz4etPD9h5dtCsTSAFwvTNK13cG9LG5RTaKogjDUp2HqM/hUSmng0APKIykY4PpWNc
+eFNLubjzpEk3Zzw5HNbANLmokk9x7GQvhbSlm854BI4GNzgE0txoOkXMe2a0DIDnaUODWtmg4PUC
+pUY9hXZjR6Hp0FxHJAjxqowUWLg/p/Kpr3w5pOrwBLm2YoM4AZozz16EVpqqqOAKeDVpLsF2ZOn+
+FtF0u2W3tLGKOJRgKBU76HpkmQ9pGQeoI4NX80maoCvbWNnZRrFbW0cSL0VFwBVjdxSE00k0DAtz
+RTD1ooA//9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0038/full/!100,100/0/default.jpg</Url><Caption>29376_0038</Caption><Caption>Canis lupus (Var. Albus), Linn. White American Wolf. (v. 2, no. 15, plate 72)</Caption><Caption>Exhibit</Caption><Caption>plate 072</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="25" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0016;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3gEgd
+z9KUMSM4I+tKBSGpsAu6k3H1rxjxVqmotqN9dzXUwMMuyK2UMBGATlt3boPQ1oeHfE+q3Go+c2oT
+XUWBCYTh8OXQAkD/AGd3Pqa5vbxvY09m7XPWN1G400CnYrexlcXcaN1Jik3Lu27hu9M81SQXF3UE
+mjFFOw7jWO1STnA9qi81WIUFsnp8pFTUlJodyA5zRUhFFTYZOKjaSNQSzqB6k0/cFTcxwAMkmuA1
+fV7e6uJVtbhJApIJjbOPyolLlBRuYfxZktI7y1YkiRoCy+X/AMtGzxn1rD8FeJv7JhE19oRmJfcL
+iOTaQB0+XGKr+KvKuhazTT5lhLoRnJCnvj8DV21vrA6JHLBKpH3ePXPSuKo7SckjpiuaCiz17SfE
+Gna1AslpONx6xP8AK4/CtSvE0S2lxIJOSc7s9K0LbV7y2tJo9PvJlljG4FnLDP0NXHFfzIylQ7M9
+crj/ABRMIdRgmWaOCSF1KO+Rlj6kdevTpVnQ/FRvdNgublUPmxqwMfHPRsj6g1yV7dS6r4kurqOT
+dbwzLJCWUHaQq9M+4redRcuhnGOtj0qwnnuIN08Pltxg9m/DqKtVxVt4wvVjaKeGFpAflk6Aj3FR
+X/ibWFiKmEQLIPlnUBhj2960hNNA4tHc4oxXntr4s1OL5HmSXnALAZxXS6HrNzqNy0cwiChcjapB
+z+dXck2yOaKcRzRUFBLjyH3AEbTnNfPuqQ21nqU09iDFL5hOIwSPoR0r6CkG6J19QRXzvqu621O8
+yrkB2AwQc8/WufEO1jSkr3GaZd6a8st1qNpHNO0rHczn5eeABUjnSb68a3SZ9OtnHmDAyN+R+lYp
+jjklKQSMG6lUXH6nmk+ySu6gBVQA/M7Drx/hXK6mupo4tbHSf8Ivq32cvp2q29xFjIKjk/TBNR6B
+qDQW07zrIVz5buw+63v6VkWf9qWV0Us0uR23xLjcfqeMVuaM2t2kd1ItpCUnbMq3L5aQ8/3enU0n
+UpvfQlOa8yxY3Is7Ce3glYkyEoCfuK3JH5k/nVvT78WsEjMgkkKkKM8ZAJH8qxr+6t7WSO4ayltJ
+d2ZFSXzI3Xv15Bqe11jRnnmi3EGMFzlDjHT+tar3tmRdp3N4a5bywhWtik23cVI3DJxnmr8mofat
+KS0PyspdwO+AM9PxrmZLzR1uDG97AsqkhgSAQe/ardpJaRTyPFcRywFc5D7tvYjPvmtYpxZXMpKz
+FSOQuByynoQpH611/g57qPWHhkTMRQ4YHNc/CNMjRZfNxE3QnnFdBoGu6Fb6lDbW8jNcTNsXj/69
+dEZJmTTO8NFFFUIO1eMeJdCeDVbnyIl2tKWy9eyg1zHizT5ZIhPbxM7fxBFyawxEHKGhdOVnqeTP
+ZXEcbLHG7OerBeB+Aqn9nnWYx+RIHwM7sjj15robhrgyss8ptk6bVXLfmen5UkK2qFrhbSRzjaZX
+cl39gSc/lXj1I30udSZmaal3Hv8ALO/J2lVAO38atJdyQN5ZeUSHqOoq3JqGnw2ztDbC2YrkvcqV
+yfTca58eJohv8vTJXKnCPGNysfY4H8jUKjd3E5Mmumtpd3mSDew4ZqrW/hiSVMtI6REDJBByBz2p
+zMdTJudS86EpIDHa25VWxjqWI/Tir8l7YRFEh0zUPOk+6ss4GfpgGuiKnFWTFZHJaxpNpaXWy3Es
+rHqQ6k59arLcLBY/ZoQwmeTcxz0A6Dj6murk0C91W5R0s4tOjyQ0ks6t+QABqpfaTp2mx/ZoQbiY
+thp2XAJ77VHJHvmuyEnbVg7Gbb63eR2i2rbGwxYmRSce1dP4CY6n41sEMb4RjIzDGPlBP5VTsbC1
+4jtdPlmnI5bYxJ+mRnFeqeAfCR0aF768h23kvQMOUX09q1pScpbGdRJI7eikorpMCMNTs+2agDU8
+NQBBcaVp94cz2cbn1I5rPbwfozk74Hb2aRjj6c1s7qdms5Qi90O7RyWofDXw/qLq8y3I2Y2Ks3yr
++BGPzqH/AIVzpEZwbq+wRj5GRePqFrs80bqn2cOwc0u5x1r8PvDttuIjvHyc5eY/0rSg8E6FGd62
+sgbGMtK2cfnW+MDkCnZqvZw7BzS7mUPDGjBAhsUYDpvJP8zU8Gh6Vbf6nT7ZPcRiru6jNWoxWyC7
+GRwQQ/6uFE/3VAqTNJmmlqoQpNFRluaKQH//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0016/full/!100,100/0/default.jpg</Url><Caption>29376_0016</Caption><Caption>Ovis Montana, Desm. Rocky Mountain Sheep. (v. 2, no. 15, plate 73)</Caption><Caption>Exhibit</Caption><Caption>plate 073</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="26" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0037;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3hadQ
+BTsVNhjc0ZNLtwSck5pDSsITNANJilxVAOBpaQUvWgApDS4prpuH3iv0oGIaYRTwm3PzE59aCKAK
+5BzRUhFFKwE4paBS0wEpDTjTTSEJimu4QZJAzwM+tOPSo4pI7qJuOMlWVh0PcUXAhtmKqZJpCS5C
++wIGOPxq5Vby1WOSFuY9vA7470tpN51srMwLAlGPuDiknrZiLFFRLKXnZFwUVRk++Tx+lPVg2T0G
+cD3qxi4pCKfSEUhkRFFPxRSAcKdTRTqYhrOoOCwB+tJx6ivG/GXifWrLxHdxxmbyUkwgVtoxVCDx
+prUgUppdwwPDM91x+oNYuvBOzZfs52vY90quytE7yIQVbqpP8q+ddR13xXeSKWv761LMdkdsWVUA
+9SvWqNhqfixNWivr69ub94GxDE8pbaf7zew/nS9tC17k8kr2se4+IvE0OhhJ5LlUQ5UCTnBx0Pft
+XD2nxRghv5YyrIDJn6cZJA98CuF8WDXdU23+oB2kLbQsIzjr1P8AX3rCTTpRHuEEkdwsfmDfzmsf
+eqe8paDcZR0se2WvxCgkujFaTAvODtDgn5u+Men867DT9Wa6ePIzjgk9fqB2/wA+tfL1vNqFpIrr
+DNGyZ2lRg89ea6rSfGutWKq3zgE9Dnn3pxm47srkk+h9NDkcUVj+FtTbWPD1rfMfmkXkc8Gtk12J
+3V0RsyM0UtFIABp1Rg08GgDgvE3ho3epSzy7jBIQcKfSuPRZ9OV4GiVnDsBIxB4JOOAP/rcV7Y2G
+GCuR7ioWsbR8FrWEkHPKCuOeFu7pmqqu1jx46sIXZCqEnniMLj86kQtdxq7WhGTwGOM/lXqs2h6X
+OweSwgZhyDsFSLaWUWMWka/8AFZvBtvRjVU8ouA6QbUtYgBywOffNc2LHUJ5WliRgJACiBNwA9+M
+ivfBb2jn/j1Q/wDABUkNvbqMpbIn/AAK0WE01YvbM8Mh0O/uIttxlVyeCn681rab4EkuJg3kll9S
+MCvYfIiznykz67RTs44CmqWEXVjdd9Cno+nJpWmRWiAAIOg6Zq7RnikNdSSSsjHfUQ0U04opgMDU
+8NVdWpwY0gJ80u6ocml3GgRLuoyCMGodxpQxpASqABwMU7NRZNLmmBJmkzTM0ZpjH5ppNNyaaTQA
+paioiaKQH//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0037/full/!100,100/0/default.jpg</Url><Caption>29376_0037</Caption><Caption>Scallops Brewerii, Aud. &amp; Bach. Brewer's Shrew-Mole. (v. 2, no. 15, plate 74)</Caption><Caption>Exhibit</Caption><Caption>plate 074</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="27" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0033;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Nc4p
+TmlUUoWpsMjyaXJpxQlgcnHpRigQmTS5NGKXFMBQTS80gp1ACU00/FMdCwGGK/SgYhzTCDTwhXOW
+Jz60EUrAVWBzRUpXmipsMnUU8CkXpTqoQ00mKdimE4ZR60bCCihSGXIpwFCYABSigUtMApMU6kpg
+NxSEU7FBFIZXfg0U9hzRUjJF6U4U1elPFMRkazriaQoLW8snuozXI3HxMt/MVI4kDbufMbbit/xX
+fW1lCGnYqTwDXmWuz2bxF5jEq5wGdeT+Qrjq1ZqXKjWEItXZ11r48uAFYwxSQ5JPljLYxkdD61ot
+47WNFdrJyjdHB4NeIpqJS7ZbF0WNQRmYEr9RkcVTvba7eW1a7vDMiA7CsmQOc8elZU60k7TdipUr
+6x1Poi18Z2Uo/wBIjeDPILdMVp23iLRbwZt9WsZDu24W4UnPpjPWvnFPEuoRxGIvHdxxqUw5+YD+
+tQpvu5C1s8ELEfNAykEY/E1vHEpfEJUG9j6norwrTPGuuWlokTtJcqihNyS5PHHQitG0+Ilwr7D5
+6uOCGbn8ulbRrwezE6E1uj2TFIawPCesT6zpzTzq4IbALLit81pe+xnsRt1ooJ5opAKh4p+agQ8C
+pM0COC8feG9R1q6glt1mliQYKROFI/PFcHN4PnO7ztD1NWX7pDghvyJr3gse2KM+uK554fmlzXaN
+Y1bK1j5+Hh3V48pbeH7ojOT5mcH9aqt4F1+VwU0qSFeeA5IGfbmvovPsKaSwz8qkfWoWEV73G672
+sfO0Xw38RM4b7Oygf59Ksv8AD7W0dJGgkfbgbVSvoBZJGOBGB9c1Kpfd8yqB7Gr+rLuCrvseGJ4L
+1+F02RSlV6qTxXR6d4Qmu1VLmx8ojk5HBr1LikJ9MUfVYdSvrEzM0TR4tGtDFGWJY5bc2ea0zRk9
+6QmulRSVkYNtu7GHrRSE80UgI0bgU/NUbWUyWsTnqyKT+VWA9CYrE+aM1DvNLvNO4EtKKh30u+lc
+CcUuag307fTuBLmkzUe+gvTAeTTS1ML49aYXouA8tzRUBkGe9FSM/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0033/full/!100,100/0/default.jpg</Url><Caption>29376_0033</Caption><Caption>Sorex Carolinensis, Bach. Carolina Shrew. (v. 2, no. 15, plate 75)</Caption><Caption>Exhibit</Caption><Caption>plate 075</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="28" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0022;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3YZoU
+MByxb608CjFSA2kJNOxSEUWATJpQTRio55ktoWlkOFUZJo0QElLzWB4evLm/uZ5pnbHlp8hHCkkn
++X8q6HFKMlJXQPQbSYrIk1Hf4itrJHHKOxA9sVs4ppphsRkVB5TjGZnPPcDn9KtEU0imMrleaKmK
+0VIEwpaWiqENIpMU6jFADcVUvYJJIJUj2vvUgxucfke1XKZLAkwG4sMdCrFT+YpNXA43+3JNMtJh
+GFjuoGTfDKPlcDII3DIB9KWP4kaZd3UCW2VtyWMssoI4HZV6tk9+lXPHF9a+HPBOpTx2qMXjKLGo
+xvZuMn165NfNMuq30WxtiEJguiJhQOO/rmsknH3UUrPVntcnjGy03Xv7TuyIomyicgk5IySBzXf2
+3iXRLu2S4h1W0MbjIJmUfoTXytdk7EE5kk+QkFmyzHPr/npU1iLSSIoWxvYFRg7s1pDRDaufWEF3
+bXalra4imA6mNw2PyqWvmbQdZu9E8S2rabcGINIqSbz8jKSMhvavoCx8VaVqd0tvZTmdycEopwPx
+qtyWrGxiinYopAPHSua1jxfa6VO0LB3cHGFTPP1yK6RxmNh1yPXFeR+KNBvJr9nfZFCv3SZN2P0z
+UTnyK4WudFJ4+ZR8lrJu/usgA/PdU58dgAf6HKSRk/Jjn0615deW8VtJD9pPnZGGUn34OT9DVeS6
+hMEXkzfMvDeW2Bn8653iJWukVyHqI+JllbzOl7ayxjPy4HJ/OtC08d21/F5trp16yZwDtXn8mrwm
+S5mSMyCQumdoClj/APWqKLWry3cNBOI3xgbhn+lONaXYhx7Htfia60zxFaRW2qaTqoSKQSL5YXrj
+HPze9ZOp6loB0u5sovDkkTy27W4Z9i4XJORyec89Otecvr2uXkQSR5JEHpEcUJNegiRtMjkU9C8T
+L+u4Voq0Q5ZHLadYXuqakLOORjKgZiHyQfyroP8AhFb61kSSWSNNhBwqH+vNWYLmy0+/bUWsI5JI
+0WIxlsLkjOe/uK0n8aR3IKDT4VTHAMjHn8qp1EXZmJo2lXE2uTRhV3xKzor/AMXevTPhtPftfukj
+RpbjI8tVVTn+dcnHqMYaG/jgQSjKECQ8g++K6bwjr32O4tbNLRJd7Aec9wAeT6YoVRXHKOh6yRRS
+0VoQB+6ee1eP+MjdG5kKOzqpP3mJJ9q9e4Iwa4rxdoE1xtNlE2G+9tHSubEqXJeJcLX1PEL64dtU
+WMwykiHOF7nn/Go7gRPCJYCFWLGfm5PrxXU3vhSSe5f7Tu84DCqASVFRR+BboqQVWOLdv+Trn8Tj
+9K5Y142S6mjgzmbi5EkF0umRs0kzKxKHtjPT65qgjQrp5mngV7rorKT09SPXNeh23gu+kto/tc0S
+eiHBKj0JHBqvqPgOcRbY1TGM4jQLu9s8YpqvG9iXBnH2/iK/021wk7Tvxu3fMEJPTn8K1LDWX1je
+Zkw6Ae+OvY8DpWhZeCNSKF5rKP8AeY+Viz4x+NW7XwSG1F98qwqoyY0HU+5/OqqeytdaMIqXUzJI
+oARAxLDbuYFwMn6gVUg0uGaTCoxOf4c4/M13lvoVrFHt8pGPGcDOfxNRf2O4kdbSNwewAP8A+qsl
+Wi+ppY52PT5pFKRQGNAfk8zg/lW34c8OH+1bVpZ38xWDAR+ta1joGpeUXdQ0p4C5/nxXWeGvDUlr
+It3en96OVReADXTTUpPQmdkjrB0FFBorsMBgal3L0JFQKxp6sc0AI9paytveCNm9SozTJNMspRh7
+dCPTFTBqXdWbhB7od2Uv7E0/IP2deOlPbTbIMGdR7bm4/KrOaU8jBqVSp/yoOaXchW2s16BfzqL+
+xtLlZpfssLM/3nA5P41aVFToKeDV+zh2FdlMaJpynItU6Yx2pw0jT1YMLWMEcgireaQmmqcFskO7
+AKkYwAAKNwPQ0maaWNWIUtRUROTRSA//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0022/full/!100,100/0/default.jpg</Url><Caption>29376_0022</Caption><Caption>Cervus Alces, Linn. Moose Deer. (v. 2, no. 16, plate 76)</Caption><Caption>Exhibit</Caption><Caption>plate 076</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="29" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0047;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3RVx2
+H5U5eR90j6inAUGpGJikOadmkNAgBNKCabS4NFgHZopozSjrTsAtIRTqSgCNjtGTn8BUe8McDPry
+CKnIppFAysQc0U92VGwxxRSAtCmsQqlmIAAySe1P7VzmrXksKXKqcxujKwPbIobsBeste06/n8mC
+YtJuKgbTzj3xitIivKtA8eWWixy2TafM6pM6idNpBGeOpB7V0ll4+sru+jhVJgspwGdQAD+dZKtH
+qynB9DsKoXGprbXMsDoQ6QtOp7Mo6/jmmw6vC5yzKVPIIIOPY4rhfFU8uoeIILZb6aGOTMUUiAYy
+2PlYZGVJFU6iSJSuelQSpcQJNGco6hlPqD0qXFUtKN79gjXUIoY7hflIhJKkDoRnp9Ky9T8a6PpW
+pnT53le4UDcIoywXPqavmSV2JJt2RU1zxO2k6nNYtHKVkVMTFMJAWO3czenf6g11SMrorKwZSMgj
+oa8xt9XGv+Pobm0kuFs5BGkkDkASLtbBK/Uf416ciLGioihVUYAAwAKIu+pUlbQKCKcaMVTEY2pS
+MlyoVcjZ/U0VJqTFbhRj+D+popAa3avN/ElzeQX8vlLIVPZSD+lej/wmvFPE2t3UWtzxFmjw5G1E
+DGom7IaVyrLJFCsUn2bEwJfbgEAZ9Pfmr3iIymTT4bWWb97EJHSM4wSBgDH4n8awZ9Q3TtGZpdxV
+TnYueBz/AFqOHVhd30KzXDxcLh2GMbenP+etck46aGsZO+psjRteEBMf21MjqHI/WqF5HfwGC0mk
+ckSK6PKcsuGyQT+tSL4g1VoUjm1I7GGQZA3P4jrU9xd6ibhNstrK4UeW7y4YAgdP1rJQd1qDqLsd
+lB4rk8oYlOccBZBn8qxUubESX9xdxCS6vJ3MLEfMrAYH61zkyzzxEXSqcHdxMDgn3qvdQiOLCHGH
+GCZBwCM9j611t8yszKHuu51OjS7L+ymhgjW9ijJc9DtPIHoeCv5iuxXXtSXlwmfQ4x+gryeS5Nnd
++dDJIkmzZ+6fsD0/Sri+JtUMIEJnJ7lguaqF4xsipavU9QGuXrP8y4HfaOP5V0dnOLi2SQHORXkm
+n65qrzxlwp453xj+lenaBcS3On75QA2ccDFWpNuzJaJrxEaYFhzt/rRVmSJXbJoqhDyflNeYa5d2
+iXsouViLOx2gLyfwr00ciuN1jRngvWuorV5dxziOIN+YrCuna6Lha5ws9hZjNxsEasNoJHOO+B1q
+KPTLSaQE2+/0MpJ/QV0lydTg3SPbzBP7rRYA/DNZrahczuBCwjGOrNgfpXDKrbc15ShLp80QaKIW
+MUZIOPLJz7nJpt5p95eTbYrmJIgqgskeMnAzV0Weuyy7hewvGf4ViLj891adhoV+YcOXdv7xjIpQ
+quWxLikYEHh2BVYT3MsueuPlzV2Hw/bS+axiBLuGw+cDGf8AGultNJmjO2S1cMfTOKtyaWyHc0ZV
+QP7p5rZTkldhZHEr4fN5K6x2SoFLfO44HJqSDwfGpB82RmHUDArsI7SYjcrO6HtyMVWnEtsyqttO
+Wc4+QZI/IUOo3sUkU7DQ4BModX9OWP8ASvQNMs4bK12QxhAeTgViaZobu/nXMtwSf4CxAFdJHEsK
+BEzgepzXTRUrXZlNocRk0U09aK3IGK1ODe1VYnJRT6jNShjQBKQjDDKCPcVF9jtM5+zQ59dgpdxp
+c0ml1AVYoUHyxoPoKXzEHBXH4UmaXNFkIcJVOSFJ/CnjaQDjr61GDgU4GmApjjbqin8KAqjoAPwp
+M0Zo0GOJxTS1NJppY07gBbmioyTmilcD/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0047/full/!100,100/0/default.jpg</Url><Caption>29376_0047</Caption><Caption>Antilope Americana, Ord. Prong-horned Antelope. (v. 2, no 16, plate 77)</Caption><Caption>Exhibit</Caption><Caption>plate 077</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="30" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0042;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2RI81
+IsWR90j61Ii81Jg1Iyv5JzSmOp6aeaQEHl89acI6k20AHNAiPZTtlSbacFo0Ah8uk8oVYxSEUDKx
+gqq64/5ZSfkP8a0sUxxxQBnGHmirhWigCwo5p+KVBzTiM0NgREVWuLyC1uLeGZtrXDFIyehYDOPy
+z+VN1LU49NaFXilczEgMqZVcD+I9q4bxjJeS3kC3N4q2xZWSNMrtb3Oc+tY1KvKiowud7b3cF20g
+gkV/LbYxXoCO1YviHxdZeH5BC0M11cld3kwAEqPVieBXL6NfeIbO0ktLS30+KP8AgkZmcj37AnNO
+stO+yTTzX8pnuJwWllYZyaxliHbTcpU1fUuWnxAv9R/489AYD+9LPx+gouPFviKNv+PKyjHvuNYc
+F7/ZOoEL8luzYIk45PpVnUNatT5kSN5skh+RR1HFY+3qM2VKPY0h4y1+2j86fSbe4i7+TIVP4ZzW
+nonxA0fWbxbErcWl63AhnTGT7EZBrP0xJP7DSN0LSj5SpBH86x5NIMXi7S76NMOkjHaP4gF5renW
+lflYpU42uj1LFNYcU23mM1pDMy7DIisVPYkZxUuVPAIz6V1M5yseKKew5opiJwcAmuau/FcdncmC
+SaFX5IBRv6da6ORPMgdAxXcpGR1FeRaha6tp15Nlo54wx2+Z94D61lUk47FqNzvbfxPHIm6SWBlI
+yu04P5E1TufEs03ywwWhB4zK+7+VecXNteXMqzQRxI/TA3kD9cVXFpr8MhYXETZHII4/nXM60h+y
+Z11w9yJ/Pke2BB+VkQKF+mKoyTXgkxC0hidg8zSMCcA5OK5a/S+s9DmMk6i5lkBCs+3ag9OepP8A
+KsCNtWkCmOJx6FiwH6mpi+bVhytaI7SUS6xci4RFZFYlCW7g4zV5G1lJVD3cMO7oW2H9RXIfZtR/
+s2OXaFnhJDjJw6nv9QT+tUPtV+EVZbZyobIYyd63hy2sKUZt3O5j8W/2fc+S5aTkhpgP6d6dqXiu
++SYQSoijPyvGwJH9RXMmTT7BoZ9QZvOI3CIYYj0zz+lWotT8PynzJ3nkdjnk7QP0rN8rd7GqckrG
+3eeJLy3ntoYZmkR0zjdkseuT+f6V0fhHxPLqOrpbeXI27OWLDAAGelcvc2WkXMcLvhDJCBGTJhiv
+rXaeCtA0+1uDfQIRIF2q28kH14rSNSLaj1Ikup2bdaKVutFdBmPzwRmuS1W0Mkr8lutdWDXHeLdS
+k06VTHCSjdwueazraK5UGZv2KWRgrHA9qnewVEAVeneqFvq8k2GkUj8OSa0mvYwqxvExdhkj0Hua
+8+U0bGY2jW4ufMEcTysPvP8AMatDSF2qfJRVH3zwAB61D/amnrMd7KrL0AJyTVmSH+0IZBFdPEMc
+svP86zVRNgZmtQWNrpwZmZDneUTAeQdMZIOOo96k0XT9H1CykmtrJAmMBpWyx/E5IrmbzQI77UHN
+1rlw2ONuwZrd0vwTFJCI7TUbsJjsRj+VbRqRk7REvMFtvD7Sy25jgjuF678ZPbr3p3/CGWkuJCEK
+k5GDWpbfD7T7WYTXAlncc5kfAzXTRaYfJVYwqKowFHatrSK5kcDf+FptSmgjlMawwpsRE64z613P
+hTQYNFtGWNAGbvk1PHYGOTLkGtaFNkWOa1pp9TOctBx60UGitzIj3c0OI5Rh4wwHqM1CGNSAmjRg
+At7Xg+REMc/dFKYLds5hjOevyik60dqVo9g1K6aPpkblxZQ7mOSdgzUqWdjb/ctUUeycU7Joxu4P
+Ipezh2FdkJ0/Snl8w2MLP6mKr8SxRqBGioPQLiq4VQchRmng1ShFbILsnbYwwyg/UUYUDAAA9qi3
+UFuadkO45lQHO0Z+lI0g9DTC1RsxosFxxfmiqzMQaKAP/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0042/full/!100,100/0/default.jpg</Url><Caption>29376_0042</Caption><Caption>Cervus Macrotis, Say. Black-tailed Deer. (v. 2, no. 16, plate 78)</Caption><Caption>Exhibit</Caption><Caption>plate 078</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="31" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0032;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2vDBc
+gFj6U8KSASMe1PVakrLQogKkUmKlYZpNoFPQRHtpcGnmgU7IQgpTS4pQtHKh3G4pCtMuLqG2eJHY
+CSVtsad2PtU+OKLILkDJwcDJ9KgPmFgDCQPXcOKukUxlpWGUmU5oqwVGaKiyGWUp2KF6UMyr1IH1
+q0JiYoIqJru3T70qD8ai/tG3Y4Rt30oZJORSgVWbUIgPumkGoIeduB9aOYCxPPDawPNO4SNBlmPa
+ueXxNc6lIY9HsWlX/ntLwv5Vk3183ijW/saMV0y3b52X+M9zj9B26muytZLG1t1igZI416DpU3cn
+psPRFHT9GlW+GpalP9ovApWPHCxA9QB/WtC9vbbT7V7m6lWKJOrGlXULJ32LdQlvQOM1znilkuNY
+0C2d18iS5ZnGRyQBgfqat+6tBrVmpY6/ZahOIYhNG7DKiWMpuHtmtMjiuY8Z4SPRpbdgJ01CMIVP
+Yg5H0xXUYyKAIsUU/FFQMeW2RlsZwM1xWoarNc3DeTdw7ckeWQQ4P0JrtHZVhZm+6Bk4ryHWbjSb
+zUJHivim1/4lIKn2pSlZbglct6jeahbbZD5hU9SVzj6gdBWXL4p1GEhY2QN2Cjr+dWY7zzYRDc6p
+mMHJbbliPSqtxd6VboxifOMksYjxXP7dlOJDdeK9UghLz6nHFjtwTWHfeP8AUJIRHb3s+6Q7SzKF
+AHfmsyR/7T1FrmfJiztiU9l/xqQW1vdwyQx7A2SAQCQPqfX6UvatMORdTsNJgvdPs1MNzMHf5mZT
+hW/PtVk3+pXLGGSSZlzzk9fyrL0q81PSdNjt1dLhl4VZF6D69cVXu/FWsAPHE1u0hyCIojhPfJqo
+Vr6ITgT6jrllZSGMLJNcxnlYxyh+vY1l3fim61GewiSS9WeO5RovPO4DPHWnaTbQ2cuLhCWbli/f
+PerGoQWczmSOGVWjwV2dCfbvVqu726GnIjprqXWrmW1ecxSi3mEo4I5Axz+ddx4b1S7vnZLiBEKj
+qjZFeH3Wpa7dNsubyfHTap2D9K9I+Fdq0X2iWZpzIwwN5yMVspXM2j0kiilPWikIhuMfY5QckbTw
+K8i1GwMcrC3hSNQT0Gc/j3r1q5i+0WksO4rvUrlTgivMptGuLOeSFpJZYyTjcSxrnxK0NKeuhycx
+ugSqDnPJFRfY76+eSN0zbIM88bz7nsBXZQaTIkRK2xT6LTWtJCmWil8tT0fP8q4ZVOVbGnJqcVcW
+UMUAt4C7SSgruIK8YwSPatzSvDTC2RYiE4wDmkuoIzcA/YZnbswzkVds1mEiJDdtCzc7W61m6mmr
+Hya3L6aS0ChEjklcDlmIwartYJ5XlHTFGDk7SQCfwrSt0vIm3PdGRR3q4l/CG2tIuT6NWkY+YW7H
+L3GmXN5KGWAjyxgYGP8AGobjQNTJXZvHHau8ik3DKDj3FBa4LYSJW59DW0YruHqee2+l3TShJYy2
+3rk16p4StkttOwgI56GqMcDySgSQxg9jiulsoVggAAxXVRi07syqNWJyeaKaetFbmZEjZFGyJvvR
+g/hVa3lLxI3qoNWA9MRIIoSP9WuPpUUlhaS/fhU08PS7uKlqPVBqRf2fZIMi3T8BVVtK0oyb2txv
+9ec1e3Uu6p5Kb6DuyqLDS9pUQLz6Z5pkOhaTHMHS0+f1bcRV8NgUoeq5IdguwWytlGBCgH0pwt4R
+0jX8qTzKDJTSQXYrRxdDGv5UmQBgDApC9RtIaYCluaKgLnNFK4H/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0032/full/!100,100/0/default.jpg</Url><Caption>29376_0032</Caption><Caption>Spermophilus Annulatus, Aud. &amp; Bach. Annulated Marmot-Squirrel. (v. 2, no. 16, plate 79)</Caption><Caption>Exhibit</Caption><Caption>plate 079</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="32" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0045;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tE4x
+T9lOVak28VFhkGygpUyqTnIx+NBWjQCHbTgtPC0oFPQQ0LS7KdTgKLDItlIYxU2KawbPG3HvQBAY
+hUbRVa2nHOM0xhQBnvF81FWWXmikBaUVIBTIs+WueuBmpRTAYeKYc1KwphFIRHThzUF3dQWNs9xd
+SrFCnV2PAqnpGv6brbTLYXIkeAgSIVKsv4GjmWwGrThxTRS596YDuKCKjMqguCfujJp6urEgHpQM
+QimMOKmIpjDigCqy80VKRzRSAmA4pwFNXpT6AEaq13cxWdrLczuFiiUsxPoK4bXvEeoWWr3MT58p
+ThNny8VyviHxIbjRpbaN5lZ8Bgckbe461zSxCvZItU2zqdZ1NfEFqoGUi3B4yp5BHeuXsmfw94ug
+vo7xIBM4ScynEciHqCR0I6j6Vz+k66YI3tppVeMD5WXtUOtX0WoAH7SWSPBKY6+nNckZzU9TocI8
+uh7ff+K7C0sorq2DXqSMVHkEHGOvU1Uj8YaZecRO4kYcxsu1h/n2rxXwvrq6fNJ5sjNaqSGhB6jH
+DfUdK6ZxdX5hv7JdsbP8u4A+WPXg11SqyvYwVNHdL4h/0obn3Iyn5vXB6H3rX8P6l9sV2diMHGT3
+ryUarfiaZJtPUzIxztyoPvz2rR0jxY1vG0MlrKpzkGMjiohOpzXkPkZ7UORmmtVDQrn7XpEM2X+b
++91q+1dqdzNkRHNFKetFIBUOak7VAhqTdTEcnrukrLdF1QMSc4PasOXw/HdAxPGrMT90LXo5Ck8q
+D9aFjjU5EaA+wrlnh7u9zVVbKx4/f/DZ5W326mJ/VTisS5+GWqBPmmyD97Jr33j0FMYc5CKRSWHa
+6h7XyPCbL4am33CcyvnqFOAfauqsfDF7DAsVsrQxjsTXpY+Y/wCqX8alQeqqPpQ8M5byBVbbI8vu
+fCWrXLMjOxQ/xEk5otfAM0ZCuGZT3r1PikOfatI0EgdVlbTrUWdhFbj+AYqdulLk01jxW6RmyInm
+ikPWimIYjVJuqkkhqYOanmHYsbqN1QbzS7jihSQrE26lDCq+404MafMBYzTg1V9xpQxouBPuo3VD
+uNJuNO4EpamsajLGmsxxRcdgLc0VCWOaKnmCx//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0045/full/!100,100/0/default.jpg</Url><Caption>29376_0045</Caption><Caption>Arvicola Pinetorum, Leconte. Leconte's Pine Mouse. (v. 2, no. 16, plate 80)</Caption><Caption>Exhibit</Caption><Caption>plate 080</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="33" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0036;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3AJxS
+qhx82M+1SAUuKxsVcj20barar9uGnyvpxT7Ug3Isgyr4/hP16ZrndP8AHunzIseoGOxu3GEjkk4Z
+s42+oOe1Zy5U7MaTaujq9tKFrnPCmpXV/wDbEvcpdRTMkkeDtHQqVPcEHNdNinFJ6iegm3ik2VIK
+K0URXItlBSpaMU7DuVXiYj5cA+4qIROD8xUj2FXSKYy1Lih3KZj5oqwVopWC5YFFLRViOAvfE3iK
+91V7OzsHsLcMwE8sW5iBxnngfrXPar4ea9nleZ0Pmxne7RDe0n97d2+gGK9deCJySyKSRjOOcVna
+hDFEqmby2t3O1w6g44Jzn8K5qtOTd7mkJpaWOV8Ma5Hb6lpulTTK9zcpIXPdioGCfXgH8q72vmnx
+pezad4tXVNLZ4FicG3J/hx/TPaugtfib4u1BIcT2qbyFAtbcFmP/AAMn9BRSmlHVhOm29D3elryu
+z8W+KASHvrGQIm9/OtwNvtlH6+2Kkt/ijfK6pPaWErd1SZomH4OP61qqsGT7KR6hiiuRsPiPoVz8
+l08llICAfOXKZPT51yPzxXUW15bXkImtp45oz0aNgw/StU09iXFrclIppHFRx3CySMo4K8EVIrB1
+3DoaGBXkba2MdqKJjhx9KKkZLdS+RayS44Rc1xEfiJpZZM3jKp5XJA4rtL9S+n3ChQxMZ4Pfivn+
+81u4huJo4IP4yOFxz0yKyq1JQ2BR5j0o69PEPlv2IJwCzCqV3rkt3EbSe4iO/hf3nJP0ry6bVtXK
+bQz4PPJ6UWV7qcN/FNcJ8oVsHBJztPPNYSqyeg407NGv44C3FgFigBmAC8jlTms/Qop7WOOa4s08
+2dxGwf5VQfL83HTr+tdhPpl9qrxyyvbKWUOGSMfMD3wTV5tCWazeKazRiB8pjDDJ4zx07D8qxgtO
+U6ZS1IbSOG2S8KQW7IA++JZScYB4IOMjjOazl0yx16yXUbkSEbTHGm07sLz6845Ge9dDo2m2zaW8
+eoxSR3YJjYsudwPQ/lWJrJ8nQJrWymMkqSbTGpycAk8gfWrSaQk7sxF02GC7kW2niNvKod2jJAj7
+YOTnr9epqrJqN54duo7jT5ZLSdsK0G7O4dOexHGcEA81YS9v721IuH8meMHy0jhXcxxjnjpTLnSt
+T1OHfNZNvAGGIAA4wegrWLtqW1fQ7DSPFx1CzWSSSRLhBiRSSfoR+ddr4b1yO+UWrODKqjAznp/n
+9a8j0bQ5bbUYG1O++zgY2qqD95zwOR3rb+H2qyXvxCu1IRI8PtQfwj0FdCnc5pw5WeuygFhn0oqR
+gCaKogbcKHtpFIyCpGK8fuNLihunD2xVS5xx717F1GK5bVtKkknyIXk3HjHT8a5sTByWhdNq+pxf
+kw/MixoB/ESKim0+W4YbIt8XsuB+FdYuktAqrNvVc9McVM9pcNIBaOSo7svFeZLDu9ze8TifsMyM
+FlvLwLjaqoxAX8adPY3CIDFql6d3rL0/Ou/htdhAuIgZCOu3NNlsICpXyeW74qXSqbqTDmR54mn3
+zkTQ30sjqeVmYhWwOBwB371Imma0biaaG7t7NZMErHHuIx7nrW1rEVrp0Pz33kg93IH9KyTr2kRR
+YOqI7YySAxJoXt0ik/Mzb99YgCrNc2tyQ2Q0sHI9uDirkVn4smiAS2hZGX+HcoI/Osa91yzunO1Z
+ZRnjApi6tIP3Vo11Cem1Nw/lXVSk/tik2tjcuNLm0G0fUtZeOW7C7ba2Vy2w+vNWPhRaE67cXZj+
+Yg72x3NYsej6hqLB0tbueRv4pAf616j4K8OSaJZs9xGqTSc4HUV1wlzNKK0MZtvVnUt1opGPNFdJ
+kNVqcH9jVdWNSBqAJvlYfMAfrSgIONq/lUW40u41LESYX0H5U1mUdYyfwpNxpQaQGfc6PpN+zPc6
+VBOzdWkiUk/iaSHw1oUceE0ayQenkL/hWlnHSlzT5Y9guypFo2lwDbDp1qg9FhUf0qaOxs4v9Xaw
+p/uxgVJk0ZNUkuwxeF6KB9KQt7UhamEmmAFuaKhdiGopAf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0036/full/!100,100/0/default.jpg</Url><Caption>29376_0036</Caption><Caption>Cervus Virginianus, Pennant. Common American Deer (fawn). (v. 2, no. 18, plate 81)</Caption><Caption>Exhibit</Caption><Caption>plate 081</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="34" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0049;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21QFX
+J6VLtoUYFPAqAGbaNtS4o20tAIdtLinlaMU0kIbijbT8UuKdkBHtpCtS4pCKLIZCVqu0kYz83T2q
+4RTCKWgFPG7BHQjIoqcrzRU2Aq6u8iwwohIDvtYDqatQSJaxJE7tnA+9zVLX50tbOKdwpVJBndXL
+P4oM7usUbF07sepPasqk1DUaO2kv0jnKtkIE3bsd6sGeNYvNkdUTGcscYrz7/hMntVaWeCNli+Y5
+4249/wA64rxpr+seMNDuLu0Vo9PQqqxocEjrz6njOOgFQqy3Go32O91n4veFtKuGt45Zr6ZTgi1Q
+FQf94kD8s1z0/wAdbVWAg0KdgTj95MoP6A14/YxKkLeYhbPB2HBHvmtzT9NtkhkNxIsUiKChbLCT
+Of8APFKVZor2Z6fa/G6weF3uNGukZQPlSRW/nitPSvjD4a1GdYbj7TYOxwDcKNv5qTj8cV5Pe2BW
+MSnaokjGVxg8Viy24L4C7gG+b0IqoV2xunY+rba7t7yBZ7aaOWJuQ6NkGiaUxxb1AYfWvnHRPEd1
+4N1QKk7CxufknTsv+0B6iu7vNTvjDG0E8ioQHTDfe9M1p7W6uZyjyuzPS4boyQvKwbaBnGOaljlW
+aPeh4ryePXdWtnQx3LtFIcvHt4Pfit3w54quLm6eO+8sQoo2sp28+h5pxkK53RHNFO4YAjoRmirA
+yPFto114enCfeTDDmvK7W8VLzZgiQsDI5HRfqa9ovrc3dhLAG2lxjNedT+GoknfcxZuQc5HesK8E
+wR594p1BTJPZRTgu6FiXbHHp+P8AStXwuzN4Ms0QqXF0S0f8TDkZP4Go9W8BXd94sWcKn9nyKrO+
+cbdoAx+NdNZaXHZyyCMxxhT94nnHTj8Qa56rUYcq1uaQvc5zWfBtuJTKVRVY8qF6EnqD2+hpPDOn
+2z6NPFqNwEQXDCEHJbaMdPxzW3qAZr1LWKVneYgZLDA4z/LJ+oqzZ6T5K4RRgDaMc4Fc0Oa1pM1q
+TWjijnvE2mLJbILYSSkj5W2kEj05rntLsQ0skVwgjijXczMOM/XpXcMkl1qrQI/7iFMYPTd2/QH8
+6oWFkyavcaZID5cmZI0cZH+0v8j+da07/CU2kub7zm9fgtNVgzbsmZCNpxgAZ5P0/nV/Rby7NvDp
+bxkT26Z83O4sucAj14rXvvCd2B5djKIoGOXiK5J9MH09qz7PQNT0rX7MzTgbnKGTYcOp/wDr10U3
+y+6yJ2mroty28yRjdLj5dpXBJP68VUtbaTdF8sZYyKcsQAQD0NdbcabOcgbWPqUp2iaO76jCs8Sl
+FOfu4z+FdCt0OayPSIf9RHwB8g4HTpRUm0KAAMADAoqyhSf3Zx6VyWor5s23aCCcHJ611YORg1lX
++ji45Q4PrWdaLcdBxavqc01jbkgOjx46/NwTWdc28sV5IkaRMjgBXkz8oHoB1710Y0q7j+Vi7AHg
+5qKazlTKtCJPdkz/AFrzJqSeqN1boc1d2EdrLBduwk/hkKjZxg9PzP5VBZA3V6TYWzeWnLyyHAHf
+8a6CXTHmieNoiY2Ugjpz7VFb2EtlCtusQCHIILZJrNX7Ddmcm0eoQXVxFaTtAHlLvIY8g8DpzWjN
+HLDpQv2eSaa3lR2kcDOARnp7ZFaR0u5hvSVgxETxt5xU8sM00L20cO6NgQx25rVSegLe4+8kWKIT
+NPCEOCrM23IrF1G5kFkVcptkbKMWI59Rnk/hVi10V7e+Es8aSmMExoEHHuM07UNITU50kuYp2lVc
+IQWBUZ9jitYvoxWtqhjeIxH5CXKr5kx2pg4LkdcAgV03h64jubpSjMCD911INcZP4ONzd27mW9le
+A5hDSY8vOMkcZPQV6VoVg9nbASD5gMZPU1009ZKxlJKxqnrRTSeaK6DMjVqkD47GqiPxUgemmBaD
+ZoIVuoB/CoBJSiQ1LAlKp/dH5VGRH3i/Sk30bzQrACiA9IM/8BFSRxQgfLCE/AVH5lODmqtEBzW8
+DMGaFCw6HFBghP8AyzT8qTzKTzKegAIYkbcsS59QKcW9sUwvTS5o0AC3NFQs/NFTdAf/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0049/full/!100,100/0/default.jpg</Url><Caption>29376_0049</Caption><Caption>Canis Lupus (Var. Rufus), Linn. Red Texan Wolf. (v. 2, no. 17, plate 82)</Caption><Caption>Exhibit</Caption><Caption>plate 082</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="35" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0043;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD29E+X
+pT1UkcjBpyDin4qBEe2jGKkxSEUWQEeKMU/FLtosgGAUuKdtpcU7IQwrTdlS4oxTsO5Ay4GcE+wq
+HJLAeU4z3OOP1q5imMtKwFNkOaKmK80VNhllBxT6aOFOKz5Lu4WQ4HTtgVaRLdjSxQRWadQuB/yw
+J+lQvqVxuwqlfqpNJi5jXoxWUuqShcFAzeuCKkXUzj7gzSTFzI0sVm3Gv6XaXwsp7yOOc4+Unpns
+T2qP+2WQ4kgGPVWFedeJdPl/tGWTS7oSpJlng/ijJ9B+NTUm4K6KhaTseri4gO3E0eWGVG4cj2qS
+vCvsMUZk+0xuZiC7swyxz3P61TtPF2reHZY7ixupJLJW+a3lJKEZ5AB6fhUwrqTtY0dOyPoA00is
++x12x1CzhuYpU2yoHALDIBGavRzJL90g/Q1u0Z3GEc0U4jmioKFlJFu5XOdpxjrXLvqF0lxhpAyp
+nI/vV1EjiOB3boASa5Ke5jeVmCAL2JOc/hQ3ZEsWfUTIBtldRkNtIIrO+0zrMJYp3aXk5IPQ9qzN
+cvZo4GaMScHIyoAGK5K68YX7Wa2VqREzjmQclR7elYyqIFBs7i68Sy29wsEcvmSZ/ebpNoT/AOvT
+J/FgghhuZLo/vFISJXJLHOM47/WuEh042+nSztBv83jezc5Pf3rYtNPis7F766IVlXO9uoHbrWCq
+NtlyglZHUWXiYmykuLlZHJfCpJlePUA1m3uv+H7hh9rWRcNuA27wD+Fctp/i2xa/ex1VQ1nK2IZZ
+ODGT/Q1b8T+Cpkha70q4faOShO7j2zmqV29RpWRLeN4cnczNqFy8jcg7mTH8qy7670Z4hbmYPBG+
+8fekZj+PauLnN9aA7zubPO4DFS2/n3s7IjAEY6fStVFdx3Oo0PxJeQ6mkUE0zwZwkbjccfTsK9s8
+OC7ZRJcBdrDsuMV4B4cWXT9WjklHyBuT1xX0folxHc6ekkZUr6rWsW72IkluXiOaKG60UwI7mJJ7
+SWKT7jKQecV59qusQaMreTA7bR1PevQmG+IqehFcb4j05JrSWIQjOMHis6iugW55hqnia81hmjjU
+QxofmzyT+FYtqs1tdTySxYlC71DjgjHFdZoPg2/F75lzGPIAPLdSc9vauql8PwyIk0kcr+WeIcYB
+I6ZHp3rllZKyNeaxz+m+d9gj1LWiQsfMUIwMD6eprldb1qbULqR5SfKT7kK9AP8AGu61Dwxf6o6y
+XO5EH3YkPA/xquPAwaJg8Z3HpgcgVClZk2OG0rw/Hq9hNdTqu9RnB7V6J4AvDfeHzb3T7/Ldo0bq
+cDpn3/8ArVUh8EzxufLDxq6FWCkgEe/bNO0bwff6Dd/aLCR/JLZkgbIDe/19615k0FjG8Z6CYblb
+yCPdEeJlUcj3rEstJFs32lDvhOCSBytezTxxTQq8ibWxkqwrlotCWLWrgW6E20yhioHyg+1XGWlg
+Zi3WnQPcebDhk2hiysOOOprrPhtezTXl5BFuezRRl8ELvz2z149K5mLwp5OvFfsdxJBMrEGMkMnq
+p9q9Y0Swh06yWCCLy4wBwRg5q6VxSNE9aKax5orYkYjU4qjfeUGqaXA9DUonz2NK6AmEMX9wCg20
+B6xLUfnjHQ0ef7Gk1ECQww7ceWOOwpuyLB/ctx9KZ5/1pRNS5Y9gHbYiOIXPsMf405IYmHMRX/ep
+vne1L5uarlj2DUcbWA9UB+tKttAo+WNR9BTRJml8zmnaIairFFGSUiAJ9BTi3FRl6aXqgBn+aioW
+bJoqQP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0043/full/!100,100/0/default.jpg</Url><Caption>29376_0043</Caption><Caption>Lagomys Princeps, Richardson. Little-chief Hare. (v. 2, no. 17, plate 83)</Caption><Caption>Exhibit</Caption><Caption>plate 083</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="36" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0048;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xFwv
+TNSKuVyRg+lOjWnkcVnYoiwAaXaKdik6UrIVyI8UopSM0YqkkK44AUMMU0LT8Zp2C4zFLtFPxQRR
+YZAyPu+ULj3NNEb4O8L7YqcijGRSaHcpPH81FWGXmio0GWE5UEdKU1FZk/YoSevlrn8qbLeQwqzS
+OqqoySxwBVIlkxoxVG11iyvVY21zDLtODtcHFcb4u+ILWUsmm6Oqvdr8sk55SM+g9T+lTOSirsEm
+3ZHa3+oWWmW5nvbmOCPOMucZPoPWo9N1aw1eNpLC5SZVOGA4K/UHmvG7KC41i7W61S5lvJBwu984
+PsO1egeHtD0/S7lbu3uXEh4dTJkY9Kzp1ed6IJR5dzpdVu5rGxaaCDzpOgXOB0rgbT4h6raaif7V
+0/dZE4LwxsrJ+fWu8vNZtrS2lkPz7FztU5J9q4HxLryzWFwktqqSYypQZB5HB9Dg1dSbgrhBKR6R
+YXttqVjFeWkgkhlXcrCpyK8l+HPiE2GoSaZO+La5XzYQx+6/cD6j+VeoDUYG6NWlOXPG45Lldizi
+jHFVvt0ROKsxusgypqmhIjYc0U5hzRWRYxCF09WbjEYJ/KvM9W1aC9E1vtuPvg5UdcHPfivTJ/8A
+jykB/u9K8u1UPbyuxs3kAJxsbANZ1anLoCVzI1HW5LG9S5hgMbeQ4wT19Dx74qr4Ws4bpzJcyBjn
+cdx5JNRazFc6nboY7UQyR5Aw+7ep6ik0CA2qyC6Ji8wbArDBJ9vU1yTlzJamkdDXu0s7W4WaIeW+
+S0cqZGOSO3WrkGtxMmxYGfndne3XrVF31aUeTDZrHCBhfMQk4qzb2eqKqfu4Oe6qeK53VcXZENNs
+nkvXmyY7NgWHJ+Yn9aLeyEyM92smzlmWToTjiqrHUFuTEbmQAckLHmn6lqLwadEJJzJmTG7btx6Z
+rRVnNWHCNmc1qzva3cbg7ZEcN8vbnpXWSLaXErMXmRdoKmOTB9888Vw97MtxdKo5LMCST26mt5bw
+Xl2l1NHtgXiOMAE49T711U5tRKnFXOggQt5f2OaVSOS8zFh1/wA813eg3EM6t5Rk91YHiuDt7y3k
+AALIPXH+Fd74d8trYtHLvH1zWtObbtciSNVutFK3WitCSOYotq5c4UDkmvLvE2qW1pG0kx3AMSih
+sEjPOPWvU8BkKnuMV4z44+G2r3d5Jd6cxlDMSUJ459PSsasOa1yomefFem3TpFAjA/w9vzroraW3
+uYcS2qysBwQORXB6f4C8RLIplsSqhuuev9a9Q0vQtSRS0sGwYHQDJrlnBJ+6aq1izAWFopLMpUAK
+rZYn/GsltRsopmjvZCZWbaEY9/p+NaGs2OtyQmK0tnGFwNhxn8a4qfwd4umDGGxEWTks8g61m6Ll
+5CbR04liDmRZY41z+FU7+wv7uxbe3mQnkBVXn65HH4VW0vw/4h0mMy3lgs4UZIUkn8K6u2W2u7YJ
+tmQ5+aMg/kaz5Z02I4PSfDMd27NcQpGyt1+Y8duCcV19j4b05V83/XsOrMM8/TtSS6ZfDUV+xW7g
+c5YrxitJdO1W3jWQh5VJ+ZU4IroXPJbAPt9Pt24WJB6ZTp+VdLpkJhhIMap/u96p2VvKwGUdR71s
+IpRMHrXTQg1qyJMRutFNY80VuSRI9Sh/aqUbkgVMGNVdCLIIPYU4EVW3ml3mpdgLBbjgZpvm4PKE
+VFvNG80tAJhLn+A0qEHPybfy5qEORTt5qlYCfIpN1QbzRvNUImLe1MLVGXNMLnFAwZvmoqFmOaKV
+xn//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0048/full/!100,100/0/default.jpg</Url><Caption>29376_0048</Caption><Caption>Spermophilus Franklinii, Sabine. Franklin's Marmot-Squirrel. (v. 2, no. 17, plate 84)</Caption><Caption>Exhibit</Caption><Caption>plate 084</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="37" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0015;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD22NOK
+kCgjjBp0a8VIFA6CoGQlKNlT4ppFAEO2nBKftp2KLIRHt4xijYKkxTgKYEPlimmOrBFIRQMrMgAy
+cAe9REITgMCfrVwgHqM0xkHUAUhlFo/moqwy80UrICxGOKkxTU6U+mIMUmKdQSMgdzSuA3GKTFOr
+O1bWrPRola5f945wkS8s30H9aOZJXYWuaAFOxUNndR3trHcRbgjjIDDBH1qene4hMUmKdTA6sSAw
+JHbNMYmKaRUmKQigCsw5opzDmipuMlTpStKifeYD61HlhCxXG7HGa4rUNb1BJjG1tlwT8y5AFTUq
+KCuwSudx9oi/56L+dMeeFhxKgYcjmuLtrrUZ8NKqCPGcDOfzqhrGryafCzj5AflRU5Z2PYZrknjY
+rZFqkzt5ddsoVbfISV67QTXnd7qtrqXjS5muVfyE8qNFbg7MAnH1JNVEvLq6cLfWl+m4ZXDBg35G
+ormzjyJYVZSRnk4PFc9TFOWjiUoOLuelJ4j02KyVYJlLKAoRnywqnF4tSNt11hIVyWc8DFcVaeF1
+vR9pkuApP3mJyQatanFY2lmqiIXUyD/WSMcnHQcV1RryfQlQu9Tq7X4gaJeXiWqNNHJJ/q/NjKB/
+oTWhHqitDGFgclDjcMc4OK8b1O5lvI1e6WCNkOU8tQojH4d61fDniC/kuHto5ri4TCiPOWA65Ocf
+StVVlbUp010PUJtWuB/qrcf8COTRY6hcTzhJigB42hSDXJX02qiNZRGwdOd4OMVseF9QuLyYrcoQ
+R0yo/mDTjUbdiHE6dhzRSt1orQQ0coRmueu7RBMRtyCe/NdCnSqV3bkHeiFj2AGaxxEFOOvQqDsz
+JkiPk7FwBWDNp8kjnz1Uc5X5AQPoa6eG0nuWLS70A/hGRmnnT3MpJU7ccHNcns1L3rGnNY4q4067
+kiZDezbGHIDk8e2c4qjYW1rbu9rb/u/KxvY85Ndpe6ZLLEywfKfde9c6ng26uGlaS4njyeiEAN79
+KajbQLmXqGo2sR8sSMz5xtTliapS2c77POBt42bH7xhn8s119n4OtrRVL2zySjOX5Jb61MPCSXJ3
+3dsAsZyijkn8e1VylKSRx9lplvc3H7q3kkgjJBkdQoc+o9q7C3+y2FrllVffHT6ULpuoXDmG3j8i
+MAY3A5FPfwnOiFmaS4nPO5m4/KlGXNHmivwG2urM671uF22puYKOSFya2fC7Wr3BljbEjdcgjNVb
+bwldxStJtiUv15zXS6Zpps0zIEL+qirowk582vzIm420L7Hmimt1ortMRkbcVJuqkjmpRIaLiLIY
+GnZFVfMNL5hpNoCzx6UzeB/Aai3mjeaSsIlEoJwEP5VIr5JBUj61XDkU4OavQCxkUZqAOaN5ouMl
+LU0tUZc00uaLhYRm+aiomY5opXCx/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0015/full/!100,100/0/default.jpg</Url><Caption>29376_0015</Caption><Caption>Meriones Americanus, Barton. Jumping mouse. (v. 2, no. 17, plate 85)</Caption><Caption>Exhibit</Caption><Caption>plate 085</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="38" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0031;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD21Fwt
+KqkjJXB9KlVeKUis7DIStJj2qUijFIVyHHtRipdvNBwOpApITZHjFV5L21iOHnRT7motWnaK2OwZ
+yOtefXksklxKZ5EUAjYrdTj2rKpV5HZIa1PQk1OwkJCXULHPIDCrWxWGcAivIdOaCTWWlkbbhd2w
+fxHPeuqfxJNDCuz5Yl4DF8DAqViFs0Ukzs/LT+6PyqBowetsf/Hf8awdG8XQ3kskU5GRjaw/iPoP
+WupBDAY6V0LlkroVyk1rHn7i/lRVwrzRS5UO5YBwMmoftMZmSMZJcEggcf55qRzthY5AwOprm7rx
+XpljO0bS7yp4VO/45qtkJnTYoxWFY+LdNvzGAzxmQ4AYd/wrSvdUsrCxlvLm4RIIhlmzn8PrSuiS
+S8n+y27S7GfHYV5R4m8d2ouxAbqV5ASGitwCVPpkkDNZ3iT4gan4o82x06M2Vl1V/MVZJOO5YjAP
+oOa5W10tIIlk+Rivys+8NknocA55yTjnge9c1R8z30LUe53Nh8TrfTIjbX2l30sO0EMXViM9Dg/U
+d6qyeItN8QSb7ORluWyUh24dR2znr+Fc9PaqJkTzUEYzyUy6qenOT09cduKg1/TbFX2W7xpIAed3
+zcKOOOCRzwP0pW5kkPlR2KW8GmWqTzMJbtz8zDgAE9DzWfqthdzMslxcIkTKCEHGB6Y/KuO0nW5o
+LmGW8jW6UcI7dc9Qc9629S1stHiJirvySw9ulEabjLTUTLukvHYamjtI8kaH5SQMD9a7vS/Ft1c6
+vb2zIRBK3GQNwHvXmVrds9sn7tXYDOc5P+FdR4Kmmm8U2ysgEZXOSMDOD0rpje5J6/iin4xRQWVd
+Xm+zaNdzc/JEx4+leM2SxX8csxBjlWQdTnIIr17xJJLH4bvGhTe+zAFeA2Ut/aXQ3MrQbuUSQAkf
+Wpm7IXK2dik0Gm232p5H2Id20JyfauW1jVm1Z0e5nfyZn3xxZ+VV4AAJ46lScjofpS6rqTm1ihj2
+xCSZEZS53sDnkYBGB7muf1K2VIbWZmkCQ2gjA34IkzyT146cVgnfcrlsXdMeI+ZLcv8AIck7MKdo
+J4GTj8KqreXct3LNZS7bJ3CqJ5QM4HPVsZ/GqNx5WlxOst8JY1zHGIiw83198c1VGrLLMEEHmJ92
+ML8uPpQluxNnU2jzRE3gMKi2UK5hCkKvOThTz16nrzSahK97aG4eG1d4sBcGNWAPIKrlivPoQaqw
+20jWxzBLa5XO93GB75qHTJLl78wxXBYhdoML7Rj6AYpp3eg1e2pqabY2Wp6e9koWC+kIkSR0yST9
+4LyADVSQ6g1zbWdxps8c0gbZEynLAZByD0zg0jQeXrDRRANHENrbD1bj6dPYVea6uyjCWe4bK4Cl
+yNv1NbJolvWzKOn3xgxFLbtC0seR5qcgZx+fFd34FuIzrUCu2QDhdwzg+3pXJx2szWEomuLYJIow
+suWYEHggjp3/ADrpfhyI/wC3o8sMqeW6hvQCneNxHtRHNFKetFUUc/4089vCF+trII5WUAM3TqK+
+fH0HVbiYsbyPJ/u5NfTVzClzZyQyAFWXBBrze+0SK2uZPLHy57DgVMnZCdzzrT9C1K0uopWvMgNy
+pHDD0IzV7U7G5nuoraGP5FXLSEngg/L9c4/WtuWymeXIZiueMf4VVc3TkLHHKRnrnAP6VzTs3cFO
+SOJ1HStYaWNGtonSDIjA688nOaqrfzW7NDLpzLJHjLIvI49uK7O6OqRuD5BC+rpu/pWZM1/IGkh8
+vLcMUg5OPfFVGzIc2ZT+J7LYg+xpI+Pm84Hg+3/6q2NP8TaZLAMO9vKvTa3Bz19/T8qwr20uJIXW
+ePJYYDGMcVkDRJMbhHKGA+8vQfhWipxsNVD0bR9P0C7JmYrLcSNveUkE8noAenFdStv4XP8ArkdC
+OivkZ/WvGo9F1FYTJbyB+5CHDAfSkt9SvYZNjTyErxhm/pTcPM0TPa49E8LXDCQROy5/ikIH6Gut
+8NaZomnzEadYxwuedwGT+ZrxjQvEWouotpWiKZyPlB5/pXsHhQXW4M+CnfFRGVpco2tLnXHrRTSe
+aK2JI0ORiq11ptvdj5xhvWkSbipFk+v50aNBYx38LxbgU2HHqKil8MFzyqEfU10HnfWlE3tWbhFi
+OYbwl8u1VH/fRqhJ4Ic52RjHpvIrtvOprfOc7mH0NSqcRNHB/wDCCXDOP3MeB/ebP9KJvAuoYzbw
+WIbv5mSP0rvFXA+Z3P41N5mBjmtFCIcp4zqfwt8SX7sTParG3OyNyB/KoNM+DOqQXBkn+xMAPlWV
+iwz+Ar20SUpeq5EVdnlWnfC3WYJZTLqVjawyMCYrWNjx9TjFem6dZJp1lHbqdxUYLHqamLZ9aYWw
+c801CKd0Dk2OZuaKgZjminYVz//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0031/full/!100,100/0/default.jpg</Url><Caption>29376_0031</Caption><Caption>Felis Pardalis, Linn. Ocelot, or Leopard Cat (v. 2, no. 18, plate 86)</Caption><Caption>Exhibit</Caption><Caption>plate 086</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="39" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0028;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD25Vwu
+cE/SnqoIBxjPY09BxXBeJNW1LT9XkNrdMgPATqOPbFYNpIvc7vbRtrgbH4hi3DrqkEhYD5XiAw3s
+cnitzw74vtdfvJ4UKJsxsUt8x/xqbxYndHRbaNtSYoxVKIrjNtG32qQCjHNVYLkRSk2VPikxTsO5
+VcBMZVj9BmouGJAVhj1UirpFMZaTQ7lFostRVhlGaKz5Rllfu15d4juludXkjXruwc16g5IgcgZO
+04rwG/TWLa5upp2BCuQC3UE8Dp7kVUloJDNR+TKkjafyNc74Uub+x8aWslk5MnnhMNyCpPIqbUJt
+Tdy0zBsdBHj/APXWTaXXlXykoQ69xwQaztYbPrSN/MXdjjOBUV3fWljF5l1cxQp/ekcKP1rxbw98
+RtbttPubaRDcOQBBI44T1J9aitrO58QTtc6hNJO+clnOfy9KzqYmMDSnh3LV6I9PuvHWixSRR2t1
+HdO0m11jJyFwckcc9uKpt8QY4rmLzdJuRZyttS6R1dCffHT6GuKtvDVmbV7idGZ+SqKcADtitjwh
+ft5lzBHbRPHPIPN82TJ3AAfd6dB+NOnXdVNLRjlSjB9zrJ/FM/2mIWumiWzLAS3MlwE8sHqduCTX
+QwypcQpNE26NxlTjqK8u8ZWOp2bxtaTiKzlym2PG5TwevUd+npXU/Di9ur7wjCbtzI8MjRK7dWUH
+itaU5N8styZwSXNHY6vFNIqQimkVszIrsOaKc3WioKC4fy7KZ+PlQnk47V4nq+owfZZw0ikPLyc5
+yScn+VeyaoWGjXe1Sx8psAd+K+cp4XumlhWBlIJIbd8qnuWPSpmJBPcxzMxHQnCgViyxqurw+eCq
+sckHritKF7bT284zWzsgIHQ8+x6n9ar6hOdW1W3vb/8Adwhdp8sdRmsW7aGkY9T0iG0tr3SEuggG
+YwEANZ2g3ria709SfMClkPt3qUeJNIksEsbE7gicnoEA9a881fVI5Z2t7ZztDEtIpx5h/wAB2rhp
+0nJu6N6lXlR6jea3DpliVkD70XhSDk1yGneIFtbe7vEJjuJZsBWB2lRj+tYJ03W20I6mJJhYKdu8
+ykfhxVaxvnjga3mDyQM28NncynGO/Ue1dUaChqtzJVubSR74l5Y6p4bhjkmR3mhUOobJDY5waxbb
+xH/wj0K6dbT2YtoTgfviXPqSADXk9tq13pkv2Nnke0nBKoh259umQPai/vDIkf2exigmibcpThmH
+dT611x3M3tue3QeLmbONSsSP+vjBH5itbQvElvqOoi1F8k0rKSFQ5BwM9cYNeBW2oNOibkkU5ywb
+5q9e+GsWkTs9zCv+nICDvY5APBwPSq1vqToehsBuopW+9RSAr6gYxpVyZlDR+W24HvxXznqoa5gc
+QhjC0zopPckDkLnpkcV9FX+46ZcBRljGcDOM8V4HqNlrkdw0UVtHHGwJPlAhvxz1qKkkrXKijNtN
+F0PTbIm5Q3ky48wMxG38R+NUdTjtbjTfs9hb3Jl83fHIx+VF9Aep+tb1r4fuWtXkksl5XmRHAJ+o
+b/Gqdroki3pXBnGeFXOK5J10mVyHPaZPdWV2Gktnnweg5Brv9N1GK9kB/wCEZJuYxnlAPzNa+mac
+toolvFhtlxwqLlv05rVfWUb9zZ2dxKTxuK7c/nXPKsm7vQtJ7HB+ILvWNSilsZIIrO03h/s8XJY+
++Koaf4UvLiIMkRRPQqR/OvRvs07NueFFJ67nBNROZ4mBWFeMDO1nJ/LFaKrJh7NHnupeFNQeACGI
+mZJAVIHarFr4V1DyN1zCA3TA5/Ou41C91aC3Z7e0MmBkbAAAPU5rl9P8b+Xc3CaxA0sW3935ZOQe
+4I/rXRGc3GyDkjcLTwpJsZ/MTcOw7fWvT/Aekrp0EjFdsjdfcV5aPiBPc3cYsdMzBGflj3fzOMV6
+j4Ek1e9imvtSKxq/CQqvAH171rDm5tSJJJHYN1oprdaK1MxitxUDadaOxbykDHqQOaEc4qRW9hSd
+nuBk3fhe3uWJEpUemOKZD4TtoSNpH4DFbm80u84rJ06d72K5pGRJ4ZgkGC5A9jzT4vDtrB0bn/aN
+au80hIb7wBpezhfYV2c7f6BfyPtsbi0hTqWZea5a8+G2vX8pabXsr2w7DH4CvTAFH8Ip27AwBTVG
+F7hzM4K28A6vb6ONO/taBo9zHc0RLYPbOelUbL4K6TFJ515f3E8pOcL8ij6c5r0veaN5rZRitgu9
+jmbX4f6HZwrGkbnBySW5b610NrbQ2cIhgGEHQVIW5phbA6U7JaiBm5oqtJIQ9FTcdj//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0028/full/!100,100/0/default.jpg</Url><Caption>29376_0028</Caption><Caption>Vulpes Fulvus, Desm. American Red Fox. (v. 2, no. 18, plate 87)</Caption><Caption>Exhibit</Caption><Caption>plate 087</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="40" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0030;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tI/l
+qRYyB8xBP0xT0HFSYqBkW32pNtTYppFKyAjK0u2nYpwFLlQXGbaNvtUmKUCjlQXItg9KaYxVjFIR
+TsO5WMVVmhnyPmiIzz8h/wAa0CKYy0WQGc8XzdKKssvzUUrIZaQcVJUFu2bWN27oCfyqK41O0t1y
+9xGv1bFUQy5UckiRKWdgqjkknFc1d+NbRTttA0yg4abZ8n0H94/TiuM1aW/1yQnUpyI/4LdeFUf1
+NY1K0YlRg2eqxXVtPnybiKTHXY4P8qmBz+FeHJp0Fqyyqzwvk7ZImKsgAyTn/PWtbwj8Qby21Uaf
+rU3n2kq/urgr86Y6BsdR+tTCtzA42PXAKdisGTxRpwCtHcxuTgKAepPrV5NasfJMj3UYUAsSDwBW
+6ZN0aGKTFZ1rr2n3kQkjmKg5wHUqcDvg1ZGoWjdLiP8A76qhkxFNI4oWeF/uyIfoadkEcEGkxlZl
++Y0U9h81FSMqzs40RmWMu/kghAcZOK82nkvZJmAtEjZjzlwWH5V6dMzrp7FEDME4XOK4TUplh3ST
+FI2P3gHBx7VnVk4oFFPcpaZeadYhhJBl/u7pJATkdgg6Vmanq009yyW1oVQ9JHHrznFVbrWLGJ2a
+BJZeDuYLk/rWBe+JriPKWkG0dcvXE1Uk9IjlMsTNeXUixyXARVOMDgE5/Wrj+GJ101Ls3JaYnMSA
+chckZOKNOSDXNKWeEqJ42UXCNlWBPPy+ua00e80hpHgtpZlEexPOmB2/hihXTtIUU2rlDTLDUY59
+pl8wAZww+n9BWvDeymfyBaGeFCrSBGzwDnHp29axJfEup2jBpLDZ6MGyP0FdbaQpcWQmvGjVmT5s
+ADfx1PvTjOa3KjFMlJjkiF1MVjklOBEeuPf86SOYKMK5z6bv8aqJpVtdwSsIh5aAbTjsfSuK1uK5
+s+bWeTy1P3N5IFbRnKT0dhygjvpNfhsiBcTuEJxuU5A+uK67w9qNrdoBDd+aWXcoLZyPb8q8OXbJ
+bxyZbdIuW55JyRivQvhvZ+XqMkykMvl4JB4H0rojJ7Mlx6npDfeopW60VQhqgeQVJ4xivOvEA0qO
+Z90gLf7Kk16Kh+Q/SuQ1mzjjZ3WD5T1AUYqKnNy+6OJ5+/2ZwUSBpIyf4gBVK50yO5dSlq4xxjPA
+/Suha2VJwywsVXnHOD7VYhujJGY3RUx0GcV51WrWhrYahfdmFoKLaPNa26SSSb95CRkgY4x610fl
+3t7Nzay+VxlduCR3rDv5L0ll3ssec4QnDfXFVLNr+znE9k5SXGCz8ce1YKtCUrt6lLTQ1NUltdO1
+WW0umKR7PMDrgkUyK/sWRYreKW6L5YF7jBP4AVCVe4Jl1J0mkPLMTjJ9KqiziedriImObOAVIGK6
+lyW0ZWp2FjrWl2WmmO4haCc5DBdzjH41yd0trfXbrHcxKspOxjkBfrkDFWYYLszKsl7HJGeSsi5/
+WtNbO3iQ7YlYnqQOtDrqDV19w1ExG0y10uwgtt0F/dM3PlZwoyTy3413ngTTxayyyqJFDLjYTkCs
+i2s/OQrHHg9OFrs/D9ibSE7l+bHWuilVdSV0rESVkbDdaKax5oroMyONqJYYZ1xIoYe9V4mJVfcV
+KD7CncRG+lWkg5jH5VTHhnTt5by+TzyAa0t5xilDmolGEt0O7MyTw3ZONpGB6AVXbwlZEkqwH1rb
+3mggEEYA+lcn1LD3vylc8u5gSeELSQffUH1PNKngqwzvyPTgVuooGcjOfWpVO0YAAHtWkcJRWyFz
+MwV8HWaE4YY9CtTx+GLZFCs5YfStjeaN5q1h6S6BzMqwaVa2+No6VbyoGFx+FNLGmM5FbRUYqyQt
+WDNzRUJc5opXHY//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0030/full/!100,100/0/default.jpg</Url><Caption>29376_0030</Caption><Caption>Lepus Artemesia, Bach. Wormwood Hare. (v. 2, no. 18, plate 88)</Caption><Caption>Exhibit</Caption><Caption>plate 088</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="41" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0026;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABOAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2yOPi
+nKpOcrj096kQcU4cnFYWLIylRTSx26b5GCj3qziuD8eX08d/bWkTEL5RkwO5zisa8vZwci6UOeai
+drEyTRh0IKnvUgWuZ8C3rXmjushJaN9pzXVgCijLngpE1I8knEi2Uu2pMUpFbpEXIdtJtqVyqKSx
+AA7ms86h5UipcIIt7EKSwwfb607IpEzCTnEWfT5qTYSuWXB9KsAhhkEGkIpNBcovFlulFWWUZoqL
+DJWYpC7gZKgnFc/L4tsEnliMhzEvzY/i+n5GujH3D9K8iu9B+0Xd7cLIyEzyrjGcAOQAMf4VUpKK
+1FY6OT4jW0Mrr5DuuAUP+NYHiXXodaktruKIrJbZWQHj5Tj+VcrPofkicsJmlU8bn2/57VktNfW0
+7FNgj+6A4z7ZBrnc41bwL5Z07SPSfCmux6TezK3zQXAyuD/EK7uy8RWV5bNIG2uoBZT2zXz5aauL
+SQW825UY5Abnb7it2O285lkN9Iv8TBj8uPUH6VlSk6PuS26FVf3nvx+Z6RdePYobkrHH5qo4VgnP
+H1rSsPGdneSrC0bJMeNvXmvLbO50+JzEtz5TlSnnLz+orqtIfSopxe/ame6K7Q8hJUKPT0zXTGo2
+9jHl0O2u9QDzIigBM9+pNc14p1wadBvklU8ZVT1Nc1r3iqzsbu5ltLvZcTDBdTkr/u1xY1WW+uFv
+9VlaZEOEDdZW7cVdurLSOxsPFt6jAvKyuQWUE8AelejeHdZbWbISsqhhwcGvGEnmu5Eso8ea/wA0
+xXoB6fhXpHgVWiu5YVKiFY8AA9TnkmqTBnaMOaKe3Wiiwhy8x5bjjmvNPEOvaRZXU8WZ3JYk+Wp2
+lh3616USBCxYZGOa8m8TTW/2t4Yvkd3wIwgJJPPcVlVeiBGMfEOmXdyq2yFH/jzCvP1O6qHiO6tJ
+tJiaKPbcAEYA64PGKlk02WeNrU2zKH5J24zV/TtHFtepLdR/6JBFuJI6MMY/rXHe0k0aqzi0ZFv4
+XR9KivtbmELNgpDnDe2T2+lVdQm0yB42muHaKPhLdT8pA9areOPErTzrbQuWCnp6VzWlhtRnYT7n
+Crnk9PSulXerMdnY6STVZLqLda2cEULcDdzmo31W9MAgacRL0G1e/wBarNH5car5vl9jGDjHpz9K
+v6TZTXW+3ZVkXPGec1qrJXY9Wc9cWjxXHnyPJIQc/MuRSm7nkuUuZmJjjOY0U8Fv6V0WuW/lGaEx
+HYRkEVg2QVbceeu4M5BB747/AFq1JNXDXY7Tws0f2JpmkVrmVuVDDdj6V6H4J0u4h1B7uVmZdpAB
+G3HPpXhBuxBOyeaFaMmvUvhX4yubvWv7EuJBMroWRxyVwOhzzU8rvcLnsB60UrdaKoBrMBCxPTBr
+ybxFDbalqEgWJ2kOAVjY846Ej1r1Z18yBk/vDFeca1bazZGaGx8hdxPKr81ZVdkOJjSy6xcz25uZ
+ksIYEEandvdlHcKOAfc1leJvFqwaabO1JmC/I0jNuOff3qC50PWriQ/a7593XYq8fjTYfBpkkUSE
+sxUBiq4yfU1g5RHY82l3TXDMNzM3Umt+0A0nS7Z4oS9xcShip4yAen+fWuyn0bQtJu0iaNpcKC0h
+Ubc+grMuprOO8WcW05VTnBHA96Upt6BFJbkWv2MI0tbqNBmUjHPfjNY81xqNvbLd6arwNNw44yOa
+6K71nSrq1WO43bQ25VCnrWYdX09P9XBK3++hx/OinUnZKxq4Qu3cyYbrUX5lY+c5O/GeR6ntmnu3
+nzDzCFCfewMACrH2ya9m8u2s53dv4VXH+Nbmn+BdY1QAXCLbQ/ewO59/WulSS3MrNs5G5hhkf7Qj
+bjI2SvcV6d8GtOg/tqe7V8TRxEFR3Bqza/C21EQ3yyF8de35V6N4X8O2Wg2Oy3hAkb70hHLU4Svo
+ElY3GPNFMY/NRVEjI24qGayt5yWZAHP8VMilyAfWplcelLRrUCgPDlkPur+fNSrodsqEKME96uiT
+ilElQ4w7BdmPJ4R0yWUSSRbmHTNRXPg7R7lDHIo54Izit7zKXzMjkVPJDsF2crB8PfDtudwgQv8A
+3mOf61aHgbRSgxbxlfpmugDhegxTvMq1CHYLsx7fwpplr/qreJP91AK0E0y3QAAEY9OKseZSeZVq
+MV0C7FWKKPAAAp24Y4xUZkphkqroQM3zUVCz80VFyrH/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0026/full/!100,100/0/default.jpg</Url><Caption>29376_0026</Caption><Caption>Sciurus Sayi, Aud. &amp; Bach. Say's Squirrel. (v. 2, no. 18, plate 89)</Caption><Caption>Exhibit</Caption><Caption>plate 089</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="42" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0029;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2xI+K
+f5dSKtLtbPbFY2RRFso2VMQFGSarPeQocbs/SlZAO2U7ZVY6jAKj/ti3Bwf50Kwrl/ZRs9qqrqkD
+VML6Bv4qqyC4/Z7U0x+1L9qg/wCei5+tSKyv90g07IZXMdRtH7VZaIkk72HsMUMvFFkBmtEN3Sir
+TKM0VPKh3LiiiWVYU3N0pyisDxBqHkOIh6c0xC3uqbshTxWHqF5dpaNJaRJLJnAV3K5/HBqg18ZZ
+VUsEDMFBbpzxV/7NPG63D2rSiLIVlO4N9RUslsw21vVftiQPpOyPhpJjcAKq5wcccn24rUWRHOUb
+KnkHsa5vxhapqFsSYGjlXkfJjPtXI6L4mvdNVrCd12r/AKrfjKn0p2vsiU9T1kXSRIGkkCgetUbj
+xCFbbEcD1NcTLrUki7pJMtVCO/e7u1hEyBmP8TAU9ldlpX2PQodVDtnzfmPvWxaa0YmXL5rgUtDG
+VCSSM7AkEj5Tip4b5lbaxww6j0pU6sKnwluDjuev2OoRXqfIcMOoq0wrzvQNUMd4nzHmvReqg1bQ
+isw5op7DmipAnWuB8a3q2d8xYPyvGBmu+XpXD+N7P7RMjY6LgZpSdlcErs88bW4nl2+TJI2cqhXg
+kcjuO4rc0ab7Tfwag1/OuoLbKklk42o2M4ZQevJJyCetYcuntBcJMiZKNnA71Z1fSLbWoIZLTUBZ
+3SDOfuMPriiE1LRkVItO5i63pUtpDdfabu6lSeQyCN5MlSTnr9a5rRdB1LVtXVrO0knfPLHoB7sa
+6Wz0rWrjXrbS9XvVubV2ws0bBjgDOD06161bxJZiGz0+CKHCZJxhUUdz61c58uhlCN3c82HgDXBC
+0krW8aquSGkzx+Ao0DTI3FxazQJ5sU4LsU5HGQM+tdbf+MbzS9SVY9Pae0RwJZHQq7gjJZRwAMHv
+1pkU0TxzXwBAnYy4PU55A/LFeVmOKdKmlHdux6GGpc0tSmZraLUlglYDfhQCMDI4x+R/Suc1+9tY
+NTRYZczKMS4HGe34461pakEvLkOcAdfSq2paAl9ptxdLEUMSeYJNp59ifengI9eyNMSkvmN0TVle
++hXeclh0Fe8J/ql+grwPwhot1eXybEG2Nxliele+qMRqPQV6XNc5JKxERzRSt1ooEPU8VheIIlmU
+bhnFbSnisPXtUsbDAu5fLz0yhOfyFRUfujjucnLZLn7g+prMu9Hiuv3ZBGc8p1rZfxJoRY5vUUe8
+bf4VBJ4i0ADMWpRCTsWRsD9K4JN9DcwtO0yOSIYh2TwtsY45DDv/ACP411NnqFxb7BPHvKjG9RyR
+7isG21TSo57mdtdh3SvvCJCwGcAYJI5HHtWmviPQ3QZvYxnsQeP0pKpJMTimax1PRZYRDfQNtwVC
+zxEgD0B54/Gq11q3huOM7xCqDjIUgCoBrmi7eL6Ij0IP+FU7698M6ggW4vYht6YB/wAK154y+KKf
+yJUWtmKmqeFeZ4bV7s54WNSVz75NM1S51PxDALaGFbWz7ooxnHr/AICltp/DMVys66iruAAMk445
+5AHNbEer6O3KXkWT14P+FaqdlaKsVbqw8JaIumEAElicsTxXd9q5zTdQsZZlWKdWY9gDXQ54ralq
+jOpuNbrRTSeaKsgYj1W1DS7HVECXtusoHTJIx+VKjmpgxpaMDDfwN4cl+/p35TP/AI0wfD3wuOmn
+H/v/ACf/ABVdBuOKXcaTjHsF2c9/wr/wz2sXH0nk/wDiqY/gDw4nIspse1zJ/jXR7jTtxpckewXZ
+zi+BdAY8WtwB/wBfcn+NTf8ACB+H8Y8i4/8AAmT/ABre3GnBjiq5I9gu+5z48BeH16QT/wDgTJ/j
+Th4J0ND8sEw/7eZP8a3txo3Gnyx7BzMzrPQNOsJRJBFIGHQtM7fzNaRPFMLUwsaaSWwtWDNzRUJJ
+zRSuM//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0029/full/!100,100/0/default.jpg</Url><Caption>29376_0029</Caption><Caption>Mus Musculus, Linn. Common Mouse. (v. 2, no. 18, plate 90)</Caption><Caption>Exhibit</Caption><Caption>plate 090</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="43" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0013;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3FUwK
+cFBGR+oqTFGKiwyIikINS4qnPqNtA2zfvf8AupyaNEImwaUCq8dzJLyIgo9zzVtOeoxQmgAClxTs
+UuKdguM200pU2KCKdhlSQKgy3A+lM2K4JHPbpVwimlaVgKBgGen6UVc20VHKhk/UZHSiorIlrC3Y
+9TEpP5CpjVkmNqmoET/Y4mw2MuR29qbBaxxrv4yRyayplaPWLl3yWZz27VsQHzbdh3xxWb1Yx8cp
+z6irqSArk8YrEtZ9yjnp2q4spdwg/wD10kxM00ffyOlSCqMkhj2qOPWrcLCRAwOa0TAkxQaWg1YD
+KQin4pMUmMixRT8UUgI7H/kH2+evlLn8hVT+2bFpmiFzGsinBVzip3do9JLqPmEOQPwr591fX9Tt
+dQlLQ7RvPzMuR+dAmezaiyy30ckbqd4wSpz0q3C/2eGSR+NoJ+tcR4B1OfV9MaSZVBjlIBXvxXb3
+wIgjjDIGfJAc43EdBWbGULWxcoJPN2bhllx0ras7YIvmHlj0zXP+HYdSRbiPU1AleXhkk3KV9vSt
+bUdQSy2w78TSAiJfUjqfwyKlWEV9VvUhkWHeTJJxhf4fc1Lp+oiBPKm+V1OMGuc8SXkXh7RH1CR8
+zuQsZxnLH/8AVXOeFfH73mpiLU3ifI+SYgKVPoa0SvqF7Ox66lyWAIQ84x9DU+7jmucuNWuLbTbq
+eO33CCFnRt3J4PGPwFeaj4qeIFkOEtXUHoUxn9a0iribseyz3KxdfUZPpU4IYAjoa8XX4p6ncFhJ
+pdsT/vNzXdeCvEl3r4nE9vHFHEBjaSSSaclZAnqdbRS0VBREyAWZQn+DGfwrxvX7CMXUqpMZQSSy
+Ov8AKvZSoeMoehGDXFat4UR53n5Knkisql7XRUbdTkfDesjw9atCtqJIXff8pwRW5P8AECG4QxNp
+bSDBA34xWVcaOTcMsaSFB/s4FV30icv8sTH6DpWTqMfKdT4Z1uzWwCPNHbyLIxKPwOTnj2o8QBbm
+8g1KC+hMkAKKhGRz178ViR6PE0KC4Z1kz93AJNTpo1qiEswVh1LVCrdxOJmXXi65kh8iazt5ozxh
+gT/PIrgb6e0ttRZYYtk0kgAhj6Lk11PiOykV47eylQux3SbOSo7Vl2XhyaTWxOYi5QBz9ela05Nt
+Ckkk2X4PE2r22ly6eJC0TDZuIGdv93nPFc87mEkNEGYn+Fea6yTSnkk2eU4B/ucEVUfRWj3v5RyD
+1I5rsTRzKTe5iwh2AJUo3TBHNet/C5CLC8Zgc7wM4xXD2ug3U54gkBPIC5/UV6r4Q02XTNMZJU2s
+7Z+tEnoXC9zoqKTNFZGpEGp27IwRmq6MSKkBp7gONvA/3oUP/ARTRZ2oziCMZ9FpwNLmpaQERsLQ
+tu8hN3rjmqs+jadPky2mfoetX80A0uVAZg8O6Rs2rp6gD04NTW2g6dbMzxwYZ8ZJOav5pwNUopCK
+x0uyP/Lun1xzS/2bZd7aI/Vc1YzSE1QWQxYYUOUhUH2UU8mkJphNAxS1FQuxDdaKVwP/2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0013/full/!100,100/0/default.jpg</Url><Caption>29376_0013</Caption><Caption>Ursus Maritimus, Linn. Polar Bear. (v. 2, no. 19, plate 91)</Caption><Caption>Exhibit</Caption><Caption>plate 091</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="44" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0023;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7Lg
+cAZpRbnaNwAPfFQ65eyWFj5kRUMTjJ7Vwt34n1aFDNDdLIQPuADB/Cs7A3Y9B8gUnkiua8J+NYNb
+BtbzbBfJxtPAf6e9deMGlyiuVTCKBF7Va21ynjTxBLpdkbKxfbf3ETMrgZ8tBwW+vPFFkhasXUfF
+2haZrMGkXFyWvZnCeXFGX2E9N2Oma6EW4z0rD8KeErfRLNZZx59/J+8llk+Ztx6nJ5J966jaKtDK
+n2cY6Un2Zf7o/KrmKMU7DuZ72nHyKufeo/sQOdyJ+ArUxSFalxRVzIOmQk58pP8AvkUVq7aKnlQX
+MvxLbfadMIzjB656V5+2leYjLuXrweleka8dujXD+Xv2rnbnFeVLrtjI8kZEkMwBIWQkZ/GlUlYl
+xuUrnRJbecziNgVORIr81uaXrN05EMoaYg7SyuQwrmrbW7x7t45vLaEnIJbbtFbVsjXM3mQRtHJ0
+OTzXPKpoTy9jubfVLu3tfmYMijhpOTj3NcjrYudQuJ9SvI0h3KqQiQjcAAcBV/3iDzTU1H7ZDDZO
+J2aWTZF5R2+YRklg3YDHJ9x3Nc946vY9L3fZoIRcx7GkmZiXZ+Rxnk42oc1UG2rtmijbQ9RHjW03
+7Fs7k47/AC/41oWviWyuXCsk0Oe8ijH6GvlxFlkt2mmuXe8zuZy5yuf5V6B4I1zUrTUrfSNXcyw3
+S7rWZzkg9dpPfocVvGdyXCSVz3SK+tZ/9XPG3tuqcsoGSQK5J4lUAgL071jXs0kbnyzMcf3Gxir5
+xI9G3qejD86AQehBry+31bW4XzG8hQHpNgj/ABrr/D2p3mozMZlREVeQvc0XuM6DFFOooGVtRjEm
+nTIQTle1eC+LNOeO/R4SMEdD1BzX0DLzCwPcV51q2lW7XjSKEJHqucVlVdtS4HmcenXV5AHhWdST
+iRBwPfBrodKR45fIu7uUExlCgKAhcfxHt+ea2JoPKtpQm8Aqc+WuW6dh61yFv4W1C8l3TGaOMOzR
+xhvujPBb1OO5rkt1bL0vY3f7MvLeCVrW7Mq/MFjDY2L3Axg//rqne6emtW7XE8U0ihcordQTjk+u
+BnjityE3dtZG2uRJK4wIj57RKuMDkpye5Oc1RvIRFplxcl5lVVDLMZiu5u20BgeOvzZyKuHvJWZL
+dmzi7Sxmg0eY3UcS+Y2IGAwZB9KuXVlcQ+GtN1DIJs3VsBsnaG5OKrRwP/ZsWtmJpJbR90iPnBQ5
+4A6DnHT1rX8JX1zqum3mksI7fT7qQsHlOSi5y2OlaxQ2zV1HV9Lt8C3LtIygx7H4Y/hVWx8RzG/j
+juIY5LUnDsI8kf41yGt2T6JdKbaV5LSUZhmGQHA4yK2NF0yQQxXDyEs4D7AMe9NRstyOXsdofEnh
+pZfLlVkIOObc/nXo+hQ2qWiy2mwxyKGDIBgivEbzSrvUbiKO2s5C4J3MSBnNenfDvTdX02ymjv5I
+TbjiJEbcVx1yauFwasdrRRRWhJHK22FjjOB0ri7iCR7qRyMgn7ortTypFYl5b+W5OBzzkCsqquio
+vUwxAkCgso54AFK+cZZUjjx3pk95FHISgMrj8hSLdJdQYMsQlY4AzmuKSNSnKIrm3kGSqOCNxGCB
++NecauBp+orYSmdIS+5EbJSVcADDdsY6H869AvbS6BMhBKj+L/61Yt5ZxajH9nuYRJESDjJBBHQi
+iE3F7EuNypBpjalpc0cEg8qSNkK9Mn/HIq9onhb7DZwxSkMVQBsdCe9auk6bb2dsUiDhSxYgZJya
+30ULEAqqR7mrU+w7HM6xpVtrFg9ncxH92AI2UcjtxWNpaXeizW+nXaxvvB+zygZ3BccH0OCK7CRP
+KmZiu8E/wgDFLFYxXE6v5fI6HHIzWqlfRjsJZSkuCsYD+uK7TSYkiswEQLkknHqaw7XTHRgVjbHu
+K6W3Xy4gMYNbU0ZyZLRTc0VoQRhqDsYYZcj3FQRMSgPtUoNIBsllbSptaFcewxVOTw7pUzKZLRWK
+nIySa0N1LmoaT3QylDpOn2rOI7b7/J6kf/Wpp0jTRljagZ5JxV/dS5zS5Y9halNNPsQDtgOPanCz
+s/LK/Zm2kYI2mrYOBwKXNUox7BdlVNKsVUBbdQPfrU8drbxDCRIPwp+6k3VaSHccSB0FNLZpC1NL
+UCFLUVWkkIbFFK4z/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0023/full/!100,100/0/default.jpg</Url><Caption>29376_0023</Caption><Caption>Lynx Rufus (Var. Maculatus), Horsefield &amp; Vigors. Texan Lynx. (v. 2, no. 19, plate 92)</Caption><Caption>Exhibit</Caption><Caption>plate 092</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="45" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0027;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3IJSj
+5h0I+oqULSlagZCVNJg0XdxBZWsl1cyrFDEpZ3boAK5K2+IdpqE7rpmkapewJ964ig+T8yaTaQjr
+MGlwajsby31G1W4tn3I3qMFT3BHY1Q1vxPovh6POo30cb4yIgdzt9FHNO8bXCzvY1MGjbXn3/C4t
+D8/Z9h1Dy/7/AJY/lnNdZofirRPES/8AEtvo5JAMtC3yyD/gJ5pRnGWzKcJLdGrtpCtT7aTbVkld
+lCqSTgDvUOUc7VZSfQGrpFMKD0pWGUjFzRVvaKKVkBZFISB1OKUVx3ibxfZ6TcG2a9WN84YKcsB6
+ADvQ2ktQOqmaF4ysoR4mGCDz+lME1vbxKEj2x9PkXAFeVP40tPPZolnmBHJ2Y2ntg9c1VPi3WJ2J
+tLG6B3AqTJj6jHvXNLERW4WZ3muGXSpvO024EH247XGzIDD+Ieh7Vy+q+FNMtoFvnaWW6dwZZZpC
+xf1rD1vxTqcVhby3dssMgmxEpfPbv0rDu/FOt6iAVj84pkbViJjHbrkZrkm3UlpsbwfLG56zYaVo
+scITybfJHtk1z3iHw1b2M8eqaQ32e8hO9HQ9D6e4rmdK8Xa+k0cL6XbGJhtYD5c1uaXr7azDcbgv
+koDjJ549apxjGN09hwm5M9E8L+IofEWlLOoCXEeEni/uN/ge1bTEKCWIAHUmvALnxRd+FNU+3aaq
+SFomSSJgdr4PHTv/AI102h/E+LxASJIVgmUZ8hicn3HrXdSq81PmZnUhyysj1XzYz0YU4YI4rjl8
+RAqCz+XkfxrkD8q6HRp/tNoXEqSDONy1opKWxFrF0iikkfa2PaigCfoK8A8V6npUuv3UiuwbzWBA
+jJJ56175M4jgkc9FUk1816vcWR1Gd1kAkLt8yg8g561jXeiQ4pdS1Z6vpyuv+kRALzgqcn9K6W28
+X+H3tQ0l0qSA4CyKR0rzvfZpG+wkkkZbb+lS6dbWE10guAzQkNklTtBI4ye1eZUows22zS66Hcpr
+Vh4juJbITxNbpjeMcH8f8KsGPSoB5SyKyRAARh8D24rziPTIpL64S11COCNGGG3E7h1xx6VEbFjd
+bW1DzQW+8CazWHV7KegXv0PVUt4UiztWM9gOa5PwjaST3+tWkFzh1nysZ4Z1GQcVTsA9upaDU9rD
+AEbNnP0z0qYaKs9000zmMMd5kt+JN3PfPetaKUeaDe5S0d0V/ENktk9wZJt0qnBXOdg64+tYfh6R
+P7bjumJWK3JbI4LH0qeTR72PcR867iSrPktn1qnhrW6EMkYQkBiMEZ4GOlehTso8qZFSTvdnqKav
+bTxZfJcjJ74Neg+CZEl0iQohUeZ1xjPArwiPEDjBMLAEbCxwx9fWvYPhXNcS6Dd+fJvAn+T2G0cU
+6UeVkN3Ozn++OO1FSSAFufSitxC3C+Zayp/eQj9K+Zdbs3tdQmVsArIQCeD1r6czkYrynx54JuXd
+7qwiaVHJJUckE+1ZVk7XQjyULGG+c9f7pqRWWOVdhZSRgEirTaXdabJ5VzbSpz1KHFDQMWPkpvAH
+WvLqVPe5WOxClvaTOytkSEfKx4w30ot4sH7RkAR/Lz1Y46U8Wq8k/vDnBXOcVbit47Z0Vk2jOeTk
+DNZudhWLNlpwEMtxtDS7WOAM7RgnIHetS10g24SSW/MqtuIMqlMptyCo65zn2qjazOt04t5GV9oC
+umcCkvtT1e0IjMzSE/xcAL9OM1vSqXVmXFpIk1VXgFvMG2GXrEByf8KxFme5uQ0igso6kY6Hj8qt
+vdm18y8aQTTyfLGp5Cj1zVaCCW4fcF3McnCrnJ966Kc0xSbbJNkQcv5aBm6ncWIHtXtHwvjCeHJS
+oIVpieR14FeX6LoOpatOFh06QDoXxtA+te3eGdJbRdDitHChwSzbemTXRT5m9RGq65NFKTRW4hgN
+O3e1QqaeDQAS21vcLtmgikHo6Aj9ar/2RpmAP7PtcDkDyV4/SrOTijJpOKe6AovoOkOctploT1/1
+K/4VFJ4d0WQKJNGs3A6ZiU4/StPNGaSpw7Bcz4tC0iEfudItE+kSj+lOPh/R593naTZkng5iU5/S
+tDNLmj2cewXZkf8ACI+HvlH9j2mFOQPLGAfpV6LSdOt8eTY20eOPliA/pVrNJmmoxWyC4iosYwka
+qPbilJ4pCaaTxVABbBoqGRiGopAf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0027/full/!100,100/0/default.jpg</Url><Caption>29376_0027</Caption><Caption>Putorius Nigripes, Aud. &amp; Bach. Black-footed Ferret. (v. 2, no. 19, plate 93)</Caption><Caption>Exhibit</Caption><Caption>plate 093</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="46" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0024;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3ERYH
+AGaeE4GQM96exCLk1CbqL++v51Fh3HlaTFQG6jzjzAaq3GoKqkAdP4ial2RNzRxRiueXW2t5Mk+Z
+H3Gen0qdfE1oTgowPpTViedG3Risk67G2PLhdqtQ6h5nJjA/GqHzFzFBWoxdQ45OKlV1cZU5FOxV
+yGRXA+RQx9zimhHIO5QPoc1axSEUrDKRhyaKtbaKVgC8LC2JTg1y9xfLbN++uY1574rpNWQvpc4B
+wducg4ryS+sYyzfNL5jMOWOcCpnPlRLOpPiS3GcShz/CAvX3qlPrwZsvA/J78j+dcfFbmKd4WcsU
+IKYPVT7/AKVsf6SdOdYEVrjG1Pr7Vzub7itc3VvUuEAEkak9FK4z+dQyE7/mjXcOR1FcxHqt3Nbm
+G8hVSpKM6nJ4AySP8Pyq7bSzwwFEcyLgkZOcfSlCoKULPU6myvxED56ABR6j/JrROr2YjO0sHHVc
+ciuBku1Kb3MkRToACetWrLUbRVA3SSZH3tpNdMZ3Fotjon1a+SfzFVWhJ4U9R+NXIvEAUjejIfY1
+hNqUbxbIztX1INPF1bMgDMjevFXzFI6qHVd5z5uR6Hg1tW0yzx7gc1wkM9krDbNt9ua7DRJoprVv
+LOcHBOKOZMpF/FFOxRQMqaxJ5WjXcnXbETXj1hrf2q8uRNEoWIDbnnmvZr9Fl064R/utGQfyr57Y
+R2mszB2ZYgxBUZw1YVtNRN2H65qb3N1FPp8e1lJygTkD3ptjrGs32pwxWiDyom3SMRgN7ZpYlg8u
+e5huAs5bCx4ySOcdfpXQ6YmnWHh2B4kVbgYkaUHHI9T6VxzlZbbmlKN/eZk6tBqtvLcXE0Uce4gj
+y1DhBzk5x1zisZNYuYEMlzcnyyec4XNW7zXby/vpIxFPKM7fvgrj+VSjTdNuLZ7q9LszIFihVuVO
+P15qYy+y9hOPPIsweJEv4c2zjapCu8ibQCenJrZ0++SZv3kcDOh2nb1B9Mis7S9LaztkkWFQk0Si
+SFxn5lHX696n0+5sLTYNQm8qUMTGuwZI9Scf4VUVGPwlOCSNzFu6szQkfSQ1LFb2bpt8uVT7tUVr
+cW9y7GKRMdhnrWlbusQZoQpcAMck4INaKfZkJElrpcRTeqygDuTXYaTFHHa4j6Z71hadqklzIIpI
+gnr3rp7cARcAAe1dFJ36lSSQ/FFLRW5BDdrvs5lAzlCMV41eaOlvdSEWzySEnvXtDZKEDqRXKS6L
+qEtyzABVJ68VzYiLdrK5UbdTzq30qad/khSJRweeas31m8FoYZYmkiIxjaAuPQ8Zrsr6wewDtiSS
+QLwAvGa55U1LUJo4WVVJfIQMM4rzasXsjReRycVqQ4jiQpEOgA/w5qci6jjV542jRWwm/nP0716H
+eWFzY6cREs3mMP8AllHls/U9K5AaJf3eqJcXBkc54inAJH48Cs/ZSTsLl7GTZxXMc5FvJ5WecjIz
+9c1WvLcXE+94ITIOCUcLn8q6G4iNvOVurh5ZA+0pwAP0FPuY7SJ4ZYrONpdrMcITyBxk9OtVTnLm
+sS9DEtLR0UfJJGD+Nbljd3mnHakkhHXGwkYrS0aC9v7bfLbHYeceQVJ/H/61aE3h2RIPtNslzFIO
+qIM/pXYo3V7FKxX03xVYXNwkU7eTJnGQOp989K9GtiDApHpXJaLo0d63mX2nRAjjzNuCa66KJIIh
+HGMKOgrrop2uRKw/NFNorYkjR8qD6jNODH0H51UtHLWkJPUxqf0qwDRcCTg9QDTRFErbhGgPqFFJ
+mlpaAOOD1AqJkUfMYIz7/wCRT80UaAVzZW0hLtZW5Y92A5/Snx6bYqdwsrdWPXCD/Cps04Gjlj2E
+OWOONdqIqgdgMUvFNzSZ5qhiknsBSZPekJppNAC5oqPNFK4H/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0024/full/!100,100/0/default.jpg</Url><Caption>29376_0024</Caption><Caption>Lepus Nuttallii, Bach. Nuttall's Hare. (v. 2, no. 19, plate 94)</Caption><Caption>Exhibit</Caption><Caption>plate 094</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="47" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0040;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2v7NH
+/wA81/75pREikAIBn0WrQFLtqbAV/K9h+VHl1OVpCKVgINlKFqTFG2mkIZtpdtSbaAMGmBFsoKVN
+ikxTAqFgCRh8j/YNDR8Va200rSGUmgBPSirRWikIsgUuKBS0wEppFPpDSAYfWlApcVBcXH2W0lm8
+tnKLkIgyW9AKVxEV5qlhpzIt5eQQM5wiyOAW+g71m3mttLdiz06PzLjvkgBfc/5/CvN9ai1LUdeF
+1qNuiTySKI4VblcAbV56dyfTnpxXbWk1npGjOscge5cbpXT+JumB7DoK5/bN3vojVwjG3VnQWk7x
+WRkuJxMyjLFVAAPpV/GRmuWtLxFWKFmDM7CQqGGDjn8ADXRxSCQBjJn2HSt6c1JaENE2KaRUmKaR
+WjEVpZVjbB9M0Vi67O8V6iq2B5YP6mipA6YVT1DU7XTIw9y+0HpxmrYrnPE9tBctGJi3yqelEpWV
+xlxfEli6hk3sp5yBQ3iOy3YAc888frXKxhEAVHYKBjhR/jWRNd3LSlmuBCmcKioN+B7iuOri1AuN
+Ns7u68T6fEvLMfYp1rmPEniWxit4bmzujD5WXURfLvY8Yx0P+fSsW61DSbZ080y3ErYxGZCxP4Z4
+rD8RXmm3sAa0hZHh+cRuOBj+X61zyxMpFqi1qXobueW4e+vJjnBAVedoPP457mntqjxYWW1m8ksC
+sgx0J4OM5q9oU+kX2nRtDNErMBuBb5lPpg1rnRtMMDeYxkU8EvJxj0rPWT1LjGKWurMG31ARyCYu
+Nx4GGHAHb2rorX4i6VahInWU/wB5gO/sKypNDtYUJgIWM8gAcVy+p2scd4ZGjBUcMemfTFdNF8vw
+kSjc9V0/x5oeoXcVtHcuJpThQyEDPpXTHpXjXhgWqa7akWByJB1GMH16V7MelddKpzozlHlZz2tx
+b71DjP7sfzNFbE0Ecr7mXJxiirsSWRWdrN1aWdv5t0+xfpmr4NVNTsVv7UxkA/UU5XtoCtfU4uXX
+tNm3rbNz03FgMfhXOSWdtNM8s2pKCxO1VcV1cvhKDcS9puJqKPwbBn5YSnv1rzqsJzd5HRFxirI5
+SbS4Li3DT30AIA2tuBbHbpXOXOmhCRDKswB7OwOPpmvWD4VslTDQkn1xWdc+DrSQ7lzGT6c1kqMo
+sHUurHl1hZwvdGMReVL164NdDPYST6eiXN267T93zufrXVJ4DglKyM7bh3KircfgtY5AQpYdzjmr
+9nJ9AU0jkC17HZ+XaXalQMAshYj8TVGPw7f6o/8ApN+5Udo1xXqI8OoEwFfNWLTQ2gbIDYPpW0KM
+gc0YfhbQltp4mZWkaM/fdjmvQT0qna2SwfNzu+tWz0rrp01BWSMJycnqRnrRQetFUIjSTcoYdCM1
+IGqjYOWsLZj1MSn9BVsGmBMGPcUZqLdS54pWAfkE1GzbRny84oBpc0WENWYt92In8amViRkjB9KZ
+mjNMCXNITUeaTfzTAkLH0/WmlqjL89KYZPakMeTzRUBmwen60Urgf//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0040/full/!100,100/0/default.jpg</Url><Caption>29376_0040</Caption><Caption>Mus Aureolus, Aud. &amp; Bach. Orange Coloured Mouse. (v. 2, no. 19, plate 95)</Caption><Caption>Exhibit</Caption><Caption>plate 095</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="48" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0001;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3DYwx
+tXPrzT9lSgUuKkZDsNBU1LijFS0IhK470balIB6gUYpWFc5bxnqPiHTNKibw3pQ1C9llCbW+7GuD
+8xGR9OtcPN8QvG/hra/ijwxGLY9ZrY8D8QzD+Vew7aZNHE0LCZUaPHzBxkY96fKUnY4Cw+LnhS9i
+DS3Utq+OVliJx+IzV6L4k+EppRGmrx5Jx80bgfqKwde0jwK8kkh0KIvuwDbv5QY/ReK5K/0bwjcQ
+zJa6dcwPgiOaGcsAffPBrH2qva6NEont9rc219CJrWeOaM9GQ5FKUlz/AKoY/wB6vA/AeuXvh3xQ
+tjLKzQM+xlzwQe+K+h1KsMggj2rSEuZBOPKUjb5NFXSoop2IJSdozgn6VUnu5V+4qgf7VSX15BZQ
+b55RGCcAmsNdTs9SlaO3vI2ZRnAP+NaqxEmR3mqX8Eu+KUN/sY4q3Z6/LIuLq0MTf3s8Gsy8vLbT
+mPnXKBgMncR/KqL+JLGZvluYemPmJH9KtpPoZXaOyj1K3kH3sVMLmA8+an/fVeZf8JLo8m4f2nFu
+T7/BH5cc1BdeMtEs4ldbrzc/wqrEn88VnLlXUFKfY9VN1bqMmZP++q5PxZ4mSxiMUc8aKw+ZmIwR
+3rzu98YavrH+j6RaG2hP/LZxlse3YVlv4bJKz6hPJPK3VnfOK5qtWNrJnVTpTestCC41G0u5W33q
+eWhJVXOCTU8F7F5DszRrEBkMPX1NWtP8N2V3cNGUGwA5OKxtf0GPTnDwDIB7iuVcuxv7HzJ/D1r/
+AGl4lN+4228R8wswx8q967Dwd4muZNfWE3E3kTSsSu3cCT/KuUvL1v7Ji06wQRiRFaZweXbGcfQV
+b8GWU0XiK0DSBZFkUkbgDg11QpytzGVSSvyroe/Yop2KK3MznfG0U0mh5gVDIrggt2FeTRymJ2Aj
+Y3GclyQcH6V6z401COw0cGQA72wM15lbXtpc3OI9obqc9zRKbSsibIx703HmS+ZIZHUFmJ+ao302
+P/Rjvlubi4OBFFgfqaXzZrK4ulviGjuM+UYSdx55wuM+2falshcR6nZXMVuy25YyggdAMjFc9SpL
+qbwpxTLN/wCGLa2tA80Xlynqu/d+tU49FtVvI8rlcitnVdVhvm8lc+Y3HTpXPyXk9nI3m8rGRz6j
+OOPeuROTdjZ2PQ7eyjjtkEaKox+Vc7rU5EvkI2T6g1PZXt7eIimVbaHH+tmYKMfU1KieH7Njcalr
+NlnqF80Mx/AE0QpyuDmkP8OuYLWXzR+9OPmPpz/hWd4rObfIGas6l4htzHE2nWbHT2T5rkjBx1BA
+9AetYmoai9xCAVWSFhlJFOVb6EVTi07lxdzmdT1L7KY4Od6xqfpnnH5YrQ8L6j9q8WaUqfITOqkn
+kYzWH4ghZZmvkUtC4AcY/wBWQMYPtxwa2vhxdaa2t28UlnLcag9yi2/zYRF7k9yRXpw1gmjhndTd
+z6fHSigdKKkDzH4z6mdP0Sz/ANGaRHkbLg4C8cV4b/aM01w0duGZSCDhvvHH8q+l/G1tHc6XH5wJ
+iVssAMk15Dfrb6dDJcRWqqVU7UA5J65PtVcyXTUnlucrb3c9j5pgIFyQCfw/h56Ctaz+IDaQhtW0
++OZJPnw0vCn2OM1wk99d3ckqxElnfJb1NXbLQNQnKNMsjLuyT0OKznCmtZ7le0ltE7/R9ck8SXr3
+NzawW0FtyCg5P+8e/WuS8UeIJdUv/Ksi6W0TYDjjd710o04Jo7afp8UkRlP7xjzx/jVNPCkNrGjT
+uPbLck/yrijKKm5Jehc23FRTOJd5pn+dJZiO7MTWrp+jXF1E0hjliAbAxHnj1/WvUdAs9Ps0BuYl
+O0cFwMf/AF66G51fRIIA2EPH4Guj6xJqy0M1BXuzzeK6httDWyjS8kkWJoyrRZ3E55GOnWs7QdO1
+qzkVsC2hYYKShdrfUHqa9DTU7GYk20Ict3UDj8ayr+C5uJFkeLZsztKvk4znB68VKm1dW3NN2vIw
+9e1W0t7WaOK3QSH5QQODxg/hnmqnw1tg3jTTmKnPnA56YpbjSybkySRNK7NnOM4/oK9A+HXhc/2m
+moP8qxHIX3xW9KKhG3cVSTlK56/RSZoqiCje2kN/atbzZ2N1wcVyd54EDk/Z2gcc7RMDxkYPr2Jr
+sVNPFNrqNOx5zB8JbG2JaAxK56tt/lWhH8PEiX5Zo93qVruAadmocU3cLnIr4Eh2jN0Q3fC9arXP
+w9guWXfehNp6hckfT0rt80YDDkCs3Ti3qF7HDyfDm0kj2nUWx2OP/r1WX4TWbTb5tRldQPlXZ/Pm
+vQQiqMBRTs8U40oLZBdnIw+Aba3i8uO6YD2QClHgK1yS97MxPsBXW5ozWihFbILs5iHwRpkTAyO8
+g9GOAa37a1t7OLyrdFRR2FTk0wnimAuaKjzRQB//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0001/full/!100,100/0/default.jpg</Url><Caption>29376_0001</Caption><Caption>Felis Concolor, Linn. Cougar (male). (v. 2, no. 20, plate 96)</Caption><Caption>Exhibit</Caption><Caption>plate 096</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="49" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0034;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABNAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3Hyyo
+yAT7U8JxUoAA5qpc6pYWkLTT3kEcanBYuODUWAm20bajjvrOaHzo7qF4v76uCKes0b4KyKQehBzm
+pshXArxSbTVPVZHtxb3A3COOZRKQeNh4OfoSD+FLqOtadpRQXlysbN0HU49fpS0W4Et1cR2cDTzO
+qRrjLMcYqFtSs0sxdtcp5B6PnrXHeK75Yopmn1OKSzl5CD526dh0H4157qXiWd3ighaQWSY+Xpgd
+PpUe0fNZILnvkTJPEskbBkYZBHeq81/ZQTiCW7hSVuiM4BNc34d161vPDssNvcqsoj2R7perY7el
+cDeWv2a8kvNRczXO7g7j2NU6iSQ0e0MBg4+YjsOtRgbzjY4+oryPwzr99D4kXdPK0TsA4kc4b0r1
+21v4byRkiydvU1aaY7jTb5PeirhUUUrDEvtws5Cpwcda8R8SRs1/MFEnlnO8uMDPbFe0a1OLXRrq
+c9ETNfPupeKVF1KsrkoRkEpgf41NSLbuhI2tGmS00/bPPIzyqdqqeAB61oaJ4viaaKxtIpmEBJO4
+devv71xOlahNfXRuUIVGUh1Y8cdMCk0nUJrLVmm+ykRsecHkc1i5WuJxPcYtettWs/s0v7tJo2jK
+uQG3du9c/ruoaXqGjwtfKjXka+XJyeq8Hp78/jXIpqsrREiNFJJPXmqzagsd0kt7Duifg7SWKsOh
+x3B/oKlVefRicWR6tfx3Fklss+xQAoIOT9BWBcwXEEXnwl5EjI3cZ3duKt6hJCbr7RARLhshSCNo
+/HvUL6jMqu0duA5xyzDmmk1sCT6jbEXen3CzI37tnVihHIPXHv6Vq69qxnDY3MzE/KhwB+dc42rX
+AkifaUkjOd2QR9MVZlv/ALZLE8sRA43FVwD16fpWqi7pspLoa3hieZtQy20RvgMCwJr2jwujedIc
+ttA46YNeHWd5b2WoLcWNrLJKB0kPy5+leufDq71K98+S8VEjAwFVe9aq1x2sju8UU6imBn+IRnw/
+eDsYzmvlvX4pZrtgijYDgEHJNfTXjBgvha9ySAUH8xXz1HZteantUjYDudicACs5y5WOKvoHhiy1
+HT5Bei1eSIfIUI4IOOKNZ0m5iWe+VbmzUMGNvIWAweRgk+xrutPuYoReWeFeBSrqSOvyHOD9VFcq
+3iF9eguxfD7VHaAiJXJwCSOeOvOMZOeTXMpuTbZrKKSsc9Bf6jNcSLERGqEgkDOB+NaMJt5jiW6u
+JZT28w/0qlcpdwXKabIsUfnfMgjHy9SP6GussH02PREgl8u3v7fl3dcFgR2+tS0riVkc29sBdsDL
+OkUf+sR5d2Bj61qxroF5D5UV+lvcr08wHBNS38SRW7BJBMynez4++T7/AJVzVxo8ImtLm9WSOCRO
+Z0BKhsnqR0rVRT6gpeRZ1rRL2zC3G4NH/E8Yyg9CKxib1EEhLNGTwytkfpWrq8+peHdSjsra8kls
+5lDRlgGBFOWO+t7Z76VIp7ZhiRQMHH4Vqm0lcOVN6FWw1KWB+GI+vNe4fC6/N1a3CnG7gnnr+FeC
+uI1ZnhnUoDkLIO31r2H4K3kdyt6gLF0xg4wK2SXQzdz1aZ9j49qKScLvGfSikSZHjP5vCt4uQMqA
+M/WvBZCbfRmkbIHnkyso5KqM4r3/AMS2Zv8AQriEZJxkAd68D1ZLsRPpcNu/7wlWO35VGeTnPPFc
+9d6pGtKyuzmrTXdYF28lrM6WrOWEDAMu3056cHHFaH9oHQrmS6hSQQTLvfYqkDPYZHHcVq2mkvEy
+Lbxkt0PFWNbtIViMFw2xHi6FSd/Pb0NYe1UpaIq3dnEajr8t7qRmjtUTLDaoJJGPQ11F3Ytr2hLd
+LcCG9iQEb2xvHpx3rF0jR/LBd43Jydo28kdq6izsL7yWENu2xxhlYdR+NTOtFStHoSlfcxdPmA0m
+T7RLIqRExssnOSRyAaZo2utL58MrM9ptYxqeoPrV3V9EvZ0gtXJS26sh6g5yT+OetX7Dwii229Vy
+OhC/41arQa7hZpnOWscmpTQrPN+7tHZFXGcc+tbsumRPGEQt3zjPQ1tabpCWkuFs8qzEsxf5snv0
+rqIIdNVRA8aRk8AP1JqXW5paOxSWh5onheFFJik3E8lSf8a9U+FVoLRbpWhKv03Y7U9NCgVsi3ib
+PA+QfzrrNAsDaRMxXbu6Cuim5N6smWxqTq7OCvTFFOc/NRXQZCZDDB5BrOk0LSpXZ2tYt7dWxzVx
+T0qQGk0nuh7Gevh3TkGFhUA9gMVSufBunXMgc7h+RrfzSg1lKlCW6HzMxY/CWkxqAIAfepRoNjGN
+i7EX0wK1s0hAYYNJUaa6C5mYp8NaVJIHk2uewJFW08P2EabEiVV9ABWgoC8AU7PFXGlBbIOZmZ/w
+j9mM4Xr7UkXh6xiff5alvXaK1M0ZqvZx7D5mV1srdMYUcVONqrhcY9qCaYTVJJbCI5JNrY9qKrXT
+ESjH92igD//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0034/full/!100,100/0/default.jpg</Url><Caption>29376_0034</Caption><Caption>Felis Concolor, Linn. Cougar (female, and young). (v. 2, no. 20, plate 97)</Caption><Caption>Exhibit</Caption><Caption>plate 097</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="50" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0017;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAE0DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2KAbQ
+BtJ+lXlXiq8C4q4orNLQoAtP20oFDukalnYKvqTimAm32o2io57u2tYfNnmjjj/vM2BXKQeLbnVf
+EkVvpsanTVbYZWGTMe5X0A9aTkluNRbOv2j0ppUelS4oIqiSm0kQz836UjIM1ZIqJhzSGRRLzVnc
+EQsegqGMc1Y/gP0piKF1rljZ2ouZJl8rdtJB6V5b438S6jrHiOHSLGYwWONzsp+Zu34D/PSsLV9R
+lnvdSBlaSKO42hWPBbPOPof51ajtX+1rMzhTcv5jH0jQAKv4kGuSVRy0N1FLUtasbbR1DXN3PdMs
+XlpBvO09OP0/Ku/8DaNdQ2g1XUoliuZ0xDbr0gj9Pqepri/A+kxeJvGV5qk+ZbOwYLEr8gvzj8Op
+r2WtKUPtMmcuglIa4H4jeLbrTNPu7DSX23yQCbeuCQocBgPcA5rD0vxDd/8ACYT6hc6pONJh0pbh
+AxJR+PmJ465zW9zM9YIqJsZrlvAXjm38b6bcTJF5NxbybJI854PQj611D4zQwGJ1ov5/sumXU4/5
+Zws/5AmhOtV9bG7w/qK4620n/oJpdBHhuhKl5eLBcqVkMgkfd3+bcT7/AFrX8UXFpCymFiWC7EVe
+SeemK5PRzIYvMDATrkqxz0Bzgn6c10nhmz+2NLqV0wcgHYD/AAj/ABrz5+4zeL5hfBt7ruk6bcw6
+e0UEcj+ZJJJHuKn3PSrt7488VWMnlC8hmL8BvIHy+/FX4Pn06dVTavmHfj1IHNYen2C3fiAxXMix
+wxDexLfeX2rONefNa5pyxtqdP4S8IS6lc22sapI7SxTPP83O8uACD7ZGa7bxBoemajoN1aXcKpbF
+Mv5Y2kKDu7fSrmlT2s2mxPatmHGAcY6VYumRbWUyDcgQ7hjORivSh8Jyt6nk3w88U6PfeNrrS9B0
+tbSwFrjfgBpChGCQPqeteqv1rxf4f6hpmo/Fm7k0rSmsIFtJAyucMzbhzjtXs0pwRVXEhoZU5Y0l
+00ctlNG3KuhU49CKz9WmEFqJWkkQKc5TFc//AG4/kmRJpQhB+8orO6tqS5a2PIbe0mM72ybTF5nz
+AnBwMgiuha7hhltxax/Z7QDbM235R+NU4EW2vrmbzTFvISOTAIDZ6nPbv1FW4jFbW97bTubgeWZF
+KgYYknB4Jrzpy5pXOmOiKVz4klvtbGn6XJJFaQA/MoOJH9W9q5668aXVprZAWNTEWiDMMt6EkdK7
+bQdGg02wOQGkc5kfH8XUj8K4XxB4etotTe4Visjku8QO7B7n2roioN2aI5maQ8XNb3aMxnmnQh0D
+yYVT1yAOK958J+JF8RaAt1IFWZRiRB/Ovmu3jhinae5XdIf4QcYroPDPj280vXIYrVo0tGcLMhHy
+kd61jK2iIep23hfxHZ638YLmOxsEt4Le1li8zZh5W3KST+XFeqyHkVzWlaXolprEur2loI7q4X5n
+DDGDzXSSHODWl9BI5bxpM0OnoQVHP8QyP5GvOH1ktHJDIUdSDtXZxn9K9R8T6c2oWSpkhQeQO9eR
+apYL9vS005SctsLjnJ7n6CuOafOWkXo7e5ktd8IwCxban8agYxzn1qppGmahHPLFd2piEvCEEYAF
+dbaRrpdhFCHEjqDg5+WsfU/EFxPut7dkIB/1y8c+g96FFNDbZcmuVgj+zWocueNwXlfwrhvELrbT
+MWkDSEYxuztHoff1rWOvW2naW8bzI107EZAyQPr3ridRu/tk5ydxJzyK0jB38iTPuJyx2qT8xyTj
+rWhoOlSXdwGUERA5ZzWhpHhq4vyJnQrABnJ/irpE0ZrePC7kX+6honUUdEOx1/hi6t0uILdJX2ph
+RuQZP416axG1cdMV5L4Xtliv4yyORkdVNervwqgdMU6bbiwtqRXVr9ttnh3lN3GRXN3XhaS1hZrW
+MPKFxu7ke1dZGasqciuh01LUm9jxHVU1G1mMLwk7h5YJU5J46Cs+706awtmjeCSW5K4Xy1JVfb6+
+9e/MiN95VP1FNMUYGViTI6cUvZoLnynd6Jqs0iytaSkn7qhDgVq+G/AmoapqiRvC64w0rMOFFfSp
+C94V9uKegx92JVz17VXKx3OHtfB8NtZxwLHkIMZPennwkMAJGgPqc13BppNZ/V4j52c9pWgrZEsw
+AJPIB4rVkxkCp2JqtMfmHNacqirCWrFgJxVpTxRRVR2Ex+aTNFFMQoNLmiikAhJqPcc0UUwGN0qn
+MTuooqZDR//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0017/full/!100,100/0/default.jpg</Url><Caption>29376_0017</Caption><Caption>Bassaris Astuta, Licht. Ring-tailed Bassaris. (v. 2, no. 20, plate 98)</Caption><Caption>Exhibit</Caption><Caption>plate 098</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="51" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0050;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD2tYQo
+zzTxGGUEZwfUVMBS4pWEQeVTTFVkisjxHqyaFoN3qLFcxJ8gboznhR+dS9NQM/XPEul6DLHDeSOZ
+5BlIol3MR6+1SaJruneIEkaxlYvFjzI3Xay56cV5PYW1x4hkuLya7Ml/kSbpOmf7vsMcV1HgnRNR
+svFAvfKkFrcQMjnsD1HT3FclPEOdSy2NZU1GOu56R5XFAgqwFpwWuyxiVTBSG3q5ijbTsMoNAApJ
+zx6c1F5Ks2MPz6qRWntpCopWAyzZAnvRWgV5oqbICcUp6U0uEjLk/KBk1lyeIbGN9hkG7uAelXdC
+Zq15T8ZL9yNL0tWwjuZnGeuOB/M1d1fxVqNv4xgntbwHS1jAkhGDuOeQfQ45BrjviZq8Gr+JbCSB
+gUSDaRuzg7if8Kwq1E4uKeppCLum9ibwcrQ3cysDhiDmvVNBhSG6kFtGwgKASM5wd/Xp9DXm3hq6
+g8iR2A3RNjr6V3mm+IrUF5/NjE1yFd4y4+U4xiuHDNObbNa+h1mOacBWG+o3UgzG6L9OcCmW+qzf
+aWjmY7B0cetempq9jlN+lrNN1csf3LxsMd+tRrrG1tkiZfp8taLULmrTTVIakCu4wt+dTwXcdzwm
+QfQikVceetFKetFSMpX2DoUm7vEM8+wrxm9tkM0pM79T9017LrAJ0K4Cjny+K8Lu5giyTMQAhJPB
+6CuPFN3SRpTKTWvk3CtFKwI5+bqaTU9LF6I7mNwkwPzA8A0WuoJqZ3wHgcfMuOnf9afe3Is7bLAs
+2flXIO4/0rhbmpW6m3QtWluLa2lWKYmSQgnZg4Peo7zTkkkUrPNNtUbixGT+QrEhTUb9i3m+UrH7
+qHbW/pXhR5ZlkuZ5GTH9/rRrF3ciWmyW31SazjCRXMitj7nmZFdNpfiu3KIt4WWXb1Ukg1yX9lwQ
+63tAURoN2W4AI6U6C6t4Lh5Fhku7g/KFjTCJzkZPetqc5JaNkOCvqd1/wkVkJRh539z0/wAac3iX
+Tov3qzSDrgAHP5GuNnjcWzXF7IkK8naDiufGuz3l8YdMtkcRKcyyk4x9K6KdSq9xOET00+NJSCUj
+kKds4Fa/hbVby/1XDxgRcknPtXkEPiV7e+EGpW4jxjmMkD8q9g8F3EE7K0Me3jrWkXVcld6CcYpa
+HbEc0UtFdBmVrqJZtPkib7rJg/lXjuq+G1M52MUjBI45Jr2UjfCV9RiuavtLySQAV69KzqQUlqVF
+2Z5YPDscCl42ZFXn5ep/Ksi6kR9QFiRvXIUNjJ3eor1K4sFWIjb0rEbSQqh44QpByOK4KkHc3UlY
+4PU7iO1nSFGxsYFyPatFfFd29rHbWts3mZBDEY57VtR+Emkunl8xkDnO0L0/Gt638PRRwJGkYZkA
+wzdSaiMFZXQpyu9znbKCXWczX1qsLKRkKCMkd8Gt2DT44IyY169SeTViW0NtKiO6jPJOc1fjhBgB
+jGcjOK2jFLYVzivEenf2jZtGgb5fwqj4NtoPD3mNfWjTbicsuOK7WS1iu1fbJvZThgvUGq6+HzMw
+LK230Faq9rD0OA1/S21zxBJd2sDw2x/vDk16r4AspbeNNytgD+IYxxTrHQlUhRGMemK6zTrX7Mo+
+UD2ArWClfUibVrI0M0UmaK2MiGNvlFOwrdVqCMkKKlBoAR7S3kHzRioX0q1c5Kc1aBNKDUtIZROk
+W20hQVPqKrnRrcqEZ5s4xmtfNHWs3CL3QXaMM+HdOeVHYSsyjGWOavpptoF2CJgpH0q5gDoKcKqM
+I9g5mZcfhzTIm3RW/lknJKEjcff1/GrqWFvGAAuQPWrNNJq1FILsaI40+6g/AUbvbFGTTCTVCFLC
+ioWY560UgP/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0050/full/!100,100/0/default.jpg</Url><Caption>29376_0050</Caption><Caption>Spermophilus Ludovicianus, Ord. Prairie Dog, Prairie Marmot-Squirrel. (v. 2, no. 20, plate 99)</Caption><Caption>Exhibit</Caption><Caption>plate 099</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+<Column x="52" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=medium;fq1=Lithograph;sort=istruct_caption_image_title;rgn1=istruct_caption_image_title;select1=any;c=sclaudubon;q1=American;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sclaudubon;entryid=x-b6719890;viewid=29376_0020;debug=xml;size=50;chaperone=S-SCLAUDUBON-X-B6719890%2029376_0038</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABLAGQDASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3EQj0
+pSiDGSB6VMBQxRRlyoHqagZCYR6UwwD0q0cUzcKWwFfyB6UnkD0qzS4piK3kD0o+zj0q0BS4pgUj
+bD0pDair20Um2gZnPbKoyxwKj+yq4ypyK1CtNKCiyAxm0yNjkqCfpRWvsFFTZDuTCql3OiTLG4yu
+0nH+fxq4tcj42vX09YbhQNuCpOamo7RuC3N03sYVED/LjGfas69161tQJPNGCMkZry2fxnLEjLHJ
+uDZz9awzqmpauWhgjeQp2HYVxyrSexXKe822uWk8YbzByPX2q5Dc+fhkIIYZH09a+dU12eOAESMG
+UbSOevpXpnhjxbbpYRC6uY0O3lnYAL7AVdKu5StIlxsekL70pwBk9BXNr430KNC0l8No43hGK/8A
+fQGKydf8aafMbSCyvVaORm8wgH+78v1HX9K6XUilcIwbdjsbPUIL8FrfeyDo5UgH6ZqzXCR/ETwt
+oxFg145mGNy+Wc5x34xWvZeONGvyBBMxyeCRxVKStqwaOkpCKqR6nbSnCMSfarmQygjvVXXQLEdF
+KetFAh69K4v4haadTtIEFwYdhJBCbs59eRXZr0rnPFEqKFWQ4XaTjA5/E1hiJctNsuCuzxCXQ301
+282QSr13Dv8AnWtoniez0gSQpcm3ZmBcSRjNQa1qPmMyR2F2Fxkg4x/PFZ9z4bc2D6ncGERRLkxH
+nI643eteeqjfxaG/LbZGhrh0fVfKxf2doVbcZI0bLjPchsfjiubGr2GkasDbRLqCbdrGVd4H0zWy
+mkaK9pHdDRL4wMgYuG65GcDA5pbLTdOvJWjj0W6t4wpIknc7Sew4WtEratmfNd2SOi0XxfYvCY2m
+jhjccw/ZVUZx6kmnw6NZXNtI9gokRMnLzDjvx8vFcFLfx2OqLbNBDJFnnyiSQPrnrXcPp8EtgBBc
+sIyu4oj5/wDHaPZ3V0y1Oz1RkS6JFqr7baeJ3i4lkz0+mOtVW8OX2mTeZaXio3YAYP5ZrXtp/JUN
+byeaBnLIuGHqNp61oQamLqHMdvHM6tgjzdpP6cVLVSL90ttSRa8O6zqGnMsd/wCVdRt/EPlZfwr1
+q2kWW1jkT7rKCK8eXxI1vJ5cmkMJAPmxIGH8q9Z0m5S70q3nRdqugIHpXVhpSbakY1I21LLdaKD1
+orquZAp4qhq1sLiLlQQPUZq4pp5KkYNKSurAnY861S0AB84sYvRUzn/AVhppmmOCqhVGc7W9a9Zb
+T7SQHMYOe5qi3hnT3feQ4Ocgg15lfB1JO8GbxqrZnmd/4fEkG5ppQMZ++cYrkr/w3cuga2nMjZ4A
+fkfga+gP7FsvL2OrMvfJqB/DekO257dCTg9KVOhiIrVpkuUD5ug0HV7a+WSQXSsp4YsRivQdIW++
+z4mxISP4kU/0r1EeHtLViwVsHqCSR+RqddGsPuogGP8AZH+FdkKc2veIcl0PJZ9I1Bt89vGgcAhQ
+Bjr9KzfDnhvUYLueW6tgpfoQxBHr9fxr3FdIs1HEYp66ZaKeIxV+xGqjtY8iubfVhfR29us/lDGR
+GVBP4mvWtKhaDS4In37lXnecmpFsrZH3CIZ9cVPkYqoU+V3CU7qw0nmikJ5oqySJWp4NVQTkc1Kp
+PrTuIsZozUQJpwPFTcLD80HB6im0uaOYQ4YHSnZqPPNOqrgOzRmm96SmA4mmFqDTDSuMYzHNFRSs
+Q/BoqWx2P//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sclaudubon:B6719890:29376_0020/full/!100,100/0/default.jpg</Url><Caption>29376_0020</Caption><Caption>Mus Missouriensis, Aud. &amp; Bach. Missouri Mouse. (v. 2, no. 20, plate 100)</Caption><Caption>Exhibit</Caption><Caption>plate 100</Caption>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sclaudubon:B6719890:29376_0038/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>John James Audubon's Birds of America and Viviparous Quadrupeds</Full><Brief>Audubon Birds and Viviparous Quadrupeds</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001.xml
+++ b/samples/data/s/sdlhomes/Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001.xml
@@ -1,0 +1,1625 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">
+
+  <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>results_nav.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>displayheader_results.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>results.xsl</Filename>
+    <Filename>reslist.xsl</Filename>
+    <Filename>reslist_result.xsl</Filename>
+  </XslFallbackFileList>  
+
+
+  <!-- Custom OPTIONAL XML for top-level file reslist.xml<2> -->
+  <CustomXml/>
+
+  <ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+  
+  <DlxsGlobals><CurrentCgi><Param name="cc">sdlhomes</Param>
+<Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="start">1</Param>
+<Param name="type">boolean</Param>
+<Param name="view">reslist</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="q1">Residence</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sdlhomes;fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;start=1;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;select1=phrase;q1=Residence;c=sdlhomes;debug=xml;size=50</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>d5d53a88c6f5cda6d4d175d711e31d0d</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/reslist.xml</TemplatePath>
+<TemplateName>reslist</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<GroupName/>
+
+<JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260765</Url><Mode>login</Mode></LoginLink>
+
+<SearchSummary/>
+<TotalResults>10</TotalResults>
+<Next/>
+<Prev/>
+<Fisheye/>
+
+<BbagOptionsMenu><UserIsOwner>false</UserIsOwner><HiddenVars><Variable name="lasttype">boolean</Variable>
+<Variable name="lastview">reslist</Variable>
+</HiddenVars></BbagOptionsMenu>
+<SortOptionsMenu><HiddenVars><Variable name="cc">sdlhomes</Variable>
+<Variable name="fn1">sdlhomes_date_construction</Variable>
+<Variable name="fq1">1910 ca.</Variable>
+<Variable name="view">reslist</Variable>
+<Variable name="rgn1">sdlhomes_present_usage</Variable>
+<Variable name="select1">phrase</Variable>
+<Variable name="c">sdlhomes</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="type">boolean</Variable>
+<Variable name="q1">Residence</Variable>
+</HiddenVars><TotalResults>10</TotalResults><SortThresshold>1000</SortThresshold><ThresholdExceeded>false</ThresholdExceeded><Option index="0"><Label>(None)</Label><Value>none</Value></Option><Option index="1"><Label>Photo Date</Label><Value>sdlhomes_photo_date</Value></Option><Option index="2"><Label>Survey Date</Label><Value>sdlhomes_survey_dt</Value></Option><Option index="3"><Label>Photo Negative No.</Label><Value>sdlhomes_photo_neg_no</Value></Option><Name>sort</Name><Default>sdlhomes_present_usage</Default></SortOptionsMenu>
+
+<ViewInstruct>reslist1</ViewInstruct>
+
+<SliceSummary><Start>1</Start><End>10</End><Total>10</Total></SliceSummary>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;page=search;view=reslist</SearchLink>
+<ViewTabs><Form>graphic</Form><Graphic name="reslist"><Url>/i/image/graphics/display-tabs-C.gif</Url><Alt/></Graphic><View name="thumbnail"><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;start=1;type=boolean;view=thumbnail</Url><ImageMapCoords>0,11,130,34</ImageMapCoords></View><View name="thumbfull"><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;start=1;type=boolean;view=thumbfull</Url><ImageMapCoords>131,11,258,34</ImageMapCoords></View><View name="reslist"><Current>true</Current><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;start=1;type=boolean;view=reslist</Url><ImageMapCoords>259,11,343,34</ImageMapCoords></View></ViewTabs>
+
+<GuideFrame><!--GUIDEFRAME_XML--></GuideFrame>
+
+<ResultsHeader><Row><Column abbrev="sdlhomes_id" section="1" parent="section-1">Record ID</Column><Column abbrev="sdlhomes_street_no" section="1" parent="section-1">Street and No.</Column><Column abbrev="sdlhomes_historic_name" section="1" parent="section-1">Historic Name</Column><Column abbrev="sdlhomes_common_name" section="1" parent="section-1">Common Name</Column><Column abbrev="sdlhomes_present_usage" section="1" parent="section-1">Present Usage</Column></Row><Index>1</Index><Debug>0.000334978103637695</Debug></ResultsHeader>
+
+<!-- "full" is used to display full record. -->
+<!-- and to differentiate between additional "brief" results -->
+<!-- used in bbcustomorder.xml. -->
+<Results name="full"><BookBagToggle>on</BookBagToggle><Result resultnum="1" sliceresultid="0" marker="5536d312bcb5e17f0911755b9b3bc5a3"><EntryIdSplit><viewid>SL020601.TIF</viewid><path>/s/sdlhomes</path><entryid>x-sl0206</entryid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0206]SL020601.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0206___SL020601__TIF</EntryWindowName><ResultNumber>1</ResultNumber><SliceResultId>0</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/510,366/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>510</w>
+    <h>366</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">SL020601</m_fn>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0206]SL020601.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0206-1</istruct_isentryidv>
+<m_id class="fieldsRef">SL0206</m_id>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">1</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_m class="fieldsRef">SL020601</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:36</m_flm>
+<m_caption class="fieldsRef"/>
+<m_iid class="fieldsRef">SL020601.TIF</m_iid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<width class="imgInfHashRef">2040</width>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<height class="imgInfHashRef">1464</height>
+<md5 class="imgInfHashRef">1e04640a6f1714ada4b5123834bb7648</md5>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">3</levels>
+<size class="imgInfHashRef">406999</size>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2013-02-08 18:59:36</modified>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/02/06/01/SL020601/SL020601.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">SL020601</basename>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>3</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0206 SL020601.TIF</Caption>
+</Captions><ItemDescription>313 N. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQADBAYHAggB/8QAORAAAgEDAgQEAwQJBQEAAAAA
+AQIDAAQRBSEGEjFBEyJhcRRR0RWBkaEHIyQyQkNSkrEmRHKiwYL/xAAYAQEBAQEBAAAAAAAAAAAA
+AAAAAQIDBP/EABkRAQEBAQEBAAAAAAAAAAAAAAABERIxQf/aAAwDAQACEQMRAD8ArXFPG2vvxBew
+x6xewxQTyRIIpimysQM469KCxcVcSz3UcA1++UyOFDyXjKq5PUnOw9aXGbIOLdRWC4e4RJ3AdlIx
+vkqAewJI9etAAQGBYHHyFWSYrVLuLWbbR1vYeI9R1CEOEmmtLiRE6fyy27+pG2cUN0DiziiDXZ1F
+xLqX7Kp5J74cqqSvK3MPKDkgHPzIO9VHTy6KskN0xOC0kUTFGQeuRg9uma7jjt7LiBRfwyG3ch3R
+urKd8kY6HrjFTAe1PijUedom13UY7lrlyxjuVMSAdBlT0B5th1GKD23EGvTzOPty8AVWctJduqkD
+sN+p7Cvt9c6KmqMsNpdjTwgAha4UnnBJzzco8uT0xmhDGHxs4Cr1whz+ZpgtNvr+szWrIdSulUFQ
+bh7qQBATv33+gPzq96JqGvXcV1b6ZL8exZQ14JW8JyRvy5AIxgbDbrk71ndjdarpWnW+rxmWW0+J
+GY5PNGzKMZZe+2AM1d7DjK75NHs/hoF/XpIYLBT+uU75Y9AegwB94qWDU+HLd7bRrMXcrzXMgxI8
+jZ8wyTjsB8sUb5E/pH4UAurq6Nmk1pbGMF0eNZWUcuDhhgZ7HpU6J7yeZx4saIsZw0ac3mz82O/b
+tWMQS8Nf6R+FcSGGLeQxp/yIFDpr22isIrq4lndZHVOUtg5O2MLiiEMUSKCkKIfRRn8aYG2kibBj
+OV+YBpV3MfOPalXNp5X4yvUu+I72KO2hhEV1MuYlwz5f+L59PzoHJbyW7gOp3Ab94HqAR096I8Rh
+m4r1QLzMTeTDCjr5zUC4vZ7sQfEEOIIxGmAB5R0r0zxHCvKvMgKEN1yMmierQalZ6rFFraTx3DwL
+gTgEhCCFbr0H47VG02SJNTga5tw1uJVZ0yQeXIJ3G/SjPFOtwa/xfLeC2h+F8PwIVRWC8uDhtwCS
+Cc9PyoK+ywLADGHLbgl8YPsKaMg6AKN/4RRDQ4rCXWF+1kmazXmaSO3YBiACds9u/tUKU25iQo5M
+vUk9/f17fLagcMod+ZowFGPIGOMj3z6/jU/T75heQhJvCj5wAZGIVRnvjflGT07ZqJcap8eiBra3
+haMcviRJyFwf6h0PvjNMRSNHICQFYEEbZx8sUHpKy12C+0a2ntr83str+0yLygNKI9nGO2x5lHpR
+D7UXRdNsJLhHeIQrGrqQecsAQPv336bVkHCWtWGnmV7WDUJ9WuIvBUcqsjOc7Y7g9wfuIrSZ9B4h
+1VdJjuLa0trawEZET3JYu6AAM3KMY26dd+tc6iXpttqMkVuLiCNGWTxI4DJ5lB3XxMDAI2+5at0Q
+kVeVzkjuFwKpmscQy8LkLLJDe3kjBpEjQqI12G5J22G3ck5OBVqttRtrqCG4gkDRTIHQnuDQPTfv
+DftSrlpUcg82Nu9KubTytxJIrcT6kjs7xx3sxVc8pGXPNuPXvQlpg6MnKFXJOy/lRLiUf6p1UIMk
+3k23/wBmh8Z5XDKh8vvXoniGcnbGRj505ZTyreQMI0mKvlY5d1b0I+VGLKx0q+Syslu54b+a5KSM
+y5iRMeU+pzmg8tq0UsUZIyx3wMY8xH/lA4+qXME0nw8aWrG3+FcKMkrjDdehO+4xQ5iWwSoHt3qU
+C8MXOjKOY4IIznFcRqzzJGCMscb+tVTQUE4APpU+AvHGoXlKN5iG3yeldXFjJa6lJaZUtHgZ7Hyg
+5/OrRJpFhZaOLiWCSS5Ai6KVA5gM+h6j33qWoNcKceXmj2kdpDpGnPMWLG5lzzE/d0+W1WG1/SZx
+DfX0MAgsIY5GKFljZiOu4yfSqB4KRvPM9pMsMZzyvKeZie21XDQtLsZH065aNlDvk5lbYcretYof
+vOZlv3nBlZJF5mY5LlgMkn3NHeGEvrayms5vE+DjcTRSAgcoDYf7jn8c09eWViNXTTFa5DyRiTJc
+OuMkbhhntUC71mTSdWfRp5I2hFuXSVgFYE+bBPy2x99QW2OLVFLmTlcsxIweg+R9aVBNK1yW+hnn
+MrgNM3KM9AQCP80q51Wa6twPrx4rvL5bdVikupJFYuM4LHGx74ND9I4E1V7/AMO/t/AtijAyFg3K
+cHBwDk74q5ycfw6LxHfRDTRIi3Do4+IchsE7gNkA+1XfhrirR+LJZIIbGWCdF5isigjHowrrtxGV
+anwoNJntW0a5/aVXzPKmA3lPMRnbb/GO9A5eCdSjCSO6kZCsvKSfy616MvLDS7flluVROqqxUnGe
+o2G1KPT9JQggw5PTMg+tOqjzjPwLr3i4FkHHpMv1qPb8F69JcGNdKmZg/ISCPKffP516cOl2MgyI
+lPqDXa6dbJ+7FTqjApv0fcTXNytzFprhiiKeaRM5AwSd981co+E9c1LTYLC801IkiiXDSTLjnUbD
+Yk9a05bZQ6lVI5c9WP8AjvXUFxBPLPDHLG8sDBZVQ55CRkA+uKmjK14A1+ObmaK0lViCQJumevUd
+qOWXC+qW8tk0lrGY1k5pEWRfIMEf+9q0Ar60gKCvRafcNK8ktjyyK5VJC6sWXsc9vaq3xbwdqeuv
+FPbhEMIYhXYZIwNh9+a0bFfD0oM30Ph/VrCwMU9q3MX5tyOmB6+lKtCcbjbtSrFaeauJZ7+DibU2
+RZJV+LkARIiDjmPflq08H6jaaTdx381/qQkKENbm0yoz82GCfwpUq6/EaFFx3phjYmV+cDYCGUZ9
+vLU6DivRZoTIZMMOzwMC3ttSpVkOx8V6U5YCcBRsDyNufTb86krr+msuVuk/A/SlSqBwa3px/wBy
+v9rfSolhJothLcS28oD3ErSuzBjuxyQNthnfFKlQT/texzj4gf2t9K+jVLI9Jx/a30pUqmj79pWZ
+/nf9G+lL7RtT/N/6N9KVKmj58XA+6vkf8T9KVKlWVf/Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0206:SL020601.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0206</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>313 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="2" sliceresultid="1" marker="5536d312bcb5e17f0911755b9b3bc5a3"><EntryIdSplit><path>/s/sdlhomes</path><entryid>x-sl0303</entryid><viewid>SL030301.TIF</viewid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0303]SL030301.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0303___SL030301__TIF</EntryWindowName><ResultNumber>2</ResultNumber><SliceResultId>1</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/508,370/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>508</w>
+    <h>370</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL030301.TIF</m_iid>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:48</m_flm>
+<m_caption class="fieldsRef"/>
+<istruct_m class="fieldsRef">SL030301</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">1</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_id class="fieldsRef">SL0303</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0303-1</istruct_isentryidv>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0303]SL030301.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_fn class="fieldsRef">SL030301</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">70beee6007d4d8a3fcc54a0467f12231</md5>
+<height class="imgInfHashRef">1480</height>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<width class="imgInfHashRef">2032</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<basename class="imgInfHashRef">SL030301</basename>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/03/03/01/SL030301/SL030301.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<size class="imgInfHashRef">409848</size>
+<modified class="imgInfHashRef">2013-02-08 18:59:48</modified>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">3</levels>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>3</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0303 SL030301.TIF</Caption>
+</Captions><ItemDescription>407 N. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="73">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABJAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABQYDBAcAAQII/8QAORAAAgECBAUCBAQFAgcAAAAA
+AQIDBBEABRIhBhMxQVEiYRQycYEVI5GhFjNCscEHJDRiorLR4fD/xAAXAQEBAQEAAAAAAAAAAAAA
+AAAAAQID/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBEiEx/9oADAMBAAIRAxEAPwAzw/xVmb5vnTV9
+XW1lLDSuyxwvbksHIHixsv74srxRXz8GUzQZoz1zQJy5UJMkstrtsR0HQnz7YQ4q3Mmqc5oaSyfG
+VD89idLMuo+kHwRcknYWwWyzL80hqpsoeAkTIj1TRSBdEF7KisxsdVrdjt37ZgK5Xm3ElfWGaozm
+ajpeXHKElnNgrD03YKbEgX7de2C8mf5rRxyVSz6oafSZllq9W9+guATfpgVT1dVRyZlDEY4ZDI0R
+Mg1CFUARRzASB3tq29++F/Qme5qf9qTltGeXJyiBzH7knxfsPPvhAYoOMM7zmsVYZa1YOXeTlSqr
+Ndj8rObDxfc7Gwxb/G85FYY6nMKuKIT7wRz/AJiggEAuRuB3sB1Jvtim1M8VYCiwaZIToTT+XJYb
+DpdWO4ttYgYmzGthkoy1IzxNSrFKYZ9mOkldI9z08be+AZcuziWuikWjrZw8pIJmm5nw6jbV16k9
+MQc/iHK5ifjJqkWUtFObgg3HpbrfATLoacV0MCSiKpiRZTMRsHbsRfoSTfxt0w5VGYg0VNWzoiGK
+VVdg1wfVaxuNiG3/AF3xIF6o4krDO0sGYyxsUZXp33Csu+2/cdxffBxczqhQUUoqWkd5FBIf5rqf
+84BZ9QyS0lakg5SI6sqPe6am+cH7gG21sEKSSeDJaWnKKGFTEY1v0N7EX++oX7A+MICNJWVVXDVS
+iefloTGbA3XbdgT0IJ9umJ6DMJ4sljNetSJ3QESBWYMD03G4Njiejhb8O1QpG4aN7erd7k2P19sQ
+UcktXkWUpEyAPGqkljdkC7i1tr2H64kFrKM0FbRklncxOYjIFI12/qIO4NiLjzjsWYINIdmiKM7a
+iL37AePbHYxrTMcgy2tra7NMyNLO4nqmTXEvzIhtpF7bXHY32GLvDC0n41nWYwRQiA1Qp0BQgqqL
+udJ7km3nbDzRTUGXJLA1O1PCp1KTvewubH63P64Ucirsrov9PZMzzGKJkmkmqmEiD1a5CVA9zYDH
+VlQ/iWLh/hDMp4JIxUVVVUaISBZ9UjKDYdCAPptbCnksNZDk3OgnnSJbNKqSMoYtcattu1v084HZ
+XSVvEc9DTNGY6JZWI0qSLsxJP72+2NJSkESVEMC6oUcrJBGLIwAAtbyd9/8AxgEtp54Z6Wq+IkmR
+Td4w2gm2/UWubXHn3xPUVSZlFG0LGFo1GuJxchbq1t+xKg/c774p5lDJSV8tKqu6wykbLfftf7bY
+qTVUUermIyncWKnYHwbbWP7YKZspzJY+IHzSbSFdCpGgne4FvY7YcZ6/Lwmmn5dRSVo0zxJs1+hI
+Hc77j29sZjR10RgYPURqD1XoGPnfBTLM0y6Iu9ZURoVN40D6r+SQL74IfKsGtyiSnqiGnLomu27h
+WHqHboL/AHwPqszpqX4GMgScqoDuG+WSzMVsT8vXr07Y9pnkzCJGT007AEXHUYoVnwj8QRZZJSa2
+eE2kLbWIubjv0xA+ZHKKqlhf0jQPzApuDITc/p498UcqnWGojg0FpKaN6b0i9rSsBfxso/XAHKsy
+m4arPhqm8lHKbI56jwCfPg9+h7YLZCUrOJM3rYVCpJJFcHqbR7n2ubYBkVwyghgcdj1lGrqB7Y7H
+PWmZcXcQzw8LViSSqsks5p0cG5tqIJt5Av8ApjPqzOVzP4Onn5q5PRII44lPqmKiwP1PfwMWaqgk
+zrNa2orZ3WngmlVL7l9LHb2GIsnoIsxzOGijg11EpVISz2Rb+1sdsZaRwJLJmdJOZKJqaNVCR9NF
+v+X26Xwxw5V8PNNNqAMjEhdPa1uvfpipwtw/W5S9XJXGD1xqq8kntfFXIM5nr66NJWYqIBKfXqsW
+Yj/GMgJmEFIlZJJJKgOtjYG5BvgDmy5fWIsSqysN9VwoP2xTzETyZ9UtPPOsD1GjlwyFQCSRf9sV
+s5y1KCipqmHnM0qgsrSNcbnf9sUSxJGkXK+HL7W2kU4lyKjpxmLc2Pl3bYSDY/fARXmE1Ml5wZgp
+vrvpubdxiWGvndJG5sn5ZAIZUPU28YK2eGNUjUKAFsLAYDS5TVPxfHmQCmmWMIfXuNjvbAzhBK2p
+p/iZqyURf0IoCg/XFeHjyoIvJSRm9Z8KLN/1f+sEOFZTU9RSslTGZIrete5GBuU5xBkmY5xGI9B0
+w8tCTb5PfztvftgnmcnJyiqm6lIWbb6YzQ5j8ZmM9XVMBqRRpU+EsMQa7lWcDMaQzkxg6ypAHTYf
+r1647C5wTVKckk9Ooidrt59K+cdjG560zJszmgzWvpFLcs1E50/Ut+2C/wDpvE9dxqhnaRUpoxIm
+k6V1Wt9+pxQraiWHNKxAy6TUSNYAX+Y4hGazQOXjkKPcWIUA46o3qeQJVLFzgA8TfMw8gf5wqUeX
+UnC9VG0NR8Ss6pTOxYflKt21G3knGY/jlYkrSisYMRvva+Pj8enMISSfmsGvd2Fh9rb4kQUrpBLm
+sjJOsaLUrJqL2DAEnF+rytcxyempoaiMJSxgcxZl9zc7++EavqFeZFWUPZAGcbAnrgxktetPRVlR
+K9lMOhfSSGNxt0xYLf8AD0zZlTTx1lOY4ggMazDe1/fEcHCeahahUnSTmFStpL2AJJ/vgcK2ikkG
+qRNYuRt/fBbhOsp480SplkPKQFV0xsxdiPAB8/tgpny+s/hzKooq6ygKQ1z6r9iPI7YQYpKk1JWF
+maJ6nnX3Ngf7YbeJc1pqioi5UDNoU3MkDqQb9r2wt0dRURVuo0ZaMA6Ry33J/fED5XcS0Iy6agcO
+zGIpqA2PbClyBWTy8nS0Q0tbTv06DFOQ5hPNeLLppBffTG21/rhhy+prcvp1pxkVVqOxLwi7j9MA
+X4IkP4JLYN/xDf8AauOwf4ekb8Pe+Tmm/NNkZQCdhv8A/eMdjnv1WU1mVLUZvWOayRr1Eh0xREke
+o4rNw9LJJphhrJPcx6ft1x+gB/Ok+uPJOhxrtIwaPheqFi9FNt0u4GLMfCjsdT0qL9ZhjZx1xKOm
+HZGJfwpKjgiGmNuh5mL8GVV8dPyhIqxnZo1b0kfTGvY7DoYz/CqkkmKnF+3qxbp8lmpk0R8oIP6Q
+WGNcHXEgw6GVigqX/mzb9t2Nv3xLHlkqtdahh773/vjUR1x9jph0Mz/DCSCssqnvbe+JVy+YA2q6
+hSetgMaZH/MGJG64lCdkdLJDROpnme8hN2t4HtjsOI6Y7GVf/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="73">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030301.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0303</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="3" sliceresultid="2" marker="5536d312bcb5e17f0911755b9b3bc5a3"><EntryIdSplit><cc>sdlhomes</cc><viewid>SL030302.TIF</viewid><path>/s/sdlhomes</path><entryid>x-sl0303</entryid></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0303]SL030302.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0303___SL030302__TIF</EntryWindowName><ResultNumber>3</ResultNumber><SliceResultId>2</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/618,418/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>618</w>
+    <h>418</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_fn class="fieldsRef">SL030302</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0303]SL030302.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_id class="fieldsRef">SL0303</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0303-2</istruct_isentryidv>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">2</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:39</m_flm>
+<m_caption class="fieldsRef"/>
+<istruct_m class="fieldsRef">SL030302</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL030302.TIF</m_iid>
+<size class="imgInfHashRef">563245</size>
+<modified class="imgInfHashRef">2013-02-08 18:59:39</modified>
+<type class="imgInfHashRef">image</type>
+<levels class="imgInfHashRef">4</levels>
+<u class="imgInfHashRef">1</u>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/03/03/02/SL030302/SL030302.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">SL030302</basename>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<width class="imgInfHashRef">2472</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">a76d46da45e057f05629b3350b7f699f</md5>
+<height class="imgInfHashRef">1672</height>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0303 SL030302.TIF</Caption>
+</Captions><ItemDescription>407 N. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="68">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAUEBgIDBwEI/8QAPhAAAgEDAwIDBQQHBgcAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcQeBobEWI0J0kbLBFSQzNpLRNEViZHLS4f/EABgBAAMBAQAAAAAA
+AAAAAAAAAAECAwAE/8QAGxEBAQADAQEBAAAAAAAAAAAAAQACESExEgP/2gAMAwEAAhEDEQA/AOfa
+71R1Guu6iq61qSol1KFC3LgBQ5A4B7VoTrLWEtHibVtWeRsEP7a42kZqBrkrx9S6oVYj+9zZx/5t
+S3cnhY2nfnk54xThNqdfpfro/wCc6pg8H+/yVKi6u1ido4/7U1VHOBlL1zk+uCe/yqsMQTwMCm+l
+WlxPEbqOFZ44Zo1kVlJ7/COOeew/OtobPK76Lq2uK0WqG91O4tLOUeMpuZGMobIPunjjHn9K6ZpG
+uJrWnR3lreTFHHYucqexBrnl9C/T9jDE19PAJ3luVhlbLx5AAXOfMHn55p90AulwaXE0Kpb392m+
+4gWXcAVJ94jPu5B+X0qho5cue8jdcDPc5/4iX/Wa89puQf8AHl/1nFbvCqJYXS3wnAXbJBMYZEBz
+tYYPoPIg0+ylrL2xN7fNdxgSuFAbIMx57YPpXk1/cGMnxZ1YE+6zkcj5+lZxqk95K0UoOxNmV5AO
+eR8+wrCZ3BaIxE8c7u33H0pHypjxks2sX0iu1vNcP57BMwIP5YqFda5fKvvXkySZGMTvtGfmDisL
+5LyJxIcF2OXjjdsFfLngA9uaiuLSS3WSCFZI5R+sBJ930Gc4GDx91RTZdI1/6Lv7i60m4eeSV3W5
+ZdzOX42r5n60UdDoItAZUMRXxmI2NuA4HnRSlm+a+ov8y6p+9zfzmlhpn1F/mXVf3yb+c0sNVnpI
+tA9vE8DtLM28vEq/4YHmT555Pyq1dGdZXHTDvbz2VrdW29ZGSZPfGORtYA88557VXrO4sFsJ4Xsp
+JbssGifxjtUeeVA5+ua0NDNJMzCPwYye2eFHp6mhCbXmoTaxqzapqss91C8pVxIwLBO4VT2GBwOK
+zeSGSATWyypIARMqcRAfskEck47k+fNaNNs45b6Nbm5FvDuG6fAIXHyzzTnqTTbe2ubaKDUra6gI
+3NPBs3k+rKpxn0yf4VuStfbD7SrJ7SC0j0y/e78IIqrtfLAYz3yR55qPb6lq08NzbpNHLLcS+JLI
+ibUX3VXaSO/C9l49Se1KenrCK7sVkt42htXJU5P6yUA494jy4+EcfWrpZW62yqsaBVxjGOMVnrIA
+SvRZ9Q027u4sPIhYMxlzsl+a4+EjtxVku7YXlvvhaW7IG/ZE48ROPLBAP4H5UltUaZuYpVbJ+Mna
+f6dqYxLNY3PjowYYIAHwsP60oJPxq9ciFTKC7hx8KDdhT2OQeCMetQhYWjtMUimubcYZUjyEkJ/b
+P/zjPlTzrjVbax0a2uru2ZhJJ4ayW52sDtznn+B8/SklnfSvaw3MMkbwxBcmR9hx9ASfu9KCrNrV
+0PoeJU0Bssj7p2PHuleAMEY7jH30Vl0pqL3WmzucEi4YExowGcA+f1orbl1fNfUXHU2rD/vJv5zS
+vjHenHUao3VWqBTtU3soJPl75pXLC0Xxefb50+57KDanvsxA5HHrTu2WyWxFzcTQ+Ix+AkZPz45H
+5Uv0m3W8neORFKxxl+3PFNbG0sLqORo9PeRkI91SCW+nNCDY3t/o02nC3ggeOYgb5Vy27nPY4xUz
+SNc6fsvY0vdOkuYok2yqPdMh5Oe/B5FSLDStLvIXkGnsgRiCJAB2GT51gx6agWEyWMmJoxKv6sdi
+SB5/KtC6B017NLpVs8UbRW77mRGYMyqWJAJ7E1YmtwkAkWQMCOMcfhVI0/TZLPVoIbNvAt1RZSoB
+yc84POKfdQa7a6DpcF1JBLK7yeGyhsYGCQc+nGKMkyiEyhVeSN0UYGE2kfjQzNJbJGOMc5FIz1HE
+lxZxysie1QRypz339v6U9hk2hCcEj186PsPKr9bReNo1paEkxrIzhWOeccmrJpPSEGg2yspSeYnc
+qZJEfAyefyPrSXraRXt7SVYgg3Mdq9j2pPfahcXkhu5faEkdcsGXBxjsRnyxxUf0y+auGP1dc6ei
+Kaa2Qi5mc7UQgDn50VXugbiW66fkfOQty6DMh7ALRWHZuCabgHUjgdVatkce2TZAOM++aWSStN8R
+OF+EelMupuOq9X/fZv5zSk1UjPumI/Ek1AjHiezFY8+bE1OtdJ1G2t7janvsE8PBHcHJ/pUHpm5j
+tXuGkKjcFAyfrVnt9dtnMmCMISCcd8elHUmT2jSHXJbWFhEVnBYOquORhQO/0JqBfaVqzNaeHYs6
+Jbxox2r3Gcj8asmndQWmoRu0Q2mPggjBOKbWGr2l3aGSKRXibIO49j689q2pfqmwSR/2s6hgSsMY
+OPpS/rm2ur7TLOKwDNIJSzjcAMYx5/WlM3UFppuv3XjbypVPeTBHw/Wmp6004xBGknVMZ2lMj69/
+nTaId9qFrustDq1kkYJlsIIYnDYI8ROTj1GTjNT4PtO1qCVh7NZvE4wY2Rvr3zkUm6qNvc6zNfWk
+viRTkMRtIIOMH8qTSTF4UjKjKE8juc0tUBLoV31M2t6NaTSRiOUF96qcjuBxWnTryW502O3kuRPI
+qfEWy3y488AfhVae5jt9PgihbeyjJC+Xmc1nF1ZqUUHgItsqbdvEABI+o5pP0x+o4KeXffs3ji/R
+d3dmO+6kIxgYHA7fdRVc+zPXbi46XkDRwII7p1UImBghW9fVjRSBrkF7VPVek7C617U5ZJLgM11I
+Thlxyx+VRP0K00zBPFusH/qX/wBaKKbdqy2H2XaBL70kt6/B4MqgfgtbE+zDp9/ajm8HhyFFxKOA
+B9KKKnlk7qByplz0zZW93LEktxtVioO4Zx/CtDaJbxgxrNPs4ONwwfuxRRVabaxoVtgnxJgR8x/t
+Wdv05aTTRxtLOFJxww/2ooowpA6WsRK8Xi3G0MR8S+v0p9p/2d6LOoeWS8Yny8RR+S0UVPNdRJrH
+0VoEGYxYI+P2pDuJ++tc3SGgjcw06IEemfWiiuP7y37W/MFrj0jomnWWlSxW9ssaGdmIBPfC/wC1
+FFFdGK6hmH03/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="68">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030302.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0303</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="4" sliceresultid="3" marker="5536d312bcb5e17f0911755b9b3bc5a3"><EntryIdSplit><path>/s/sdlhomes</path><entryid>x-sl0617</entryid><viewid>SL061701.TIF</viewid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0617]SL061701.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0617___SL061701__TIF</EntryWindowName><ResultNumber>4</ResultNumber><SliceResultId>3</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/520,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>520</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_fn class="fieldsRef">SL061701</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0617]SL061701.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_id class="fieldsRef">SL0617</m_id>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0617-1</istruct_isentryidv>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">1</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:39</m_flm>
+<m_caption class="fieldsRef"/>
+<istruct_m class="fieldsRef">SL061701</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL061701.TIF</m_iid>
+<width class="imgInfHashRef">2080</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<height class="imgInfHashRef">1488</height>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">5c7d9bc65058c16af3a8c75681f7d09c</md5>
+<size class="imgInfHashRef">421754</size>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2013-02-08 18:59:39</modified>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">4</levels>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/06/17/01/SL061701/SL061701.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">SL061701</basename>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0617 SL061701.TIF</Caption>
+</Captions><ItemDescription>204 W. Henry</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABQYABAcCAwH/xAA2EAACAQMDAgQEBQMDBQAAAAAB
+AgMABBEFEiEGMRNBUWEHIoGRFBUjMnFCocEWUrElMzVy4f/EABcBAQEBAQAAAAAAAAAAAAAAAAAB
+AgP/xAAZEQEBAQEBAQAAAAAAAAAAAAAAARExAhL/2gAMAwEAAhEDEQA/AHW+1a/TVbyIXsqIk7Ko
+EmMKPLGKGz9TTLEzLrEufZ9zD6DmhXUkDP1FqbzFniE7bVBAC9v6cfN/PehclzcPpgaG4Qnt4ZjC
+/wBx/msSA8erLuTG3UrtGAz+8YI/j19q836v1AqAl1ds27GckZ/xS9balGwPjogcJ5/49KI+OPAU
+OCxIHLHhSfSmAqmu6pIp/wCrXAdeSgJ3du3PerFrreoT8jU7hvUBsFT6EUvtatfrtj4VP02IXli3
+AQD1Pn6DHrRi+6WkhtbZ7eRvG2nYOVICjgcHA4+nl27MBL82vgOb64+r1z+d3eCRqE5x3/UpEm1e
+9XMVwSYk5M6A9u3zL5H3qqmrRWiF4pUkzwAH4Iyfv5UwaD+fXhKj8fOCw4JkNULnqDW3uFgt72Y+
+bMknzBaSI9dW4t1aR1ikMh/TBP0P1rm36hME8hDlg42ZAzjB7iritCk1vUdhVNRuTIeB+oQR9KAa
+h1BrsBlKa7fEIOCHAzx5CqkNyNUVp5d7AKAA3G4nyAHlXFzYNasSGb51JZXPBPt9/XNTBqXw6vrr
+VukYrm+ne4uPGkVpJDkkBjj+1SvH4Yjw+jYxjH68n/NSsXqlPqe4ibXNStmJDiVm/wC2T6e3alS9
+limVW7N/tyV3ex9/59abOqkWfqK88OREmSUryxywPfihL2+LPEoVghMcgCkDg4BPoea6RkJtLSKa
+aBww27QWbuMEZ+/FedzqBhK+DISqvwVUsFI5JPl/99hVjTYbXwwZ5CHRiSoOCcDAGP6s5A+9GtI0
+uxv+pHt4oIQkEXivnn5wVxgZxnnmgYNCt4E/DSiOULbQiTww24vI5J3cd+Ae/maNLdhYTNKA80Ss
+AhbCrg/t9yfOs36tvZ9NXwbSd7dkuvCZkYjcqgsO3OctRjoW4gbp+9uruVp5DKIY0kJPJUYwP5NA
+I6g1ODEr3VsttPC4QmKQs0nqMbQMj+ewx5ClyOzsNbYRxXEdvNCrOSIyfEUAkgKOd2ew960D4kKl
+zFZwsSwWM4yhUA7hyB28qymG1kB8eNyCjNsdTgjBqxVRGJ7jJ86sxAOCuD9qZYukwzaZG0rPJfok
+rbUHyBmI7efbPlVXqLRR07rk9kWdkQJhmxk7hnyq6COmSJLptsuChTILBSdzZ/vXdwL6VS6IpSMZ
+aQtnCj696r9OG4k3Qxxybdx+ZRwe3HP186PTPaNcm0B2eCRjcOS3v9fKsh/+G+7/AEkodtzfiJOS
+MZ59KlWOi/8AwGORiZxnnn0PPtgfSpXK9Ui9WWU9x1FqBcL4BlIVgQMEgdxg5PvxQSN9VeO5RLpS
+hXMgdgzEYwTu7EZUj2x3pp1c6dN1FrK6pMUhhk3I6zDIOB8u0HPvSTcX0Flfyx2ksM0blMO8ZwVL
+fMCM+pB4711jKpDctaEuwLsGXDYz8pycnAPr5V76PrNlp2qNfym5dijDEcbYDFhwc9xivBtRtYiI
+1mjRVmO0heCA2AfbgE49x3rue0/MtC01rREFw88sbsrY34Xdz796o71XULHWrt3WO8UBjIBFAM/t
+CjueAMH70e6VkWzsbc28MjBZzL+HdGeV5MBRjGFAHfk1m9ybu2cHc67sjduOTzRHSdK1fVIZXtY5
+JBGcMBJg9vQnmmDYdT0m86gjE+qCSzWJSBgrL555VQD9s1m1zb2Gh6gNKnu3lizuecQMuzcSSCp5
+yAc0M1TQ9W0iCKa/geFJG2qS4OTjPkaDLKxMnPY0kGtFYNU6h0SbRr21ubOxjjjciYKflbzU4Oce
+1AviQ/i9V3iE7WPgj+Bhcn7UhqN7HOCfXFXIriQTMZpJJeAPmJbjHHemKa9BmgSyaF2bCTlm+bAK
++o7Z5FG1tIn05WWBpHwWdJSB9j9u9AdF1C0it2e7td0UT+Jv8IHt3XI5Hl96ZdZ1uxXplJrGVZnk
+wuVGQg88gjg98dvXyqB16CRYumV2srBpnb5ey5xxUqr8M5zc9HRHaVCTSIB7A8VK53qlvqDpmGfq
+u+vzZlzKx3Kz7d+P6lPbtjIyD7YrO+oE/AXs1tEgSA8qrKSyn2b/ACKY+uN46r1TJYK03rweBSTd
+xnxRtJOT2z2rr5ZU3hfl2zg+fvThBqcVidNs4mt1SFWldo1IYExEHOeOc96U5U/bnuea4EaxlvnI
+xzgjGftVovatF+Kkga1TMaxqC2cndj5s/XNPPR1jJp+hxy3skcHi3BdGLAMBtHORz2HakCCTflYR
+iIEkBmGf7+ZxTZYLHfWsX4uVpLf9zELgLx249qlVz8Rr9zeR2qzmSOLAJBJQsV5OPI4PNIke7Y5H
+JPlVzUGimvnMRKpuJBckgjPGM8+neqW3njPFWAlpVnd3au8VtPKgOCyRlgD6ZAqzqdjcWF3JBcwv
+DKAjFHGCAQCK9tE6s13Rbc2um3TQwyNudEUfMfXJ7GqVxqN5qt8095K80r4BZjlsAYH9qD5cROIh
+IqnkhR75zX20eUuLUyKgkYA7zgD+faiP5VfX0SKltOVZgAEhdsY4/wBtXL7pTWLLUEklsGZflYGC
+M7cADuPLgc+9QbV0RpL6D08LKRy8glZ2J8iccYHb+Kle/S94t/pkl8sTRi4mL7GOSvAGD9qlcr0J
++q6Peaj1JqxOlSOqT/pOw2JIuByGxzzntQi86OuW0x58zxXZkKi0igdhtB77sedSpWpQmzdNdQmT
+adH1FwpIBFu5H04pyf4U2SRoz3l+SQCVWLODjkcCpUq31Rdg+FOlRxhjJduxHZ14+2Kuw/D+G2ha
+K2ur2BT3CDIP0K1KlTaBMvwms3bcL+8X1At8/wCK6h+FOmRNmS41CUegh2/4qVKfVBiH4f6EhjP5
+bO2wADxN5z9AKL2WiWGkF2stOeJm/cYrdsn25FSpU2i8qSPz4E4/90b/AIqTWUkqFVZo89yImJ+l
+SpTTBHTrZbS2MaF2yxYlgQc1KlSsj//Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061701.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0617</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="5" sliceresultid="4" marker="5536d312bcb5e17f0911755b9b3bc5a3"><EntryIdSplit><path>/s/sdlhomes</path><entryid>x-sl0617</entryid><viewid>SL061702.TIF</viewid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0617]SL061702.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0617___SL061702__TIF</EntryWindowName><ResultNumber>5</ResultNumber><SliceResultId>4</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/628,424/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>628</w>
+    <h>424</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_fn class="fieldsRef">SL061702</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_id class="fieldsRef">SL0617</m_id>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0617-2</istruct_isentryidv>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0617]SL061702.TIF</istruct_isentryid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption class="fieldsRef"/>
+<istruct_x class="fieldsRef">2</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL061702.TIF</m_iid>
+<m_flm class="fieldsRef">2013-02-08 18:59:46</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_caption class="fieldsRef"/>
+<istruct_m class="fieldsRef">SL061702</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/06/17/02/SL061702/SL061702.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<basename class="imgInfHashRef">SL061702</basename>
+<size class="imgInfHashRef">580462</size>
+<modified class="imgInfHashRef">2013-02-08 18:59:46</modified>
+<type class="imgInfHashRef">image</type>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">4</levels>
+<height class="imgInfHashRef">1696</height>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">005dadc60168f4d501b4490e7fb49b90</md5>
+<width class="imgInfHashRef">2512</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0617 SL061702.TIF</Caption>
+</Captions><ItemDescription>204 W. Henry</ItemDescription><Url name="Thumb" width="100" height="68">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAYEBQIDBwgB/8QAPxAAAgEDAgMGAgUHDQAAAAAA
+AQIDAAQRBSEGEjEHEyJBUWEUcSOBkbHBJDJCQ6HR8BUWMzdEVHJ0g7LC4fH/xAAYAQADAQEAAAAA
+AAAAAAAAAAABAgMABP/EAB0RAAICAwEBAQAAAAAAAAAAAAABAhESITEDUUH/2gAMAwEAAhEDEQA/
+AKPWeI+Im4m1u00/Xr3vVvZUW3M5jSJASAFYtgdAOm1LQ4x4o734ccR6scjmDd+SWP27DO3XfrUX
+jCXk4v4gQDdtRlyR1wGO3y3qsuFufhleVPolIK9AAcAYGOu2PlTaGoYl464mdxE2u30SN4SWuWLp
+jz2OfLp51qHG3E0ckjRcQalKkYVgWuHGRnrgnz9KV+8Ik7wOGIx161LVY57Nm/Xhs8qoACOnX7sV
+jUdv4N1ZNWtoGueJL9714TzW3xZ5epAf5kYOD88U1NDqVrYGPT9SuJZCFAe7lMmOUbkepbzrzdp0
+N6DzWokWaMEhk2PTP17b11TQNb+Ote9t7hopFPiVT5+uOgz1pJyx/DLzy4ybq3EXEWlSqr3M7OMt
+yq+centj93lSe3G+vPcPdXOpalFbn+ihhmIBPnsTkjpVnrtnLcuhkusRuSWZH3Aydwv3n3NVU2io
+NMSW1S2l72Vl5nmGR6eeAuMnoKhkMoMrbnjPXpIxLHxRqcTjJ5TM2G326Hb/ALFSouN9Wgu2Mmva
+nITg921yxCbZO4wM+1K0lpBGs9w93E/JkIqk+JidsbdMb59qxhlgilVZYlJyrFgSSuce9Ua1RqGy
+7461hLf6DW9SMjHC5uXIX7etQrfjfiEmQvxHqBboi/EONwP4+ylm+kIuWJb9LmAB6fxiosTqGIYj
+lwSQR19qMYaAen+yXUr3WOCviNQuZLidbqSPvJJC5IGMbnPrRULsPwOz4kfmm9lI+W1FMIzg/GLl
+eONcOSM383T/ABmqYsAoQO+MnJx0+qrrjaUS8ba2TGq4vZR4RjOGIzVL3K/DxuJB3jMQU5Tkehz5
+045geXAAq30LS7rXJn0+zVGnK8wB6hV3YjzqtggkuZ+7jj5n3JA8/Wujdn/D19Za7aahc2pjiZ5U
+WQuASQMFSp/D0zQlJIKKzR9M07Tr69TVJpntbIxs09sjJLv0TBI5dzudyMbU9a1pmncMQWl5ZRTi
+2nj5m3ByOoB26jIwep96whVLri2RHdpYmvj4GwVxzdMYp24n0yG90R+ccqweJeUDHUDHsKi3Y6VN
+HMRxRayxATWrwyDbxMFBX3IGwPoaj3WgNc6fJeRiEx3bErHDMGWMeXOw67jy6VX31qk3E5tweVfh
+i5x681V2r2K2OmyTxGOOXvgvM3TFIofB3L6V2oW+nwQyRrM0syN4Qi+AAerH132FUgkKygqSCpzz
+KcHPrTxqOi28eix3Ziyz2gd26ZbAwR9dJAhJkWNGB5wM4U5X2q0PhJm69mW5ZJ1BBYkMCck753+2
+ooAOQM58qkLGoQrljysGJxjY7UXKW4lJhcKjDKqzZI9iR5+dOgM9Fdhv9Xp/zsv/ABorPsR5P5hO
+UYspvpSCRgnZfKilJvpx3jiwto+INQeOOTmN5NJNJj1c7D296XVht1mVZjNHCduZF5yNvfH2Uw8V
+3c1xxdqlqocQC8kV5AhblPMcHbpWUNm1vEwL98O5ZQHOTzlcAgnoNztQycUWUb4LIl+Eu+eILtlc
+k7NThNxhr+jxWlvPpllDIo76CSSEs/KxzkHPQ+1JsVhK92kNx9GC3IzMdh9Yp57Q7VI7yxA6xWUM
+WxyMBc5rOrAiDF2haz8X3jm2RTksLeFY2LH9LmwTnND8V6heXiTXN3K4GB3RJIYZ3BJOd6SlIMq7
+eYqyi/OBouKQbsZb7U7a6vhcWlmmnTqpVisjyhgT08R2+qvllqVu19GurRi7tAxZ0t2CsdiBs3z9
+aW7iX8uiYHbJzXwS5uCaWmHR0riniDS+IYbSz043EQS2aLEsXKV9MeR296SNQsI7O0soyoIRsO4b
+kyfIk1stWMdleTI3K627EEeRrY+rXFtpNnLgTtcIVlSTBV/PcY3/AGYpVaZmkWuqSw3XBYtRZ/BS
+xSCSGJoge/AB5mEnVj6jyxXPyQ7DYZcZ2HQ+wq5s5JHnkuIoZGUKwYhi6qSD0zuPrqkZHjYjbwbZ
+9KpHolaPSfYapXs+Ibr8bKf9tFHYamOz0g/32b8KKzJvpzbVLW3g4n1SZIWDSXMokxIcOOc/++1V
+dxObWBnboNs4z126Vr4h4kWHiPVI1tiSt3KuS2M4c0vXutz3a8gRY022G+4NLhJsup0iNewS28x5
+5BkkkY9c0065xbY6zpgiEUyXKd0A0mCCqx8h3G+c70nSSSTOXdizHzrDlPpVMb6JZvURhgdt/ntW
+w3IVTjrUYFtvavpyRjHWmowd4zODgk1uibmmRQ6jmIGWOAPnWyw025urqMJbTSLzDm5NtvPenccP
+2mspGxs/hJox3bCCN5VYDGNlHz33yaSUkhkmyguZodLkmsLmeKXni5We1kEi4bfZqsntoDp0UKTc
+8Ma4OCA59MHy61Mk4NsYeaS4h4gdDjeLT+6UH5vg0ahplramB9Kg1BgOXwyplgAMHONs/I1CclxD
+JFFFFLa3URZsWhfAQjAI9NvOl2ZViunQ5ZVcjbYmn+CO7to3xapbo7kzCV8u3p8j91K+taZySXFy
+kqynn53AOcA9KPn6K6YJRo732Gb9nQ2/tk34UUdhoZezsBgR+WTHf6qKsyD6V+o9j/Dt7qV1dyXW
+pCSeV5HCypgFiSceDpWmHsU4YLeK51Q/66fglFFBvQyJ8XY7wnAxJiupTn9bNn8KlR9lPCY8PwLn
+nO5L9PlttRRXJKTvpREtOy3g6FQP5HjcqMZdiSfnvvUuLgLhaEHutEtFyN/Bn76KKtbATouGNFgQ
+pHp1sEznHdKRn7K3vp8MUHdW2bZSf1Kqv4UUUJcNbsgScPW86/S3V4/nvIP3VgOGLJWBWa5U58nH
+7qKK5qQ1s3W3DtrFcd6bi6kIOyvJkdPTFS30OwkVg0CEMdwVGPsxRRV4JUBtky0tYbSARQII0znl
+UAD9lFFFdC4RfT//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="68">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061702.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0617</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="6" sliceresultid="5"><EntryIdSplit><viewid>SL081701.TIF</viewid><entryid>x-sl0817</entryid><path>/s/sdlhomes</path><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0817]SL081701.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0817___SL081701__TIF</EntryWindowName><ResultNumber>6</ResultNumber><SliceResultId>5</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0817:SL081701.TIF/full/516,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>516</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_fn class="fieldsRef">SL081701</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0817]SL081701.TIF</istruct_isentryid>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption class="fieldsRef"/>
+<m_id class="fieldsRef">SL0817</m_id>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0817-1</istruct_isentryidv>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_x class="fieldsRef">1</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<m_flm class="fieldsRef">2013-02-08 18:59:44</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_caption class="fieldsRef"/>
+<istruct_m class="fieldsRef">SL081701</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL081701.TIF</m_iid>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/08/17/01/SL081701/SL081701.jp2</filename>
+<basename class="imgInfHashRef">SL081701</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">4</levels>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2013-02-08 18:59:44</modified>
+<size class="imgInfHashRef">418458</size>
+<access class="imgInfHashRef">1</access>
+<use class="imgInfHashRef">access</use>
+<height class="imgInfHashRef">1488</height>
+<md5 class="imgInfHashRef">f01c74ff832e7b231b77e315e808f873</md5>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<width class="imgInfHashRef">2064</width>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0817 SL081701.TIF</Caption>
+</Captions><ItemDescription>225 Monroe|||William Acton House</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABQYAAwcEAgH/xAA4EAACAQMDAgQEAwYGAwAAAAAB
+AgMABBEFEiEGMRNBUWEUInGBkaGxFiMyUsHRFSQzQuHwBzRD/8QAFwEBAQEBAAAAAAAAAAAAAAAA
+AAEDAv/EABkRAQEBAQEBAAAAAAAAAAAAAAABETEhQf/aAAwDAQACEQMRAD8A195oopG8R7lBn+Jl
+cp9iOMV7jmgl/wBK6ilPkFlOfwyaqvXuoEMkdwgX+V4sj6ZUgj86Xr+6vAUnurGCaEnPiKwYdvPc
+BjP1rOQMhuoY2CyLKu7th85/Ovcd3ZyEhZ8Fe4ZiP1pUik0u7u/lmuLJocs4YuuGHbvleQfyqQXS
+wafd3EF8kqgSna8YY4XkcqR/01cDjI8cUJkLMVHmGpduuqbW3vkjG5o3QYO7/dQTSupY9T09bqGF
+Wikyhjjcq5I4ztI9feuYXdt8RLbkSCZUwNyFjgYIIx6fmD7UwN76tE1tJLHIdpj3oc8+4xVcOohg
+qic72Gcu2ccfhmg8twl1oUYjlgMgTZKVYAgnABwfXJoRK7RRrcSREIufC3DapXyJ/oPTNMB6/wBV
+nUFrae5Kk88jAx75GB/elbUtd6hgtTNHeTLldxCTZGAc555HHBxxzV6aq94//rwiFflycBmb0GOS
+CftzXJM108UlvFfIkUqEyQiHuWyCOex+nemDz+1mrSWdvcrqMyoZI9wH+7dxjPp6ij1n1DfRSpb3
+F9458ZVciNlZQR7jj05xz60g2MsNvAiXAX99cxOgc8DaWV8r54OD7U6W3TDrZfE201yHeIERLKys
+RnI4z5HkA9+exxSyKe7SdbiDcsofB2kjPf71KG9L3kuo6MJZZJGmSRo5Fl4dGXgqfX1z7ipWVnqj
+pTeuY5AMcNxnmlzVLs6Yr210uYHIKGIc4zzj6DOR6ds0M6d162i6u17TLm9laaS9YW8AQkAdycgc
+fpRHWZbF7OQtDKJRnbKiMCjAZyGPmMVq5V6PJbx3E72BabxriQgxn5UQYAyfIHyoF1U8EOm2ywWM
+T3BkmhZh8rMo387h39a7NE1iDT4b3xZIwBcFmYDbuJzkAcccZ+9Kl9r629tcTfEpNc+FLBBHkbYg
+7HLD3K4OffHlVAXpfWF09ILSedxayg+J4ePkJPB5FN11oepvcfF2t4Q7YYTjzHkQefeststxibA4
+B5px0jrS+0nTmtVlLxKflLL29qtBC4Ot2atDfSRSRJEI12xo2VAIBPmSAe/0oANavHu1j+IiJACY
+RSgx9CfSqtQ1+41VCwJjDEhizcmgqk7xtzu8qK0rSLm91EFbWK38cAb2nRSBz3HY/h/zX24nms5z
+Jc3EqxTkDcnyZwf5eQB747Um2+qCKEeJH4boSC8RIYn0Pt3pts7ScCG9vo7gWpbaWM24Iox/EDkl
+ecfr51AJCqdU0nxZBNDb6o8Iz2I3buSOT3yfWn631BpBiyAdmwz3DEKuT3K5xk+3as71q2FpqOoX
+MjIJobq3nysQCEMM4A5Hv2wcfatE0q4uDpML6Tp5meNRvzNsRwRnIDd898gc+tKhg05yIHDRojBz
+uC474HmO/wBalV6XJNLbM11Y/CylzlBjntzx/wB4qVlXTD+q5mg621eRHIYXj5AJHGfUU82d3F1B
+o+mLq1+tqZAztztO1eBgE/L657nB4pB6uYr1nrLAgH4t/wBaK9LaPpmv211Lq+oLDLGwVA1wFL8Z
+7EdvetvjkYih0e46gudPtbmOS0uYPGSSRvEZJYgQVyfJgc/akKdo5TJJEmxGkJVCckA9hWkJ0h0f
+EQ3+JShx5/GAfotIGrW1vaatewWcniW0cxSJic7lHY5pAPsGUQzAsASeM+dWSn/LHHJ3jj7Gua3O
+1HO1m+cDj3rpyfAfHByMH071R26fpd5NGCIxGu3gyHbk5yeO/nVo0K7jdWMlscEf/TvXBF4q2Usi
+zygqUzzweTj9Ks+KurqGVpJSfBZOeM85xjjiopii6UvZYpXNzpv7xPlU3aBgR27/AIUU1XUJra3i
+xbrbeCoBlglV95ypOQpI8j3pThZmtZCJJMhlZvm7kk84+wr1LYX09s7xQ3MhR/FO0E4Qrkv9PeoO
+qW6iOna9Bb3DeDIkJWOQ5ZiPf0Bzx7+1aX051hpRWGOa6jjKW6De7YBIUZH17/hWLJgtNubb+7yM
+DOT6UT0q0hurVy4kMiAbQGAB+tKN/tL211CHx7OdZYSSAwPYjyqUt9ARJD02VCAfviflOc5ValZX
+qsq6ngM/W2rpkLm7f5iDgc9zjyrss7iz06bwJQkW1OWZeWP5VqD9EWMmrz6lsVpZpTKd67wCfY8V
+3y6LNNEFe5QKv8IECHH04rTUZswv7y2Sax0+5uVV9rGOM8evrShqyNbajcQyrKj5BxMCH7dyD61u
+MuiXMkZWXVbxR2UAqpb6dqB3fRNsbvxHvoyzLhmuApYnIx79qsqMXgKAyBgSNwIwccird3+Xcj1H
+61sUfQGlOTme1kb0iiDf1q8f+O9GJBmiEgPYbMf1q6Mp0u2Eul3njRsXABVc/wAeORXiC2WKz1Dx
+kMZMYMe5gMsD/wA1sH7F9PWikNbRBSQSHPH616NhpVkQbOw0sgDjeqjP0POamjILC5inint5ggmM
+IWEr5sDx286dOmdGurkSxSRSuxjUozF48he6hscelEtRuma48QWUCOvZ4Y1OPviuS31m7E5zK7Ej
+b87Z4ooZadO2s1xfeJocyqY3EStcf6ZAPzEjuBjt/eiXT3Sv+K9EadcWMEMN27N4twWJMgBIwRnj
+7URsmuwrrb6a8quCCzvgepzxzn3rrtpri3ultIJ7exhblUDLtGe/Hbv6VNQX6V0a40TSXtbp1eQz
+NICowMHH9qlENPK/C4Fws5DEFlcMM+nHb6VKzvVXTrdyIBCXhIPJwDmhcum3Lo7TzXZbPy7MYJ+w
+zUqVdFK6eEGJEvZvP5hIwH04FD7yB4hmDRrqVwMKxgP596lSroEXMWsMhWHTdUAIwQInAPtwBxXE
+g6itY2ittL1ZFY5bELHJ+9SpV0eZv2nuFG/Rr44/miJz9Rg0Pay6nJIGjXoX08FgKlSmmPXwPU4A
+J0q8bjAzbFsfjUisuqQebDVFPtDt/PFSpTRbNp/UsihWstSI8wVdq8RaDrJ/j067we4eBjUqVNVo
+PSNpcWWjNFPbvE5mZtrIV4wOcVKlSuaP/9k=
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0817:SL081701.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=6;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0817;viewid=SL081701.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0817</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>225 Monroe</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_historic_name" searchfield="false" sortfield="false"><Values><Value>William Acton House</Value></Values><Label display="on">Historic Name</Label></Field><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="7" sliceresultid="6"><EntryIdSplit><cc>sdlhomes</cc><viewid>SL081801.TIF</viewid><entryid>x-sl0818</entryid><path>/s/sdlhomes</path></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0818]SL081801.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0818___SL081801__TIF</EntryWindowName><ResultNumber>7</ResultNumber><SliceResultId>6</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0818:SL081801.TIF/full/516,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>516</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_x class="fieldsRef">1</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_iid class="fieldsRef">SL081801.TIF</m_iid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_m class="fieldsRef">SL081801</istruct_m>
+<m_caption class="fieldsRef"/>
+<m_flm class="fieldsRef">2013-02-08 18:59:43</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">SL081801</m_fn>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0818-1</istruct_isentryidv>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_id class="fieldsRef">SL0818</m_id>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0818]SL081801.TIF</istruct_isentryid>
+<levels class="imgInfHashRef">4</levels>
+<u class="imgInfHashRef">1</u>
+<size class="imgInfHashRef">418549</size>
+<modified class="imgInfHashRef">2013-02-08 18:59:43</modified>
+<type class="imgInfHashRef">image</type>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/08/18/01/SL081801/SL081801.jp2</filename>
+<basename class="imgInfHashRef">SL081801</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<width class="imgInfHashRef">2064</width>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<height class="imgInfHashRef">1488</height>
+<md5 class="imgInfHashRef">5a4928f15e9edc68a3d08d69b78d2647</md5>
+<master class="imgInfHashRef">0</master>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0818 SL081801.TIF</Caption>
+</Captions><ItemDescription>226 Monroe</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAwADAQEAAAAAAAAAAAAAAAUGAgQHAwH/xAA9EAACAQMCBAMFBAcIAwAAAAAB
+AgMABBEFIQYSEzFBUWEUInGBkRUyscEHIzNSYqGyFiQmQkOi0fBy4fH/xAAXAQEBAQEAAAAAAAAA
+AAAAAAAAAQID/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBMSFB/9oADAMBAAIRAxEAPwB5qnGGuW2q
+3cEV4ipHMyopiU4AO29W+gajPqGg2d3PJzSyR5dgMAkEg/hXJ9bwde1Dbf2iT5+8a6DwTNz8JQE/
+6ckif7s/nWIKKe76SkmUKQM71O3HEt0rOI2AePvGR3HxpdxBqEnSaSJlkgB3UHDYzuRUxdXxuLX2
+uNlMkQ7k527EedSCpn4svQUWO6999gOUbnO/h4V9g4l1KWyaQTZJbCthc9s9seP50hi4f1TUhbXk
+OnSPFy9yRvg4z37nemr6VrETxtLav0o0GCVACnA+nh9KswNLHWNRnnaFrhnxgFlQEg+JwB+NMrjX
+47UBXYlyeXHMNvj6+lQ0d1qCEQWVosYdmLSy3IA37ZIyTWrecJXGpMJNQ4iiD91jgt2ZE/3A59cU
+g6WL2Vk6sUwdDgkEbgUS30yLze90z2kGDy/H/monTzqeixiP2+HU4gNiytE49N8g/wDe9OrPUzMQ
+EilD4y0TDYj0xnepAx+07i3lIlneSFl5lZVHMB4nYYI/751lLqVwUHQu4yTgqGwCfyIpfciLAeON
+4SWBBXIBPjhh2NfUuGtZG6UsbBt2hcBWz/Cw2z8QM0gotNkmlsUe5KNKSclO3f4CivumzdeyWQKw
+5ichxg5zRWGnHdcBOt6hg7e0P2Pb3jVbwNdrFwvcK0uGF04XG53C1Ka7trV/sMe0P/Ua+cOatJY+
+1RiQKhlBYjGdx3/lXT4y2dcnnF5ISDyM+S6Z7nbBHnWmJAolgWQlnOOnuvOD4Y8x2rbv7o3UJf2g
+yKchlONwT4Ed/Wk3tVw3StGQOOsGDge93AzmqKW4/SPc8PS/Z9tYRyRIM/rcqQexGPlRLx3dcQ6c
+5uIEtbaAGScxknnUdl+Zrw4t4cfV9XFws0dtbQW8hmmZCwHLIQAAO5PNU4baWfSUtIVlis2ky9yY
+yRKV7KoHlnxNPBr6Tqt9cazJIbiQFo5XCc2VU8pI2O21Xd1Nc/2RaZJczpcqocBc8pHbtURAlppR
+EkVrdz3HKRloz2IIO3YbfGndlr0tzYPp8trc9OQhyvSIYEeIb/7TR6Xt5ewQaQVlP95jPVJAyTzY
+rV4L4ju11I208/UmkwYXlOfeHdfmM/Ony2mjajBYw3V5e2r2mSrdAMGyc9x2peeBtHS4Wa04mlRl
+bmUvZEkHOR2NB0/pJcRJPGWHMM5XH0x2NaphuesWEHWXzLcrfz/5rGy1ewt7eOJrvqFVwSsLjJ8w
+MUg461xV0DqWMz84uIm5gpXs2d8/CoLXTiGs15ebYkEMckHO4NFJuAJ3ueEoJ5CC8k0zsfMmRiaK
+5605vrak61ftv+3f6ZNaehQpPfahbSQyyx9LqFY15scvifTetzWQRrF43h1mz9aTWmoyaZqt7LCS
+He1ljX4kV1ziKSfT2ikjjthL2OEZNs7jlz4bDtnekUVpGNUjjub6G1QSczPOSqqBucjz2xgedJLr
+X9YvIzDNfzmInJjDcqk+oHeljKzEsSCfMtvViOgXOuQ6hPyTahFJZ+0M5YhhEGPiVP3vMDfvSfUt
+Za4vJnRllJeZYS4/YxquVVE7KPlk1OXN2lwYuS2igCDB6fifM17RMDd7kYLPuT5pSDa0zWL5763S
+S4wjyBSOQAH54phHxI945t0iaMvGxVywPKQpPbHpSWzhmjmti5jCpMr/ALRc+HrXrYdJNUtOk5Ql
+GSQt2BPMD8sYoNldUvwGJu5PdUnZEH5U2mvLxJGPtU0YCI3KoTxQN5etIViQc49qtt1K56m1ObyW
+0uHBj1C1AMEKkEvnmWMKey+YqKacOXd3eXksVzdyuERmHYbhseA8sU21i19r4dureZ2WSLFym3f3
+cn5Eq31pFw7eadpmotcXV/C0bI64SN2OSQR/l9DTvVNettQu447W2uGguYGgWfk5UY48M+Rz9aCv
+/Rsf8EWef35P6zRR+jUg8D2Z/ik/qNFct6qC1debVro+PWbw9ak71it/KwGcgj6irLUo86peZJ2m
+bc9hvSqCwEs1y7AHLco2rriI4hub3Vz8s1kILhhlYZD8Eqlm04dwzjB7BjX0aVDIu4Y/Ek1aiQKe
+7nzrJyDIT5gfhViNLjACyIrL/wCNbUekQ4XpIE5dxhQfxpRDxo/OrJGzYII5VJq4tOGbCWKK7HXj
+lYc45m+6T5j51QaLpWpPde7bxXdsgDMObpyYzuBgYJp3qOt2+jTxQw8PIsrAkddsEYOMjY5Hkam6
+OVQcIajJJIrPFEEblUu33x5jHhWUfB+sNJyiKID97qDFdMXjDUbjcabZITv7wLE1Q6LcahexM9xb
+2+FIHuLyDt4d80o5Tp/AWqTXIW4YLDjPUiBck+WMCqe34NuNJgSb9ZJ0pBKGdcBBzeQPl6V0tud0
+HTcKR3xvU7Jo/EN31Em1lI4XBUoqA5B+AFShrpdkunWEdqI4oxHsFiXlUfKisdJWePTIRdSyTTEZ
+d5V5Wz5Y9O1Fc1R93wrdXN7dTLJCpkcuqucdz416fYVrp1mkD3KSXJYu7RoSB6ZoorWaNCPhyW6j
+MiFApJ+8cV62XCztKVnngiXGxJJz6UUUoerwrpaoee8Z2PbAAFe9roWi2bkmR5c+Dnb+QoopQ5jv
+rFF5EdUA2wEI/KiSfT5WVpei7LupZMkfDaiilSMOtpkW6i3Xw2i/9V4nUlHOJJ+XnblQID7q+Z27
+0UUoyk1CFYQ1uquxfBDZTAzue1H2mnO6vIgXI5SFYnHrttRRSq2UkWUF0OVPjRRRWB//2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0818:SL081801.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=7;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0818;viewid=SL081801.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0818</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>226 Monroe</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="8" sliceresultid="7"><EntryIdSplit><entryid>x-sl0909</entryid><path>/s/sdlhomes</path><viewid>SL090901.TIF</viewid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0909]SL090901.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0909___SL090901__TIF</EntryWindowName><ResultNumber>8</ResultNumber><SliceResultId>7</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0909:SL090901.TIF/full/516,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>516</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">1</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_m class="fieldsRef">SL090901</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:30</m_flm>
+<m_caption class="fieldsRef"/>
+<m_iid class="fieldsRef">SL090901.TIF</m_iid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">SL090901</m_fn>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0909]SL090901.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0909-1</istruct_isentryidv>
+<m_id class="fieldsRef">SL0909</m_id>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<basename class="imgInfHashRef">SL090901</basename>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/09/09/01/SL090901/SL090901.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">4</levels>
+<modified class="imgInfHashRef">2013-02-08 18:59:30</modified>
+<type class="imgInfHashRef">image</type>
+<size class="imgInfHashRef">418565</size>
+<access class="imgInfHashRef">1</access>
+<use class="imgInfHashRef">access</use>
+<height class="imgInfHashRef">1488</height>
+<md5 class="imgInfHashRef">59122161fc1c1a73496772d8320f000b</md5>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<width class="imgInfHashRef">2064</width>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0909 SL090901.TIF</Caption>
+</Captions><ItemDescription>259 S. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAAAAcEBQYCAwgB/8QAOhAAAgEDAgMFBgMHBAMAAAAA
+AQIDAAQRBSEGEjEHE0FRcRQiMmGBkUKhsRUWI2JygtEnM1J0wfDx/8QAFwEBAQEBAAAAAAAAAAAA
+AAAAAQACA//EABoRAQEBAQEBAQAAAAAAAAAAAAABEQIxEiH/2gAMAwEAAhEDEQA/AGTJqt6dR1TN
+2Ire1lZVBALNhFYhRjw33PiayHC/aTc33Fl5Y6hK5tZXxbkgKIQPMgePzNe/HepjS7TVIrJ4fbJW
+eSRCCWZScEjHUgY9BvSNW5kUSvzsWYYJzv8Aes887E+rNN1/TNXuLqDT9QS4ktG5JljbPKf/ACPm
+KsCx/wCbfevl3g/iSbhzXI76NpGixmWNXIEnXAPnuennT40HjHTuJtHluYZBA6LiSORhlM+eKrzi
+V/aFxtBoOj3FtZalJFrB5RGkeGaPocsCMcpG31qg7Oe0DV9ZvJbHVHku2JDe0EhFiQAls4G5Jxj6
++VLXjR7x+I7g3ZYuGKrJ3hIK52AJ8P0zVVpN6lneYe9uYIZcJMYB1TIyD5+dM5mF9QalqBhQCGa5
+5nX3e6Kn8z0rGT6xrveRqdZuoZHz8KqVOPAArnxWottrV3cWQuYlJtI0b/d6lM4BI3Izjx3FZHVt
+av7ly62sxw4O42BxjOeu+1GBbXPHGv2cN7HJq1yWfHs85VRykHDDAHluPQ0a12h6nbW0DW+rTiSR
+FLKpU4OMHHkSeo/TpWE1GaW4tjA/Isne5Uq24JIBz08zXU8Xt1z7G93Fb2dmQguGXeRtwDtueh3+
+vjTkLY2HaPq/7Eb2m/1CXUJZCFlGFijHXHTr/mrDR+N9Wflur/WHNtGGeQGQKSBvgDGW8qWMUs0F
+sCJlZGPIYyN+XPh8s5ovbh30/laPDBuUsTuD5Y+lXzE+k+z3WZeI+F/2ndEu8tzKF5jnlUNgD0FF
+VfYwpXs6twylT7RNswx+KiuV9JYdpciRcZ6ipMyyGbnDLlRjAGwOx8dxS/lK+/yqQD881su0mZ5O
+P9YV5WYLMFVT4AKNqx7JzZGB064rvz4H7YWxu5ymSFClmYDPKPOrSw1m40tZY4ZSUm+JW8/PrVXZ
+kwXKN1yQCMdRWt0vh8yuk+oqCyAckOPdX+rzPy+9VSq1K2OoK95JcxrHFDnJzucjw+v1xVAgLSqk
+YMjHYADG9M670qzvYu7mTn+uCPQ+FaDTuHuEr21t+aGKK4tUHOJSsbNj8RIwG9aPpKHQ9YFpomns
+6iCWPL/xEJiz45O5OQNx4ddqiX11d8Rzt+yo0jeYHEjOTmMjLZU/CNts7nApjp+7sVoLaN9OFuAQ
+IwycuD12riOfh+2z3MunR5GDycg2+lZ0EdqFlIlhPczXEbzK4jfByWyc58v/AJUGF3iiyYlbnA3f
+HTwxn5U4+JL3SDYNb21xaKXOT3ar19APzpc6ja2YiuEiuI5HVDls9f8A3yrUpUEBLThJE+F8dCeQ
+ZycD70wtPuYdGhF1ZWkc9yWBa5nUOw8MKOiAdNt6wOlHm1WCMZMckyI2+M7imPdaYILRViuFgSPn
+csgALncgDyGaKjl0G4W90iGdHDq++Qc/SioXBDI3DimMgjvX+Hp1orjSRXaVbTxceatK8TrHLNzI
+xGze6vSskNvGnnxlxHwndX19oOthe9iPKsoiJaNzuCGA26ilhwvwuOItYms1uFVI2Iyx3YA13l/A
+oLS7is76GeaHvljbJQnAPl+dbDUb+4istOmtj3SOgMmADsRsOlMCHs20O2tWRoeZipBkzg9PA1n9
+T4AmvWiGl3CW8UC93zzSO3MB0AA/WjZUykuovPw/DHLK/tgly7AcueviNvKtmYYp7N+8VTiFSMjp
+uKhaHwFex6ow1O+gltE3kjjDkvtsN+gzW7i0bT42BW3Gy8uGyRj06UUMisUCj4E+wqLYWncXF68r
+h0ll5o168i46UwTZ2537iP15BXjPa25wGhibyBUGhFnq/D41C/adbxYVZAvLyk9Awz1/m/Kvy90+
+C20c2yLGSUVHlO2dsZrY3TWzzKIo7blBb8A8Nj+derQWxCvJBbggrynkHXNOoouHdGkv++mhRSsM
+uWds5GBnAx5+Ga1moKf3XtFwQw5BgjodxVrw/DpWgadqqQXhf2gCQrKQSDg/Dj1r8u2E0MkcbqZH
+hcqrjIGBknHnvVaW17Jo2h4JWN85W5lG/rRU7gSFLPhtYoxhTKzdc5zjeiud9JC9pI/1F1r/ALA2
+/tWm12b92eDLZJLRIpUYrIOTB+RORnOKVfaJGW7StYCoWJuVAUdSeVdtqfWlR93ptpE0CwMsKgxD
+8O3Sut8grrUGVLZyMcxG1R7JUe3Ur/jNStSj5rU7A43qv02UANDjBDbH51gOb1Gt7hZkX3Ts1e6T
+RSIrqNid81LkQSKUdcqRvVdPaPFkwsQucnB6+tKTA6npjeqHWNJa5YziSUurKyhUBxynPrvUzv1Y
+Y5ijdNxXqHkACq4Pr41Iqb+w4gsEa79mmAMx5lUb4Y77Vd32napfxwWNokhUwo3fyOFw3NkknxIH
+hW9yx65B+dcSIx+dKLi44ZOmRyyXrKwJXD82QTj3hgdM7bVxp9zDe6jcGFn/AIFsysD8J5genzGK
+31zYieNkkUMpG4YbVh9V0C60G5k1XTUkntnQpPbLuVB/EvnjyqRn8EFpOG42frzsP0oqL2bXUd9w
+iksLh0WZ0yB4jFFc760w2oaBfT9rl9ei0lW3S4EgmeIlSAq/DtgmmjZPJKjSyBlBPuhgQaKK1odX
+S89u3XHoaqbWORJQDA4DErkqd8dDRRVqWMaSd2ecENk52P3o7onfB36e6aKKtCPPYd57yKQ39Jwa
+gLYXKghUYfy8pIooq1O4o7obNE4I6qykj71KijdmIMUqnyKHH3ooq0vYQHoY2x/Sa6FlGTvER/aa
+KKNSbYwJaW5jhiWNeYthV5Rk+NFFFZL/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0909:SL090901.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=8;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0909;viewid=SL090901.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0909</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>259 S. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="9" sliceresultid="8"><EntryIdSplit><path>/s/sdlhomes</path><entryid>x-sl0909</entryid><viewid>SL090902.TIF</viewid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0909]SL090902.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0909___SL090902__TIF</EntryWindowName><ResultNumber>9</ResultNumber><SliceResultId>8</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0909:SL090902.TIF/full/516,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>516</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_fn class="fieldsRef">SL090902</m_fn>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_caption class="fieldsRef"/>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0909]SL090902.TIF</istruct_isentryid>
+<m_id class="fieldsRef">SL0909</m_id>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0909-2</istruct_isentryidv>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_x class="fieldsRef">2</istruct_x>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_caption class="fieldsRef"/>
+<m_flm class="fieldsRef">2013-02-08 18:59:48</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_m class="fieldsRef">SL090902</istruct_m>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_iid class="fieldsRef">SL090902.TIF</m_iid>
+<width class="imgInfHashRef">2064</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">ff6b5c87e2f3ebffe613d2974968dad1</md5>
+<height class="imgInfHashRef">1488</height>
+<access class="imgInfHashRef">1</access>
+<use class="imgInfHashRef">access</use>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2013-02-08 18:59:48</modified>
+<size class="imgInfHashRef">418554</size>
+<u class="imgInfHashRef">1</u>
+<levels class="imgInfHashRef">4</levels>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/09/09/02/SL090902/SL090902.jp2</filename>
+<basename class="imgInfHashRef">SL090902</basename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0909 SL090902.TIF</Caption>
+</Captions><ItemDescription>259 S. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="72">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAAAAUDBAYHAQII/8QAOxAAAgEDAgQEBAQDBgcAAAAA
+AQIDAAQRBSEGEjFBEyJRYQcUcYEVIzKRJLLRJUKhscHxUlRicnPh8P/EABYBAQEBAAAAAAAAAAAA
+AAAAAAEAAv/EABgRAQEBAQEAAAAAAAAAAAAAAAABETFB/9oADAMBAAIRAxEAPwDZXOt3Ym1bN5Ko
+hupIIgsoAXHKBtj379qoTcUX8cyWUeol5sKHmBHl6HOO59qyXE154PFnEMZuHEa3KuIlQEElQCSD
+1xy9gakiWW30yW5lWOIxxNKZWGXJC55WYdO2BjAzihLmkcUcQTa480us3MunfiPyakgKpBUgdRjP
+Ny9TT2/1nVotN1eWLVLtbu2KtFCSAQpA9Rgg+bBHTastw1CTwOYJOZmvFeYsrYCyE5Vj7ggH7VZ4
+ivzdaXaXqsEfU4oY/LnKMr+YE+2f86kc8S8Ta1pFxb2C3jNdMhYm3lBIJ8o5lI23PqelQw8W6hM0
+FiNSu2dADPOgIc7fpXbGSe57Z6UuW5Muo2VxFbtJqF6DcrbnCKVK8sQJHRQOZ2NW30uKXSpbV2F0
+ynmcysMIxxsqD+9/KAN+lSNbfinUJJyGnuZFzhPD5WzjrkKdv3pxZXeo3SiZtRchjkwxtllB6Z9/
+/s1j4reSwYqkb/JsCqsmQOnc53HoTTjS4IxdFke4gcYJMb7MD75yR9aE3kB5YxmaR/dmzUhdT3P7
+mqFoAsQIZmzvljU5aoLGV65P717kep/eqwavQ9SWBntnH1ooiOUzRWpxOH8UCNviFO95HLHYPNLD
+JIMDnxykrk+w7dP3FfGu8QQxcNahBYWNxFHcxiMylT4Y3xhSRvkdBTrjvVNOl16yjlhaO6tr4IZw
+A2YiCD5e+5H7Us431T57h+ys+ZJfEvEwwcE4GThh2NBWdIuXstOtVeK2HJEgEcaZfG2CGJ3Oeo23
+pPq0kdzYpYySMh/GOVg5AURyeYNt06kGtJoxWKaBnKKr8vIZNyWI5uYZ7dKU8X2nyfEGkXUTRxpO
++Ze48RAzL/MRVOpW0uOee8uJre5kS4V5LaKSMlm8CPy8sY6Esxxv0CmtfpVqI5G8zxFsDlhGRGTv
+vncnvnHWknw00/8Astb4yOJZWbw+4VAcHb/qJO9bs25Z3WSFC3L+tfQ+npVUj5Z1hWOVmnH90soO
+e3btVnT7QR5aW3jjcHYo2ciobeJo8iGU8wO6OMg+/r/jU8F007sivGGT9ajqKyDEHFe53pMNdsWu
+LiBZVLwYzhhg5Hak+n8TyT6ybeV1MZIUAHvSmyzX0GqHJr0NQl6E/l0V825/K9d6K1E4FxyMcX6r
+KG80VyhX281UNb1OHUL3TDbxpEIs83IAN1GMnHenHH1yw1rWIiuV+ZyGwNsEHGazjyWo1yPmixEk
+Z5kx3PWmE01q4RuHrRkl/jJGVw3NzOqAYGd/LuM9OhpLf61cX+gRxXVz4lzBc5Qs2W5SpH3FQFJJ
+HkIZlm5SIwcYwOi79NulVp9Nu7UI08JVeflBOOtJdk4bvrHSbK0sfMsywKCvUHYHr++1Sx8W29xr
+Utoko54oS7DJBX2Pr7iueXOp6xBDbfJm1bEeSY4N0bfI83f1qi2p8RNcM3jTKWJyyIqk/cb1nA6t
+NrscsCMCYvKSGG4Xr/jnFZqS9mAmEMsgWUku5O5HoPal+kXN1qFqWv4+R4m5V65YYG5yTvWVv+KN
+Qg1C5gjEJjjlZVzHvgH61SFrnsrq05bhSFJI3Vsnf1qqYpluvmIHKTZB5CcAkf8ACe30NZJOKdQR
+ieSE57ENj/On3DOr3GualJa3McSqsJfKA5zkDufenLE6Fa8dQx6Ni5l/j0PKyMN8gZ3rP6r8SNQk
+8L5VBBybuMbk/wBKQ67FcSanDplpZ+PdSgcjpkyNnPl9CNvtSPUIb6xmeG/t5recAZSVCpxRIH6G
+4E1SXXuGY724H5hldDjvg4opd8ITzcBRE/8AMy/zUUgl4w4d059K4iu7SJpL6dTK+GLHnGDsO30r
+KcIaVpus8X6msltzWyWykRvn9WEBJzv1zU/FvCXFY4n1HUNNiuHt7iYyIba4wQD6jIxW34K0NtP0
+K3e+tHTU5FY3EsozIcsTylupxtR4UL8GaIGjZLCNWjzykdd/X1pFxrwrJdWVp+E6c0swueebkYDy
+49CfWukeAvY174AA3wPrRqZG74K4fYBgZ7cYJyHOB3OcjAqsPh9pk0ay2+oXBVgGVwVYEHv03rXX
+E9laxMZ5UCHqGNKm1qFUWLT7QFF2U45EA9h/SjUUx8BLbxkDU3AzneMD/WsZc/C1p7+5lXWU5WkL
+D8nJOTn1reXLXt4GNxdLDH2C7Uqle3iPhxlise7OzHA+g7k0y1MSnwvueZg2q2647GIn/Wn/AArw
+G2j3811dapA3NH4aiOJvUE5zj0p5YzWsZ5ridIlfcFwR/tTWW40y1xzzxqWwBzZ3J9qdqRJoFt44
+l/FAGUYHIn/ukXFHC91c6bHJJezaq9ufJHIvn5cbhd9/ptWstJVeYoqgKB6dfoaZqwwMbHIGCcE0
+alX4cwvbcJJFNavasJ5MRSJyEDO21FPrXPgDPrRWoH0yDGCDj/tJqB3VM/lysfZDRRWCW3Wo3aNi
+HTrhgR2ib+lJrg8Q3RYGCWFP/GST9KKKU8g0OfxA8tvPNId8yRk4+/QfarEtnfwxMyW0jEDZY0OT
+98UUUJTntNSeFW/C7nPogJb756Ck9xpmsmVnTSrrnYbEISB9feiilK/4Dq8MhdNNvJpyP1yQkqn0
+z1PvTLReHdTkuQ+oWrqkoIJZDzoex6UUVJpH0RgxblkY9cgGvlYdTt05Y4ZHGMAlDkCiipHuk+L8
+l+fGyScxyH2P+1FFFaD/2Q==
+</Url><Url name="ThumbLink" foo="bar" width="100" height="72">/cgi/i/image/api/tile/sdlhomes:SL0909:SL090902.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=9;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0909;viewid=SL090902.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0909</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>259 S. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Result resultnum="10" sliceresultid="9"><EntryIdSplit><viewid>SL090903.TIF</viewid><path>/s/sdlhomes</path><entryid>x-sl0909</entryid><cc>sdlhomes</cc></EntryIdSplit><CollName collid="sdlhomes"><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName><EntryId>S-SDLHOMES-X-SL0909]SL090903.TIF</EntryId><EntryWindowName>S_SDLHOMES_X_SL0909___SL090903__TIF</EntryWindowName><ResultNumber>10</ResultNumber><SliceResultId>9</SliceResultId><MediaStatus>P</MediaStatus><MediaType><MediaGroup>image</MediaGroup><MediaNature>dynamic2</MediaNature></MediaType><MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0909:SL090903.TIF/full/518,376/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>518</w>
+    <h>376</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_x class="fieldsRef">3</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_iid class="fieldsRef">SL090903.TIF</m_iid>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_m class="fieldsRef">SL090903</istruct_m>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_flm class="fieldsRef">2013-02-08 18:59:38</m_flm>
+<m_caption class="fieldsRef"/>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">SL090903</m_fn>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0909-3</istruct_isentryidv>
+<m_id class="fieldsRef">SL0909</m_id>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0909]SL090903.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<basename class="imgInfHashRef">SL090903</basename>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/09/09/03/SL090903/SL090903.jp2</filename>
+<ext class="imgInfHashRef">jp2</ext>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<type class="imgInfHashRef">image</type>
+<modified class="imgInfHashRef">2013-02-08 18:59:38</modified>
+<size class="imgInfHashRef">424419</size>
+<levels class="imgInfHashRef">4</levels>
+<u class="imgInfHashRef">1</u>
+<master class="imgInfHashRef">0</master>
+<md5 class="imgInfHashRef">92504e9c909824601629cbe28d973495</md5>
+<height class="imgInfHashRef">1504</height>
+<access class="imgInfHashRef">1</access>
+<use class="imgInfHashRef">access</use>
+<width class="imgInfHashRef">2072</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo><Captions><Caption>SL0909 SL090903.TIF</Caption>
+</Captions><ItemDescription>259 S. Ann Arbor St.</ItemDescription><Url name="Thumb" width="100" height="73">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABJAGQDASIA
+AhEBAxEB/8QAGgAAAwEBAQEAAAAAAAAAAAAAAAECBAMFB//EADAQAAIBAgMGBAQHAAAAAAAAAAAB
+AgMRITFBEhMyUnGRIkJRYSMzcrEEFIGhweHw/8QAFgEBAQEAAAAAAAAAAAAAAAAAAAEC/8QAFREB
+AQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/APtThShTjJxveyw9wgqU5uKptNZ3KqVFSowb
+jtPBJW1sOE4trYiscG0v97mERB0KlWVNQtKOGOpKqfh/FelJWbStFu9tTtKTVWMdnBp3foOc5RUV
+GDk27Yae5RnnKnFzSovwq6aTs8C4KnN2jSdtW1ax1jKTk1stJasrUDk6NNeRC3VNeRHawmsrAcnR
+pvyInc078COrzEBCpUuVBuafKh4lAYJq1SSWSbAc1epLqwKN+2oUoyllZEuuksIyfokdIcEeiKMj
+lWrKlFSkn0tcn8xFN2jNteizR2eKFYomnOUorai072IdZxqNOE7dMDshgcZV3F23U3eWynYe1PeN
+bL2Es7ZspxTalZX0foPQCXmIbEAm3f2DXqPMVsQMVR/El1YBU+bP6mBRvpvwR6Iu5zp4U4r2RaMh
+gT/JSd0ADEwAGK9hvKxLX9gJkspksoLgJYL9ytAMFT5s/qYDm/iTx8zAo3018OPRfYsmnwR6L7FG
+VTIabQ7XFayx/UBhYEhgKw7CvnqO60Ah5iGwKiGgviU0mibAYanzZ4+ZgOpfez+pgUboVI7uPiWS
+1K2480e55+o0SK3ucOaPcFUhbiXc87QoRHobyHNHuG3DmXc855A+JdBFeg5w0ku4tuPMjDqDyYiN
+jqQvxx7hvIc0e5geRL0LB6O8hzLuLeQ5l3MC4QWQgqo71Z2x8TAgAP/Z
+</Url><Url name="ThumbLink" foo="bar" width="100" height="73">/cgi/i/image/api/tile/sdlhomes:SL0909:SL090903.TIF/full/!100,100/0/default.jpg</Url><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;subview=detail;resnum=10;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0909;viewid=SL090903.TIF</Url><ContactLink>mailto:sdlphotos-help@umich.edu</ContactLink><ContactText>E-mail Help</ContactText><Record name="result"><Section name="default" class="default"><Field abbrev="sdlhomes_id" searchfield="false" sortfield="false"><Values><Value>SL0909</Value></Values><Label display="on">Record ID</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>259 S. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Empty abbrev="sdlhomes_historic_name" empty="yes"><Label display="on">Historic Name</Label></Empty><Empty abbrev="sdlhomes_common_name" empty="yes"><Label display="on">Common Name</Label></Empty><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field></Section></Record></Result><Absent><Field abbrev="sdlhomes_common_name"/></Absent></Results>
+
+
+
+  <Assets>
+    <script type="text/javascript" src="js/_reslist.js">
+        <script type="text/javascript" src="vendor/sly.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.selection.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="vendor/jquery.stickytableheaders.min.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/sly.pagination.js" timestamp="1469476504"/>
+        <script type="text/javascript" src="js/reslist.js" timestamp="1469476504"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_reslist.css">
+        <link rel="stylesheet" type="text/css" href="css/reslist.css" timestamp="1469476504"/>
+        <link rel="stylesheet" type="text/css" href="css/sly.pagination.css" timestamp="1469476504"/>
+    </link>
+</Assets>
+
+  <SearchForm><NumQs>2</NumQs><Q name="q1"><Value>Residence</Value><Rgn name="rgn1"><Option index="0"><Label>Anywhere in record</Label><Value>ic_all</Value></Option><Option index="1"><Label>Historic Name</Label><Value>sdlhomes_historic_name</Value></Option><Option index="2"><Label>Common Name</Label><Value>sdlhomes_common_name</Value></Option><Option index="3"><Label>District Name</Label><Value>sdlhomes_district_name</Value></Option><Option index="4"><Label>Bibliographic Reference</Label><Value>sdlhomes_ref</Value></Option><Option index="5"><Label>Photo Negative No.</Label><Value>sdlhomes_photo_neg_no</Value></Option><Name>rgn1</Name><Default>sdlhomes_present_usage</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="ic_all"><Option index="0"><Label>all</Label><Value>all</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_historic_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_common_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_district_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_ref"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_photo_neg_no"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel></Q><Q name="q2"><Value/><Rgn name="rgn2"><Option index="0"><Label>Anywhere in record</Label><Value>ic_all</Value></Option><Option index="1"><Label>Historic Name</Label><Value>sdlhomes_historic_name</Value></Option><Option index="2"><Label>Common Name</Label><Value>sdlhomes_common_name</Value></Option><Option index="3"><Label>District Name</Label><Value>sdlhomes_district_name</Value></Option><Option index="4"><Label>Bibliographic Reference</Label><Value>sdlhomes_ref</Value></Option><Option index="5"><Label>Photo Negative No.</Label><Value>sdlhomes_photo_neg_no</Value></Option><Name>rgn2</Name><Default>all</Default></Rgn><Sel name="select2" abbr="ic_all"><Option index="0"><Label>all</Label><Value>all</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_historic_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_common_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_district_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_ref"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_photo_neg_no"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sdlhomes</Variable>
+</HiddenVars><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>thumbfull</Label><Value>thumbfull</Value></Option><Option index="2"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+  <!-- WUT -->
+<Facets><Delta label="SQL">0</Delta>
+<Delta label="facets">0</Delta>
+<Query>SELECT SQL_CALC_FOUND_ROWS * FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sdlhomes-X-',sdlhomes_media.m_id,']',sdlhomes_media.m_iid ) as `id` , `sdlhomes_present_usage` as `sortval`  from sdlhomes left join sdlhomes_media on sdlhomes.ic_id = sdlhomes_media.m_id where  (  ( match (`sdlhomes_present_usage`) against ('"Residence"' in boolean mode) )  )  And sdlhomes_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'sdlhomes_date_construction' AND f1.value = '1910 ca.' ) x1 </Query>
+<Query>SELECT* FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sdlhomes-X-',sdlhomes_media.m_id,']',sdlhomes_media.m_iid ) as `id` , `sdlhomes_present_usage` as `sortval`  from sdlhomes left join sdlhomes_media on sdlhomes.ic_id = sdlhomes_media.m_id where  (  ( match (`sdlhomes_present_usage`) against ('"Residence"' in boolean mode) )  )  And sdlhomes_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'sdlhomes_date_construction' AND f1.value = '1910 ca.' ) x1 </Query>
+<Query>SELECT b.field, b.value, COUNT(b.value) AS total FROM ItemBrowse b, ( SELECT* FROM ( SELECT t1.* FROM ( select istruct_isentryid, concat('S-sdlhomes-X-',sdlhomes_media.m_id,']',sdlhomes_media.m_iid ) as `id` , `sdlhomes_present_usage` as `sortval`  from sdlhomes left join sdlhomes_media on sdlhomes.ic_id = sdlhomes_media.m_id where  (  ( match (`sdlhomes_present_usage`) against ('"Residence"' in boolean mode) )  )  And sdlhomes_media.m_searchable = '1'  ) t1, ItemBrowse f1 WHERE f1.idno = t1.istruct_isentryid AND f1.field = 'sdlhomes_date_construction' AND f1.value = '1910 ca.' ) x1  ) a WHERE b.collid = ? AND a.istruct_isentryid = b.idno  GROUP BY b.field, b.value ORDER BY b.field, total DESC, b.value </Query>
+<Debug>{
+  'sdlhomes_date_construction' => '1910 ca.'
+}
+</Debug>
+<Field abbrev="sdlhomes_date_construction">
+    <Label>Date Of Construction</Label>
+    <Values>
+        <Value selected="true" count="10">1910 ca.</Value>
+    </Values>
+</Field>
+<Field abbrev="sdlhomes_orig_usage">
+    <Label>Original Usage</Label>
+    <Values>
+        <Value count="10">Residence</Value>
+    </Values>
+</Field>
+<Field abbrev="sdlhomes_ownership">
+    <Label>Ownership</Label>
+    <Values>
+        <Value count="3">Brown, Harold</Value>
+        <Value count="2">Armbruster, Lee and Donna</Value>
+        <Value count="2">Dieterle, Kathy</Value>
+        <Value count="1">Freeman, Calvin and Roxanne</Value>
+        <Value count="1">Gumtow, Paul</Value>
+        <Value count="1">Hassberger, J.</Value>
+    </Values>
+</Field>
+<Field abbrev="sdlhomes_present_usage">
+    <Label>Present Usage</Label>
+    <Values>
+        <Value count="10">Residence</Value>
+    </Values>
+</Field>
+<Delta label="xml">0</Delta>
+</Facets>
+<SearchForm><NumQs>2</NumQs><Q name="q1"><Value>Residence</Value><Rgn name="rgn1"><Option index="0"><Label>Anywhere in record</Label><Value>ic_all</Value></Option><Option index="1"><Label>Historic Name</Label><Value>sdlhomes_historic_name</Value></Option><Option index="2"><Label>Common Name</Label><Value>sdlhomes_common_name</Value></Option><Option index="3"><Label>District Name</Label><Value>sdlhomes_district_name</Value></Option><Option index="4"><Label>Bibliographic Reference</Label><Value>sdlhomes_ref</Value></Option><Option index="5"><Label>Photo Negative No.</Label><Value>sdlhomes_photo_neg_no</Value></Option><Name>rgn1</Name><Default>sdlhomes_present_usage</Default></Rgn><Op name="op2"><Option index="0"><Label>And</Label><Value>And</Value><Focus>true</Focus></Option><Option index="1"><Label>Or</Label><Value>Or</Value></Option><Option index="2"><Label>Not</Label><Value>Not</Value></Option><Name>op2</Name><Default>And</Default></Op><Sel name="select1" abbr="ic_all"><Option index="0"><Label>all</Label><Value>all</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_historic_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_common_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_district_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_ref"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel><Sel name="select1" abbr="sdlhomes_photo_neg_no"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value><Focus>true</Focus></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select1</Name><Default>phrase</Default></Sel></Q><Q name="q2"><Value/><Rgn name="rgn2"><Option index="0"><Label>Anywhere in record</Label><Value>ic_all</Value></Option><Option index="1"><Label>Historic Name</Label><Value>sdlhomes_historic_name</Value></Option><Option index="2"><Label>Common Name</Label><Value>sdlhomes_common_name</Value></Option><Option index="3"><Label>District Name</Label><Value>sdlhomes_district_name</Value></Option><Option index="4"><Label>Bibliographic Reference</Label><Value>sdlhomes_ref</Value></Option><Option index="5"><Label>Photo Negative No.</Label><Value>sdlhomes_photo_neg_no</Value></Option><Name>rgn2</Name><Default>all</Default></Rgn><Sel name="select2" abbr="ic_all"><Option index="0"><Label>all</Label><Value>all</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_historic_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_common_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_district_name"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_ref"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel><Sel name="select2" abbr="sdlhomes_photo_neg_no"><Option index="0"><Label>all</Label><Value>all</Value></Option><Option index="1"><Label>any</Label><Value>any</Value></Option><Option index="2"><Label>phrase</Label><Value>phrase</Value></Option><Option index="3"><Label>ic_exact</Label><Value>ic_exact</Value></Option><Name>select2</Name><Default/></Sel></Q><HiddenVars><Variable name="type">boolean</Variable>
+<Variable name="c">sdlhomes</Variable>
+</HiddenVars><ResultsViewOptions><Option index="0"><Label>thumbnail</Label><Value>thumbnail</Value></Option><Option index="1"><Label>thumbfull</Label><Value>thumbfull</Value></Option><Option index="2"><Label>reslist</Label><Value>reslist</Value><Focus>true</Focus></Option><Name>view</Name><Default>reslist</Default></ResultsViewOptions></SearchForm>
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0109___SL010901__TIF.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0109___SL010901__TIF.xml
@@ -1,0 +1,806 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0109___SL010901__TIF">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0109</Param>
+<Param name="viewid">sl010901.tif</Param>
+<Param name="view">entry</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0109 SL010901.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sdlhomes;entryid=x-sl0109;viewid=sl010901.tif;view=entry;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>f2f225f7faaf2aa75e5e4f12aba7ff46</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0109</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0109___SL010901__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0109%5DSL010901.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0109%5DSL010901.TIF</ItemUrlEncoded><TitleForTagging>209%20N.%20Ann%20Arbor%20St.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next/>
+<Prev/>
+<Self/>
+<TotalResults>0</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260641</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;page=search</SearchLink>
+<BackLink/>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0109]SL010901.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABgADBAUHAgEI/8QAPBAAAgEDAwIDBgMGAwkAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcYGRodEWI0JTk7FiwfAVJCU1Q4OSotL/xAAXAQEBAQEAAAAAAAAA
+AAAAAAAAAQMC/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBAjFB/9oADAMBAAIRAxEAPwDYntYg283V
+yoPO3x2p2OK3dRiac58/Gb9aoJNU8eMNBFLKEYgmRgCWzjGBz6/Ore0Z2jRmjHI/g7Cs4JptI/5k
+/wDWb9a5NnGf+pP/AFm/Wn1JIGe9LNBH9ij/AJtx/Wb9a89jT+bcf1m/WpGa8JoIM9mBGxSS6J/w
+ztn+9CeqXd5p7gG8uVQ5J33GT9CfL7ZoxupljjO4rg8YJoJ1hZ4pBNPceMsZV49rEgDPfGPQeWfO
+grYOoL6EH2y4vJFPBeKZyIRj4mAGSe3ypqbqO4ijeeO/v5LTeoZ3uBHJCWGFBQktsJ7MQPw5rm9v
+rSC5jZbqLc5DbpGG0IO+fPPoOefvQH1FZSXPUc8sUiXcE7gI5cj3QMnaW4xwQM8eldQTb7qXrC01
+ldOi1bUDcxsVMck24OwGccDnI5GO+aYvuretjqJtxfXsMinYYoJ9wLge8Af7jy7UO3LXunX9qWE0
+dxCwaJ2bnGcDA9Mg80W6ZeXWlRxare3sdxayruKJMql9rH3QCpGQRkD05qxWs9EXd3f9HaddX0sk
+tzIjF3kOWJ3t3NKn+k7o3vTFlcmFYfFVnCKgUYLHBwOBkc/elWO+qhNqUYuoZVZTJdN7qqQcNjGR
+88iiG1eOCIxjKhRuAIxgE1nmiWbprOjRK/iB5Z3ZcD92RyfxAB+1Et3qRe88NGAibMniA58MKf8A
+Ic8+bVo5FCXKlWJI90ZJHOKUVzFMSEcHBxWZDqW4gvp7WLxAiK6pGVJZgRwee3507ofUYtBI4Ilm
+mlCBi2I4VwMk55JJz9cUg041W3ms2VlIY55grgfD59s1Wr1dYTWc7xSo8kYztLYyMgd/vWb9W6hL
+b6ywaYywq+xWPfg55Pn3x9AKmYCHX+tNPu/93iZsE7dw/I0P2mvia+WFt0Uzo8fjI5XuRhgqnJPq
+O2eaBrht13IEjaRzyFUE5+f0ptbpAY4YbnD5OSgJZPLv+P413Br8cOjWkSSCGSfUpG3oJ0YyufJg
+oHIGe/HzIoZ12JgqrH7NDemQMmWJPJ2jxAB4fw5yOc5xzmq3T0spdPNvLduJA24PJEIwFPG4tjJP
+34wKs7DQhc6hcG1cajZWjKZGikEMkrY52Ovu8c4zjz5zzUAl1PYajaW1jNfQBLaQ5SdF/dsQecAk
+4XjtwO/FRo4Lwl4hHG1vbc7ioVMsOCcjvgceePQUV9V3rar01dwWDSz2tt4byidVV4VDegwfyPnz
+zUDSorW96ViMsN4ILVi9w6KcSsSAee3uoFA+dX4rX+iZZJuj9PkmRY3KMCq8gYYgY+VKmugIfA6I
+06MEkAPjPpvalWO+qHp9X0rS1N5G1x7WgfZ4h2qviDGfXGcUDHXZYbpp2lYe6sYTO5ZMcsWHzPcU
+x1es0WrTxN4wj38HYQvwgnBPehxzvMY3qqnzY/6/GtsxyvW6iuRqBmLhJdhUN3x/oZpXOtR7QYIU
+SIAeFEB3bzZs/b8PTuP3SCC6kj3bijYyvvD8fOvA5IBHOfWrBNtL6/D3AUvJHLjxQOefX5YoqScS
+6cpk0+41NhgpIU8CIDyBY+8w+wprUbe6ihtntYyyMHXBiXaCGIAC9hwPrRBYXtzKbC0llZIzKUdQ
+cZHh8L+NTdAQLPVNSDeLai3seSUgHhw8ep7tz6k1KXo57mBPAjZrjaSERWUg54CsMg8d+3fyqJqi
+SgMY3kd4n2fGzenz+dSLOOQ26ySzTAlRwJGGDjJ86Cbp9l1ZoAuo7pHis1iMhlkbxAApzj3TgknF
+VWmXM1xqszyySxxTlluGt5GQvkFj278A8HPendTaSHS55UuJyFXJBlYg8+YzVHperpYwbpI3c+Lv
+4I80Zf8AOiirqK4jfQSI7m3vkVAscykJNEN3wnHDqc89uakdNz2ydOWizX0rs1wypZx+9znvt5yx
+zkcY49eaz0zvNJCruW3Dknk9zU6CeSzZZYmIPvE/MirB9K9NI0egWytb+zn3j4WANoLEjgdvXHl2
+pVD6FvZdQ6L026mkaSSRDuZu5IYj/KlWGqe1Cw0ppFmuLSOQRZ2qxLLzx8B4oek0vR/amCaHp65O
+RviGR9ajSdTStKRJbwxqSf4zwM/3qO2vCLfLHHE5xxvk7GtETI+n9DSbI6esPeOMmM4P2zxVtP0b
+03dQeFJo9rGMZBjXYw+hFUEHUcl3PEkNqHYsNqB/eJ9KMbVbn2X98D4zZYozA7QfIHGMCiBPqHoT
+2yyVLCch0JKLIeOSec/c1E03pnUdNu4ZrqIThIwoMb52sBjdjjuCaPlljY+GSVcDseKc8MY+IYpR
+i2oWFvBdI5LwTXAbxQ4PxqQOB9KizRPHZSOElaINgSCM4PA+Vbc8MZdXIQsvZiBkU1JBG5y23HpS
+jDTbPqWkSWtthpZRtXcQuT9/pQVJbXERIkgYHsAykV9QNptk596GMnzyKrNR6Y0y6ktc2UMgE4Mg
+IB93a2ftnFdZ1FfOsEEiSRscfF2HkKsY0E1zHBzuckDHnkYwB61vqdI6CkbImm2wV1IbCAZFSbXp
+zSrSMJbWkESq24bUHB9c96b0OugbWSy6J023lR0dFbKuMHlyR/elV9ZxrFbIgOQKVY6rMDHqKyMD
+p8rDP8cLZPP0rmSG+YAnTmz8on4/9aVKu6ho2+pDmOwdWPYiJwR+VWthrWv2aiOaxmuFUYBKNn8d
+tKlSia3UGpNEy/7Ku0J9EJx+VVtxrmsBdsVjqQ+axd/ypUqCHca71A2Gj028kx3EkDLj6ECmv2h6
+kLFjo1zg/wCB/wD5pUqpHf7Q9RY/5Lc/+D/pXA6h6mxzo82T3xE/6UqVCO/2h6kVF/4RcEnuPCf9
+KcHUXUpAxpE4/wC0/wClKlUGhdN3Fzc6DbS3kZjuG3blK7SOT5GlSpVwr//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0109:SL010901.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/514,370/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>514</w>
+    <h>370</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_fn class="fieldsRef">SL010901</m_fn>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0109]SL010901.TIF</istruct_isentryid>
+<istruct_caption class="fieldsRef"/>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<m_id class="fieldsRef">SL0109</m_id>
+<istruct_x class="fieldsRef">1</istruct_x>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0109-1</istruct_isentryidv>
+<m_flm class="fieldsRef">2013-02-08 18:59:46</m_flm>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_iid class="fieldsRef">SL010901.TIF</m_iid>
+<istruct_m class="fieldsRef">SL010901</istruct_m>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_caption class="fieldsRef"/>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<type class="imgInfHashRef">image</type>
+<basename class="imgInfHashRef">SL010901</basename>
+<width class="imgInfHashRef">2056</width>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">414517</size>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/01/09/01/SL010901/SL010901.jp2</filename>
+<md5 class="imgInfHashRef">293ca4df8fa9c77323afbe2c19237f92</md5>
+<modified class="imgInfHashRef">2013-02-08 18:59:46</modified>
+<u class="imgInfHashRef">1</u>
+<ext class="imgInfHashRef">jp2</ext>
+<master class="imgInfHashRef">0</master>
+<levels class="imgInfHashRef">4</levels>
+<access class="imgInfHashRef">1</access>
+<height class="imgInfHashRef">1480</height>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="4"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=4;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=4;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:4/0/native.jpg</Part><LevelWidth>128</LevelWidth><LevelHeight>92</LevelHeight><LevelMaxDim>128</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:3/0/native.jpg</Part><LevelWidth>257</LevelWidth><LevelHeight>185</LevelHeight><LevelMaxDim>257</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:2/0/native.jpg</Part><LevelWidth>514</LevelWidth><LevelHeight>370</LevelHeight><LevelMaxDim>514</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1028</LevelWidth><LevelHeight>740</LevelHeight><LevelMaxDim>1028</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2056</LevelWidth><LevelHeight>1480</LevelHeight><LevelMaxDim>2056</LevelMaxDim></Level><MaxWidth>2056</MaxWidth><MaxHeight>1480</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>209 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=thumbnail;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=thumbnail;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=thumbnail;rgn1=sdlhomes_ownership;q1=Cole%252C%2520Richard%2520E.;select1=phrase" target="_blank">Cole, Richard E.</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>10:36</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>One story, gable front Folk House. The house is one room wide, and sits on a very, narrow lot. Heavy eaves line and pediment front. Hipped roof entry addition to front (east) facade. Shed roof addition to south rear. Stone foundation. Asbestos siding. Aluminum siding on the entry addition. Some windows are six over one. One and a half story barn behind.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=thumbnail;rgn1=sdlhomes_date_construction;q1=pre-1870;select1=phrase" target="_blank">pre-1870</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>1926 City Directory: Jack K. Gabriel (Anna) - laborer. No listing in the U.S. Census of 1920 or the City Directory. On the 1912 Sanborn Map. This lot was probably carved from a larger lot (207). The house was moved to this site, and was formerly a millinery shop. Originally it was a Greek Revival style building.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; Tax Rolls: 1931 and 1935.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 60</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>60</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>209 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>209 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value><Value>One story, gable front Folk House. The house is one room wide, and sits on a very, narrow lot. Heavy eaves line and pediment front. Hipped roof entry addition to front (east) facade. Shed roof addition to south rear. Stone foundation. Asbestos siding. Aluminum siding on the entry addition. Some windows are six over one. One and a half story barn behind.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL010901_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0109:SL010901.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0109:SL010901.TIF" canvas-index="1" mode="single"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?cc=sdlhomes;entryid=x-sl0109;viewid=SL010901.TIF;view=entry;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0109%20SL010901.TIF;lastview=thumbnail</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABgADBAUHAgEI/8QAPBAAAgEDAwIDBgMGAwkAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcYGRodEWI0JTk7FiwfAVJCU1Q4OSotL/xAAXAQEBAQEAAAAAAAAA
+AAAAAAAAAQMC/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBAjFB/9oADAMBAAIRAxEAPwDYntYg283V
+yoPO3x2p2OK3dRiac58/Gb9aoJNU8eMNBFLKEYgmRgCWzjGBz6/Ore0Z2jRmjHI/g7Cs4JptI/5k
+/wDWb9a5NnGf+pP/AFm/Wn1JIGe9LNBH9ij/AJtx/Wb9a89jT+bcf1m/WpGa8JoIM9mBGxSS6J/w
+ztn+9CeqXd5p7gG8uVQ5J33GT9CfL7ZoxupljjO4rg8YJoJ1hZ4pBNPceMsZV49rEgDPfGPQeWfO
+grYOoL6EH2y4vJFPBeKZyIRj4mAGSe3ypqbqO4ijeeO/v5LTeoZ3uBHJCWGFBQktsJ7MQPw5rm9v
+rSC5jZbqLc5DbpGG0IO+fPPoOefvQH1FZSXPUc8sUiXcE7gI5cj3QMnaW4xwQM8eldQTb7qXrC01
+ldOi1bUDcxsVMck24OwGccDnI5GO+aYvuretjqJtxfXsMinYYoJ9wLge8Af7jy7UO3LXunX9qWE0
+dxCwaJ2bnGcDA9Mg80W6ZeXWlRxare3sdxayruKJMql9rH3QCpGQRkD05qxWs9EXd3f9HaddX0sk
+tzIjF3kOWJ3t3NKn+k7o3vTFlcmFYfFVnCKgUYLHBwOBkc/elWO+qhNqUYuoZVZTJdN7qqQcNjGR
+88iiG1eOCIxjKhRuAIxgE1nmiWbprOjRK/iB5Z3ZcD92RyfxAB+1Et3qRe88NGAibMniA58MKf8A
+Ic8+bVo5FCXKlWJI90ZJHOKUVzFMSEcHBxWZDqW4gvp7WLxAiK6pGVJZgRwee3507ofUYtBI4Ilm
+mlCBi2I4VwMk55JJz9cUg041W3ms2VlIY55grgfD59s1Wr1dYTWc7xSo8kYztLYyMgd/vWb9W6hL
+b6ywaYywq+xWPfg55Pn3x9AKmYCHX+tNPu/93iZsE7dw/I0P2mvia+WFt0Uzo8fjI5XuRhgqnJPq
+O2eaBrht13IEjaRzyFUE5+f0ptbpAY4YbnD5OSgJZPLv+P413Br8cOjWkSSCGSfUpG3oJ0YyufJg
+oHIGe/HzIoZ12JgqrH7NDemQMmWJPJ2jxAB4fw5yOc5xzmq3T0spdPNvLduJA24PJEIwFPG4tjJP
+34wKs7DQhc6hcG1cajZWjKZGikEMkrY52Ovu8c4zjz5zzUAl1PYajaW1jNfQBLaQ5SdF/dsQecAk
+4XjtwO/FRo4Lwl4hHG1vbc7ioVMsOCcjvgceePQUV9V3rar01dwWDSz2tt4byidVV4VDegwfyPnz
+zUDSorW96ViMsN4ILVi9w6KcSsSAee3uoFA+dX4rX+iZZJuj9PkmRY3KMCq8gYYgY+VKmugIfA6I
+06MEkAPjPpvalWO+qHp9X0rS1N5G1x7WgfZ4h2qviDGfXGcUDHXZYbpp2lYe6sYTO5ZMcsWHzPcU
+x1es0WrTxN4wj38HYQvwgnBPehxzvMY3qqnzY/6/GtsxyvW6iuRqBmLhJdhUN3x/oZpXOtR7QYIU
+SIAeFEB3bzZs/b8PTuP3SCC6kj3bijYyvvD8fOvA5IBHOfWrBNtL6/D3AUvJHLjxQOefX5YoqScS
+6cpk0+41NhgpIU8CIDyBY+8w+wprUbe6ihtntYyyMHXBiXaCGIAC9hwPrRBYXtzKbC0llZIzKUdQ
+cZHh8L+NTdAQLPVNSDeLai3seSUgHhw8ep7tz6k1KXo57mBPAjZrjaSERWUg54CsMg8d+3fyqJqi
+SgMY3kd4n2fGzenz+dSLOOQ26ySzTAlRwJGGDjJ86Cbp9l1ZoAuo7pHis1iMhlkbxAApzj3TgknF
+VWmXM1xqszyySxxTlluGt5GQvkFj278A8HPendTaSHS55UuJyFXJBlYg8+YzVHperpYwbpI3c+Lv
+4I80Zf8AOiirqK4jfQSI7m3vkVAscykJNEN3wnHDqc89uakdNz2ydOWizX0rs1wypZx+9znvt5yx
+zkcY49eaz0zvNJCruW3Dknk9zU6CeSzZZYmIPvE/MirB9K9NI0egWytb+zn3j4WANoLEjgdvXHl2
+pVD6FvZdQ6L026mkaSSRDuZu5IYj/KlWGqe1Cw0ppFmuLSOQRZ2qxLLzx8B4oek0vR/amCaHp65O
+RviGR9ajSdTStKRJbwxqSf4zwM/3qO2vCLfLHHE5xxvk7GtETI+n9DSbI6esPeOMmM4P2zxVtP0b
+03dQeFJo9rGMZBjXYw+hFUEHUcl3PEkNqHYsNqB/eJ9KMbVbn2X98D4zZYozA7QfIHGMCiBPqHoT
+2yyVLCch0JKLIeOSec/c1E03pnUdNu4ZrqIThIwoMb52sBjdjjuCaPlljY+GSVcDseKc8MY+IYpR
+i2oWFvBdI5LwTXAbxQ4PxqQOB9KizRPHZSOElaINgSCM4PA+Vbc8MZdXIQsvZiBkU1JBG5y23HpS
+jDTbPqWkSWtthpZRtXcQuT9/pQVJbXERIkgYHsAykV9QNptk596GMnzyKrNR6Y0y6ktc2UMgE4Mg
+IB93a2ftnFdZ1FfOsEEiSRscfF2HkKsY0E1zHBzuckDHnkYwB61vqdI6CkbImm2wV1IbCAZFSbXp
+zSrSMJbWkESq24bUHB9c96b0OugbWSy6J023lR0dFbKuMHlyR/elV9ZxrFbIgOQKVY6rMDHqKyMD
+p8rDP8cLZPP0rmSG+YAnTmz8on4/9aVKu6ho2+pDmOwdWPYiJwR+VWthrWv2aiOaxmuFUYBKNn8d
+tKlSia3UGpNEy/7Ku0J9EJx+VVtxrmsBdsVjqQ+axd/ypUqCHca71A2Gj028kx3EkDLj6ECmv2h6
+kLFjo1zg/wCB/wD5pUqpHf7Q9RY/5Lc/+D/pXA6h6mxzo82T3xE/6UqVCO/2h6kVF/4RcEnuPCf9
+KcHUXUpAxpE4/wC0/wClKlUGhdN3Fzc6DbS3kZjuG3blK7SOT5GlSpVwr//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0109:SL010901.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0109:SL010901.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0206___SL020601__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0206___SL020601__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
@@ -1,0 +1,814 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0206___SL020601__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="q1">Residence</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">1</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0206</Param>
+<Param name="viewid">SL020601.TIF</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0206 SL020601.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>a1abf4edea19b13cba5570d4c45e31d5</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0206</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0206___SL020601__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0206%5DSL020601.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0206%5DSL020601.TIF</ItemUrlEncoded><TitleForTagging>313%20N.%20Ann%20Arbor%20St.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="1" name="S_SDLHOMES_X_SL0303___SL030301__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF</Url></Next>
+<Prev><Url index="9" name="S_SDLHOMES_X_SL0909___SL090903__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0909;viewid=SL090903.TIF</Url></Prev>
+<Self><Url index="0" name="S_SDLHOMES_X_SL0206___SL020601__TIF">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF</Url></Self>
+<TotalResults>10</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260766</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;q1=Residence;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0206]SL020601.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQADBAYHAggB/8QAORAAAgEDAgQEAwQJBQEAAAAA
+AQIDAAQRBSEGEjFBEyJhcRRR0RWBkaEHIyQyQkNSkrEmRHKiwYL/xAAYAQEBAQEBAAAAAAAAAAAA
+AAAAAQIDBP/EABkRAQEBAQEBAAAAAAAAAAAAAAABERIxQf/aAAwDAQACEQMRAD8ArXFPG2vvxBew
+x6xewxQTyRIIpimysQM469KCxcVcSz3UcA1++UyOFDyXjKq5PUnOw9aXGbIOLdRWC4e4RJ3AdlIx
+vkqAewJI9etAAQGBYHHyFWSYrVLuLWbbR1vYeI9R1CEOEmmtLiRE6fyy27+pG2cUN0DiziiDXZ1F
+xLqX7Kp5J74cqqSvK3MPKDkgHPzIO9VHTy6KskN0xOC0kUTFGQeuRg9uma7jjt7LiBRfwyG3ch3R
+urKd8kY6HrjFTAe1PijUedom13UY7lrlyxjuVMSAdBlT0B5th1GKD23EGvTzOPty8AVWctJduqkD
+sN+p7Cvt9c6KmqMsNpdjTwgAha4UnnBJzzco8uT0xmhDGHxs4Cr1whz+ZpgtNvr+szWrIdSulUFQ
+bh7qQBATv33+gPzq96JqGvXcV1b6ZL8exZQ14JW8JyRvy5AIxgbDbrk71ndjdarpWnW+rxmWW0+J
+GY5PNGzKMZZe+2AM1d7DjK75NHs/hoF/XpIYLBT+uU75Y9AegwB94qWDU+HLd7bRrMXcrzXMgxI8
+jZ8wyTjsB8sUb5E/pH4UAurq6Nmk1pbGMF0eNZWUcuDhhgZ7HpU6J7yeZx4saIsZw0ac3mz82O/b
+tWMQS8Nf6R+FcSGGLeQxp/yIFDpr22isIrq4lndZHVOUtg5O2MLiiEMUSKCkKIfRRn8aYG2kibBj
+OV+YBpV3MfOPalXNp5X4yvUu+I72KO2hhEV1MuYlwz5f+L59PzoHJbyW7gOp3Ab94HqAR096I8Rh
+m4r1QLzMTeTDCjr5zUC4vZ7sQfEEOIIxGmAB5R0r0zxHCvKvMgKEN1yMmierQalZ6rFFraTx3DwL
+gTgEhCCFbr0H47VG02SJNTga5tw1uJVZ0yQeXIJ3G/SjPFOtwa/xfLeC2h+F8PwIVRWC8uDhtwCS
+Cc9PyoK+ywLADGHLbgl8YPsKaMg6AKN/4RRDQ4rCXWF+1kmazXmaSO3YBiACds9u/tUKU25iQo5M
+vUk9/f17fLagcMod+ZowFGPIGOMj3z6/jU/T75heQhJvCj5wAZGIVRnvjflGT07ZqJcap8eiBra3
+haMcviRJyFwf6h0PvjNMRSNHICQFYEEbZx8sUHpKy12C+0a2ntr83str+0yLygNKI9nGO2x5lHpR
+D7UXRdNsJLhHeIQrGrqQecsAQPv336bVkHCWtWGnmV7WDUJ9WuIvBUcqsjOc7Y7g9wfuIrSZ9B4h
+1VdJjuLa0trawEZET3JYu6AAM3KMY26dd+tc6iXpttqMkVuLiCNGWTxI4DJ5lB3XxMDAI2+5at0Q
+kVeVzkjuFwKpmscQy8LkLLJDe3kjBpEjQqI12G5J22G3ck5OBVqttRtrqCG4gkDRTIHQnuDQPTfv
+DftSrlpUcg82Nu9KubTytxJIrcT6kjs7xx3sxVc8pGXPNuPXvQlpg6MnKFXJOy/lRLiUf6p1UIMk
+3k23/wBmh8Z5XDKh8vvXoniGcnbGRj505ZTyreQMI0mKvlY5d1b0I+VGLKx0q+Syslu54b+a5KSM
+y5iRMeU+pzmg8tq0UsUZIyx3wMY8xH/lA4+qXME0nw8aWrG3+FcKMkrjDdehO+4xQ5iWwSoHt3qU
+C8MXOjKOY4IIznFcRqzzJGCMscb+tVTQUE4APpU+AvHGoXlKN5iG3yeldXFjJa6lJaZUtHgZ7Hyg
+5/OrRJpFhZaOLiWCSS5Ai6KVA5gM+h6j33qWoNcKceXmj2kdpDpGnPMWLG5lzzE/d0+W1WG1/SZx
+DfX0MAgsIY5GKFljZiOu4yfSqB4KRvPM9pMsMZzyvKeZie21XDQtLsZH065aNlDvk5lbYcretYof
+vOZlv3nBlZJF5mY5LlgMkn3NHeGEvrayms5vE+DjcTRSAgcoDYf7jn8c09eWViNXTTFa5DyRiTJc
+OuMkbhhntUC71mTSdWfRp5I2hFuXSVgFYE+bBPy2x99QW2OLVFLmTlcsxIweg+R9aVBNK1yW+hnn
+MrgNM3KM9AQCP80q51Wa6twPrx4rvL5bdVikupJFYuM4LHGx74ND9I4E1V7/AMO/t/AtijAyFg3K
+cHBwDk74q5ycfw6LxHfRDTRIi3Do4+IchsE7gNkA+1XfhrirR+LJZIIbGWCdF5isigjHowrrtxGV
+anwoNJntW0a5/aVXzPKmA3lPMRnbb/GO9A5eCdSjCSO6kZCsvKSfy616MvLDS7flluVROqqxUnGe
+o2G1KPT9JQggw5PTMg+tOqjzjPwLr3i4FkHHpMv1qPb8F69JcGNdKmZg/ISCPKffP516cOl2MgyI
+lPqDXa6dbJ+7FTqjApv0fcTXNytzFprhiiKeaRM5AwSd981co+E9c1LTYLC801IkiiXDSTLjnUbD
+Yk9a05bZQ6lVI5c9WP8AjvXUFxBPLPDHLG8sDBZVQ55CRkA+uKmjK14A1+ObmaK0lViCQJumevUd
+qOWXC+qW8tk0lrGY1k5pEWRfIMEf+9q0Ar60gKCvRafcNK8ktjyyK5VJC6sWXsc9vaq3xbwdqeuv
+FPbhEMIYhXYZIwNh9+a0bFfD0oM30Ph/VrCwMU9q3MX5tyOmB6+lKtCcbjbtSrFaeauJZ7+DibU2
+RZJV+LkARIiDjmPflq08H6jaaTdx381/qQkKENbm0yoz82GCfwpUq6/EaFFx3phjYmV+cDYCGUZ9
+vLU6DivRZoTIZMMOzwMC3ttSpVkOx8V6U5YCcBRsDyNufTb86krr+msuVuk/A/SlSqBwa3px/wBy
+v9rfSolhJothLcS28oD3ErSuzBjuxyQNthnfFKlQT/texzj4gf2t9K+jVLI9Jx/a30pUqmj79pWZ
+/nf9G+lL7RtT/N/6N9KVKmj58XA+6vkf8T9KVKlWVf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0206:SL020601.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/510,366/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>510</w>
+    <h>366</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_caption class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_iid class="fieldsRef">SL020601.TIF</m_iid>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2013-02-08 18:59:36</m_flm>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_id class="fieldsRef">SL0206</m_id>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<m_fn class="fieldsRef">SL020601</m_fn>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0206-1</istruct_isentryidv>
+<istruct_m class="fieldsRef">SL020601</istruct_m>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_caption class="fieldsRef"/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0206]SL020601.TIF</istruct_isentryid>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_x class="fieldsRef">1</istruct_x>
+<levels class="imgInfHashRef">3</levels>
+<ext class="imgInfHashRef">jp2</ext>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<modified class="imgInfHashRef">2013-02-08 18:59:36</modified>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<basename class="imgInfHashRef">SL020601</basename>
+<master class="imgInfHashRef">0</master>
+<size class="imgInfHashRef">406999</size>
+<md5 class="imgInfHashRef">1e04640a6f1714ada4b5123834bb7648</md5>
+<loaded class="imgInfHashRef">2013-11-25 02:17:28</loaded>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/02/06/01/SL020601/SL020601.jp2</filename>
+<use class="imgInfHashRef">access</use>
+<access class="imgInfHashRef">1</access>
+<type class="imgInfHashRef">image</type>
+<width class="imgInfHashRef">2040</width>
+<height class="imgInfHashRef">1464</height>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>3</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/res:3/0/native.jpg</Part><LevelWidth>255</LevelWidth><LevelHeight>183</LevelHeight><LevelMaxDim>255</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/res:2/0/native.jpg</Part><LevelWidth>510</LevelWidth><LevelHeight>366</LevelHeight><LevelMaxDim>510</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1020</LevelWidth><LevelHeight>732</LevelHeight><LevelMaxDim>1020</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;start=1;resnum=1;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2040</LevelWidth><LevelHeight>1464</LevelHeight><LevelMaxDim>2040</LevelMaxDim></Level><MaxWidth>2040</MaxWidth><MaxHeight>1464</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_national_register_listed" searchfield="false" sortfield="false"><Values><Value>10/10/85</Value></Values><Label display="on">National Register Listed</Label></Field><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_district_name" searchfield="false" sortfield="false"><Values><Value>North Ann Arbor Street</Value></Values><Label display="on">District Name</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>313 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_ownership;q1=Freeman%252C%2520Calvin%2520and%2520Roxanne;select1=phrase" target="_blank">Freeman, Calvin and Roxanne</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>11:10</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>North and east facades  taken facing southwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>One and a half story, cross gabled, Craftsman style house. Gabled dormer on center front roof. Full width porch with tapering, wood columns resting on formed concrete block piers. Wood balustrade. One over one windows. Wood shingles on second story, and aluminum siding on the first. Addition to the rear. Two car, gable front garage at rear.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_date_construction;q1=1910%2520ca.;select1=phrase" target="_blank">1910 ca.</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>Owners: Eva Rogers 1910-1920; George and Ada Bracey 1920-1925; George A. Hartmann 1926-1940; C. Graydon and Doris Everett 1940-1955; Oscar Smith 1956-1961; Robert Todd 1962-1982; Calvin Freeman 1982-1994. This house is listed on the National Register as part of the North Ann Arbor Street Historic District.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; 1985 Multiple Resource Nomination, Laurie Sommers.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 82</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>82</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>313 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>313 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>North and east facades  taken facing southwest</Value><Value>One and a half story, cross gabled, Craftsman style house. Gabled dormer on center front roof. Full width porch with tapering, wood columns resting on formed concrete block piers. Wood balustrade. One over one windows. Wood shingles on second story, and aluminum siding on the first. Addition to the rear. Two car, gable front garage at rear.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL020601_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0206:SL020601.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0206:SL020601.TIF" canvas-index="1" mode="single"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=1;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0206%20SL020601.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQADBAYHAggB/8QAORAAAgEDAgQEAwQJBQEAAAAA
+AQIDAAQRBSEGEjFBEyJhcRRR0RWBkaEHIyQyQkNSkrEmRHKiwYL/xAAYAQEBAQEBAAAAAAAAAAAA
+AAAAAQIDBP/EABkRAQEBAQEBAAAAAAAAAAAAAAABERIxQf/aAAwDAQACEQMRAD8ArXFPG2vvxBew
+x6xewxQTyRIIpimysQM469KCxcVcSz3UcA1++UyOFDyXjKq5PUnOw9aXGbIOLdRWC4e4RJ3AdlIx
+vkqAewJI9etAAQGBYHHyFWSYrVLuLWbbR1vYeI9R1CEOEmmtLiRE6fyy27+pG2cUN0DiziiDXZ1F
+xLqX7Kp5J74cqqSvK3MPKDkgHPzIO9VHTy6KskN0xOC0kUTFGQeuRg9uma7jjt7LiBRfwyG3ch3R
+urKd8kY6HrjFTAe1PijUedom13UY7lrlyxjuVMSAdBlT0B5th1GKD23EGvTzOPty8AVWctJduqkD
+sN+p7Cvt9c6KmqMsNpdjTwgAha4UnnBJzzco8uT0xmhDGHxs4Cr1whz+ZpgtNvr+szWrIdSulUFQ
+bh7qQBATv33+gPzq96JqGvXcV1b6ZL8exZQ14JW8JyRvy5AIxgbDbrk71ndjdarpWnW+rxmWW0+J
+GY5PNGzKMZZe+2AM1d7DjK75NHs/hoF/XpIYLBT+uU75Y9AegwB94qWDU+HLd7bRrMXcrzXMgxI8
+jZ8wyTjsB8sUb5E/pH4UAurq6Nmk1pbGMF0eNZWUcuDhhgZ7HpU6J7yeZx4saIsZw0ac3mz82O/b
+tWMQS8Nf6R+FcSGGLeQxp/yIFDpr22isIrq4lndZHVOUtg5O2MLiiEMUSKCkKIfRRn8aYG2kibBj
+OV+YBpV3MfOPalXNp5X4yvUu+I72KO2hhEV1MuYlwz5f+L59PzoHJbyW7gOp3Ab94HqAR096I8Rh
+m4r1QLzMTeTDCjr5zUC4vZ7sQfEEOIIxGmAB5R0r0zxHCvKvMgKEN1yMmierQalZ6rFFraTx3DwL
+gTgEhCCFbr0H47VG02SJNTga5tw1uJVZ0yQeXIJ3G/SjPFOtwa/xfLeC2h+F8PwIVRWC8uDhtwCS
+Cc9PyoK+ywLADGHLbgl8YPsKaMg6AKN/4RRDQ4rCXWF+1kmazXmaSO3YBiACds9u/tUKU25iQo5M
+vUk9/f17fLagcMod+ZowFGPIGOMj3z6/jU/T75heQhJvCj5wAZGIVRnvjflGT07ZqJcap8eiBra3
+haMcviRJyFwf6h0PvjNMRSNHICQFYEEbZx8sUHpKy12C+0a2ntr83str+0yLygNKI9nGO2x5lHpR
+D7UXRdNsJLhHeIQrGrqQecsAQPv336bVkHCWtWGnmV7WDUJ9WuIvBUcqsjOc7Y7g9wfuIrSZ9B4h
+1VdJjuLa0trawEZET3JYu6AAM3KMY26dd+tc6iXpttqMkVuLiCNGWTxI4DJ5lB3XxMDAI2+5at0Q
+kVeVzkjuFwKpmscQy8LkLLJDe3kjBpEjQqI12G5J22G3ck5OBVqttRtrqCG4gkDRTIHQnuDQPTfv
+DftSrlpUcg82Nu9KubTytxJIrcT6kjs7xx3sxVc8pGXPNuPXvQlpg6MnKFXJOy/lRLiUf6p1UIMk
+3k23/wBmh8Z5XDKh8vvXoniGcnbGRj505ZTyreQMI0mKvlY5d1b0I+VGLKx0q+Syslu54b+a5KSM
+y5iRMeU+pzmg8tq0UsUZIyx3wMY8xH/lA4+qXME0nw8aWrG3+FcKMkrjDdehO+4xQ5iWwSoHt3qU
+C8MXOjKOY4IIznFcRqzzJGCMscb+tVTQUE4APpU+AvHGoXlKN5iG3yeldXFjJa6lJaZUtHgZ7Hyg
+5/OrRJpFhZaOLiWCSS5Ai6KVA5gM+h6j33qWoNcKceXmj2kdpDpGnPMWLG5lzzE/d0+W1WG1/SZx
+DfX0MAgsIY5GKFljZiOu4yfSqB4KRvPM9pMsMZzyvKeZie21XDQtLsZH065aNlDvk5lbYcretYof
+vOZlv3nBlZJF5mY5LlgMkn3NHeGEvrayms5vE+DjcTRSAgcoDYf7jn8c09eWViNXTTFa5DyRiTJc
+OuMkbhhntUC71mTSdWfRp5I2hFuXSVgFYE+bBPy2x99QW2OLVFLmTlcsxIweg+R9aVBNK1yW+hnn
+MrgNM3KM9AQCP80q51Wa6twPrx4rvL5bdVikupJFYuM4LHGx74ND9I4E1V7/AMO/t/AtijAyFg3K
+cHBwDk74q5ycfw6LxHfRDTRIi3Do4+IchsE7gNkA+1XfhrirR+LJZIIbGWCdF5isigjHowrrtxGV
+anwoNJntW0a5/aVXzPKmA3lPMRnbb/GO9A5eCdSjCSO6kZCsvKSfy616MvLDS7flluVROqqxUnGe
+o2G1KPT9JQggw5PTMg+tOqjzjPwLr3i4FkHHpMv1qPb8F69JcGNdKmZg/ISCPKffP516cOl2MgyI
+lPqDXa6dbJ+7FTqjApv0fcTXNytzFprhiiKeaRM5AwSd981co+E9c1LTYLC801IkiiXDSTLjnUbD
+Yk9a05bZQ6lVI5c9WP8AjvXUFxBPLPDHLG8sDBZVQ55CRkA+uKmjK14A1+ObmaK0lViCQJumevUd
+qOWXC+qW8tk0lrGY1k5pEWRfIMEf+9q0Ar60gKCvRafcNK8ktjyyK5VJC6sWXsc9vaq3xbwdqeuv
+FPbhEMIYhXYZIwNh9+a0bFfD0oM30Ph/VrCwMU9q3MX5tyOmB6+lKtCcbjbtSrFaeauJZ7+DibU2
+RZJV+LkARIiDjmPflq08H6jaaTdx381/qQkKENbm0yoz82GCfwpUq6/EaFFx3phjYmV+cDYCGUZ9
+vLU6DivRZoTIZMMOzwMC3ttSpVkOx8V6U5YCcBRsDyNufTb86krr+msuVuk/A/SlSqBwa3px/wBy
+v9rfSolhJothLcS28oD3ErSuzBjuxyQNthnfFKlQT/texzj4gf2t9K+jVLI9Jx/a30pUqmj79pWZ
+/nf9G+lL7RtT/N/6N9KVKmj58XA+6vkf8T9KVKlWVf/Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0206:SL020601.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0206:SL020601.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0303___SL030301__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0303___SL030301__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
@@ -1,0 +1,891 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0303___SL030301__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="q1">Residence</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">2</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0303</Param>
+<Param name="viewid">SL030301.TIF</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0303 SL030301.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>4280e02f54084b90e7b44ff2fab2f08b</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0303</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0303___SL030301__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0303%5DSL030301.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0303%5DSL030301.TIF</ItemUrlEncoded><TitleForTagging>407%20N.%20Ann%20Arbor%20St.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="2" name="S_SDLHOMES_X_SL0303___SL030302__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF</Url></Next>
+<Prev><Url index="0" name="S_SDLHOMES_X_SL0206___SL020601__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0206;viewid=SL020601.TIF</Url></Prev>
+<Self><Url index="1" name="S_SDLHOMES_X_SL0303___SL030301__TIF">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF</Url></Self>
+<TotalResults>10</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260767</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;q1=Residence;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0303]SL030301.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABJAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABQYDBAcAAQII/8QAORAAAgECBAUCBAQFAgcAAAAA
+AQIDBBEABRIhBhMxQVEiYRQycYEVI5GhFjNCscEHJDRiorLR4fD/xAAXAQEBAQEAAAAAAAAAAAAA
+AAAAAQID/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBEiEx/9oADAMBAAIRAxEAPwAzw/xVmb5vnTV9
+XW1lLDSuyxwvbksHIHixsv74srxRXz8GUzQZoz1zQJy5UJMkstrtsR0HQnz7YQ4q3Mmqc5oaSyfG
+VD89idLMuo+kHwRcknYWwWyzL80hqpsoeAkTIj1TRSBdEF7KisxsdVrdjt37ZgK5Xm3ElfWGaozm
+ajpeXHKElnNgrD03YKbEgX7de2C8mf5rRxyVSz6oafSZllq9W9+guATfpgVT1dVRyZlDEY4ZDI0R
+Mg1CFUARRzASB3tq29++F/Qme5qf9qTltGeXJyiBzH7knxfsPPvhAYoOMM7zmsVYZa1YOXeTlSqr
+Ndj8rObDxfc7Gwxb/G85FYY6nMKuKIT7wRz/AJiggEAuRuB3sB1Jvtim1M8VYCiwaZIToTT+XJYb
+DpdWO4ttYgYmzGthkoy1IzxNSrFKYZ9mOkldI9z08be+AZcuziWuikWjrZw8pIJmm5nw6jbV16k9
+MQc/iHK5ifjJqkWUtFObgg3HpbrfATLoacV0MCSiKpiRZTMRsHbsRfoSTfxt0w5VGYg0VNWzoiGK
+VVdg1wfVaxuNiG3/AF3xIF6o4krDO0sGYyxsUZXp33Csu+2/cdxffBxczqhQUUoqWkd5FBIf5rqf
+84BZ9QyS0lakg5SI6sqPe6am+cH7gG21sEKSSeDJaWnKKGFTEY1v0N7EX++oX7A+MICNJWVVXDVS
+iefloTGbA3XbdgT0IJ9umJ6DMJ4sljNetSJ3QESBWYMD03G4Njiejhb8O1QpG4aN7erd7k2P19sQ
+UcktXkWUpEyAPGqkljdkC7i1tr2H64kFrKM0FbRklncxOYjIFI12/qIO4NiLjzjsWYINIdmiKM7a
+iL37AePbHYxrTMcgy2tra7NMyNLO4nqmTXEvzIhtpF7bXHY32GLvDC0n41nWYwRQiA1Qp0BQgqqL
+udJ7km3nbDzRTUGXJLA1O1PCp1KTvewubH63P64Ucirsrov9PZMzzGKJkmkmqmEiD1a5CVA9zYDH
+VlQ/iWLh/hDMp4JIxUVVVUaISBZ9UjKDYdCAPptbCnksNZDk3OgnnSJbNKqSMoYtcattu1v084HZ
+XSVvEc9DTNGY6JZWI0qSLsxJP72+2NJSkESVEMC6oUcrJBGLIwAAtbyd9/8AxgEtp54Z6Wq+IkmR
+Td4w2gm2/UWubXHn3xPUVSZlFG0LGFo1GuJxchbq1t+xKg/c774p5lDJSV8tKqu6wykbLfftf7bY
+qTVUUermIyncWKnYHwbbWP7YKZspzJY+IHzSbSFdCpGgne4FvY7YcZ6/Lwmmn5dRSVo0zxJs1+hI
+Hc77j29sZjR10RgYPURqD1XoGPnfBTLM0y6Iu9ZURoVN40D6r+SQL74IfKsGtyiSnqiGnLomu27h
+WHqHboL/AHwPqszpqX4GMgScqoDuG+WSzMVsT8vXr07Y9pnkzCJGT007AEXHUYoVnwj8QRZZJSa2
+eE2kLbWIubjv0xA+ZHKKqlhf0jQPzApuDITc/p498UcqnWGojg0FpKaN6b0i9rSsBfxso/XAHKsy
+m4arPhqm8lHKbI56jwCfPg9+h7YLZCUrOJM3rYVCpJJFcHqbR7n2ubYBkVwyghgcdj1lGrqB7Y7H
+PWmZcXcQzw8LViSSqsks5p0cG5tqIJt5Av8ApjPqzOVzP4Onn5q5PRII44lPqmKiwP1PfwMWaqgk
+zrNa2orZ3WngmlVL7l9LHb2GIsnoIsxzOGijg11EpVISz2Rb+1sdsZaRwJLJmdJOZKJqaNVCR9NF
+v+X26Xwxw5V8PNNNqAMjEhdPa1uvfpipwtw/W5S9XJXGD1xqq8kntfFXIM5nr66NJWYqIBKfXqsW
+Yj/GMgJmEFIlZJJJKgOtjYG5BvgDmy5fWIsSqysN9VwoP2xTzETyZ9UtPPOsD1GjlwyFQCSRf9sV
+s5y1KCipqmHnM0qgsrSNcbnf9sUSxJGkXK+HL7W2kU4lyKjpxmLc2Pl3bYSDY/fARXmE1Ml5wZgp
+vrvpubdxiWGvndJG5sn5ZAIZUPU28YK2eGNUjUKAFsLAYDS5TVPxfHmQCmmWMIfXuNjvbAzhBK2p
+p/iZqyURf0IoCg/XFeHjyoIvJSRm9Z8KLN/1f+sEOFZTU9RSslTGZIrete5GBuU5xBkmY5xGI9B0
+w8tCTb5PfztvftgnmcnJyiqm6lIWbb6YzQ5j8ZmM9XVMBqRRpU+EsMQa7lWcDMaQzkxg6ypAHTYf
+r1647C5wTVKckk9Ooidrt59K+cdjG560zJszmgzWvpFLcs1E50/Ut+2C/wDpvE9dxqhnaRUpoxIm
+k6V1Wt9+pxQraiWHNKxAy6TUSNYAX+Y4hGazQOXjkKPcWIUA46o3qeQJVLFzgA8TfMw8gf5wqUeX
+UnC9VG0NR8Ss6pTOxYflKt21G3knGY/jlYkrSisYMRvva+Pj8enMISSfmsGvd2Fh9rb4kQUrpBLm
+sjJOsaLUrJqL2DAEnF+rytcxyempoaiMJSxgcxZl9zc7++EavqFeZFWUPZAGcbAnrgxktetPRVlR
+K9lMOhfSSGNxt0xYLf8AD0zZlTTx1lOY4ggMazDe1/fEcHCeahahUnSTmFStpL2AJJ/vgcK2ikkG
+qRNYuRt/fBbhOsp480SplkPKQFV0xsxdiPAB8/tgpny+s/hzKooq6ygKQ1z6r9iPI7YQYpKk1JWF
+maJ6nnX3Ngf7YbeJc1pqioi5UDNoU3MkDqQb9r2wt0dRURVuo0ZaMA6Ry33J/fED5XcS0Iy6agcO
+zGIpqA2PbClyBWTy8nS0Q0tbTv06DFOQ5hPNeLLppBffTG21/rhhy+prcvp1pxkVVqOxLwi7j9MA
+X4IkP4JLYN/xDf8AauOwf4ekb8Pe+Tmm/NNkZQCdhv8A/eMdjnv1WU1mVLUZvWOayRr1Eh0xREke
+o4rNw9LJJphhrJPcx6ft1x+gB/Ok+uPJOhxrtIwaPheqFi9FNt0u4GLMfCjsdT0qL9ZhjZx1xKOm
+HZGJfwpKjgiGmNuh5mL8GVV8dPyhIqxnZo1b0kfTGvY7DoYz/CqkkmKnF+3qxbp8lmpk0R8oIP6Q
+WGNcHXEgw6GVigqX/mzb9t2Nv3xLHlkqtdahh773/vjUR1x9jph0Mz/DCSCssqnvbe+JVy+YA2q6
+hSetgMaZH/MGJG64lCdkdLJDROpnme8hN2t4HtjsOI6Y7GVf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030301.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/508,370/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>508</w>
+    <h>370</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_flm class="fieldsRef">2013-02-08 18:59:48</m_flm>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0303]SL030301.TIF</istruct_isentryid>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_caption class="fieldsRef"/>
+<m_caption class="fieldsRef"/>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0303-1</istruct_isentryidv>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_iid class="fieldsRef">SL030301.TIF</m_iid>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_fn class="fieldsRef">SL030301</m_fn>
+<istruct_x class="fieldsRef">1</istruct_x>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_m class="fieldsRef">SL030301</istruct_m>
+<m_id class="fieldsRef">SL0303</m_id>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<modified class="imgInfHashRef">2013-02-08 18:59:48</modified>
+<ext class="imgInfHashRef">jp2</ext>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/03/03/01/SL030301/SL030301.jp2</filename>
+<type class="imgInfHashRef">image</type>
+<md5 class="imgInfHashRef">70beee6007d4d8a3fcc54a0467f12231</md5>
+<height class="imgInfHashRef">1480</height>
+<basename class="imgInfHashRef">SL030301</basename>
+<access class="imgInfHashRef">1</access>
+<levels class="imgInfHashRef">3</levels>
+<size class="imgInfHashRef">409848</size>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<width class="imgInfHashRef">2032</width>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<use class="imgInfHashRef">access</use>
+<master class="imgInfHashRef">0</master>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<u class="imgInfHashRef">1</u>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>3</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/res:3/0/native.jpg</Part><LevelWidth>254</LevelWidth><LevelHeight>185</LevelHeight><LevelMaxDim>254</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/res:2/0/native.jpg</Part><LevelWidth>508</LevelWidth><LevelHeight>370</LevelHeight><LevelMaxDim>508</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1016</LevelWidth><LevelHeight>740</LevelHeight><LevelMaxDim>1016</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;start=1;resnum=2;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2032</LevelWidth><LevelHeight>1480</LevelHeight><LevelMaxDim>2032</LevelMaxDim></Level><MaxWidth>2032</MaxWidth><MaxHeight>1480</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_ownership;q1=Dieterle%252C%2520Kathy;select1=phrase" target="_blank">Dieterle, Kathy</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>17:16</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>Two story, gable front and wing, Folk House. Partial width porch is now enclosed. One over one windows, several in pairs. Small window over porch. Aluminum siding. One story addition to rear. Barn and two other outbuildings at rear.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_date_construction;q1=1910%2520ca.;select1=phrase" target="_blank">1910 ca.</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>Remodeled in 1935. The 1920 city directory lists Frank and Winifred Dieterle on "west side Ann Arbor one north of tracks". They remained there through 1947, when it is listed as Frank Dieterle Est. It was then purchased by Earl S. Clark. The current owner is K.S. Dieterle.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; Bird's Eye View of Saline, 1872; Tax Rolls: 1931 and 1935.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 101</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>101</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value><Value>Two story, gable front and wing, Folk House. Partial width porch is now enclosed. One over one windows, several in pairs. Small window over porch. Aluminum siding. One story addition to rear. Barn and two other outbuildings at rear.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL030301_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0303:SL030301.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0303:SL030301.TIF" canvas-index="1" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">sdlhomes_date_construction</Variable>
+<Variable name="fq1">1910 ca.</Variable>
+<Variable name="sort">sdlhomes_present_usage</Variable>
+<Variable name="rgn1">sdlhomes_present_usage</Variable>
+<Variable name="select1">phrase</Variable>
+<Variable name="c">sdlhomes</Variable>
+<Variable name="q1">Residence</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">2</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sdlhomes</Variable>
+<Variable name="entryid">x-sl0303</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SDLHOMES-X-SL0303 SL030301.TIF</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>SL030301.TIF</Label><Value>SL030301.TIF</Value><Focus>true</Focus></Option><Option index="1"><Label>SL030302.TIF</Label><Value>SL030302.TIF</Value></Option><Name>relview</Name><Default>SL030301.TIF</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABJAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABQYDBAcAAQII/8QAORAAAgECBAUCBAQFAgcAAAAA
+AQIDBBEABRIhBhMxQVEiYRQycYEVI5GhFjNCscEHJDRiorLR4fD/xAAXAQEBAQEAAAAAAAAAAAAA
+AAAAAQID/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBEiEx/9oADAMBAAIRAxEAPwAzw/xVmb5vnTV9
+XW1lLDSuyxwvbksHIHixsv74srxRXz8GUzQZoz1zQJy5UJMkstrtsR0HQnz7YQ4q3Mmqc5oaSyfG
+VD89idLMuo+kHwRcknYWwWyzL80hqpsoeAkTIj1TRSBdEF7KisxsdVrdjt37ZgK5Xm3ElfWGaozm
+ajpeXHKElnNgrD03YKbEgX7de2C8mf5rRxyVSz6oafSZllq9W9+guATfpgVT1dVRyZlDEY4ZDI0R
+Mg1CFUARRzASB3tq29++F/Qme5qf9qTltGeXJyiBzH7knxfsPPvhAYoOMM7zmsVYZa1YOXeTlSqr
+Ndj8rObDxfc7Gwxb/G85FYY6nMKuKIT7wRz/AJiggEAuRuB3sB1Jvtim1M8VYCiwaZIToTT+XJYb
+DpdWO4ttYgYmzGthkoy1IzxNSrFKYZ9mOkldI9z08be+AZcuziWuikWjrZw8pIJmm5nw6jbV16k9
+MQc/iHK5ifjJqkWUtFObgg3HpbrfATLoacV0MCSiKpiRZTMRsHbsRfoSTfxt0w5VGYg0VNWzoiGK
+VVdg1wfVaxuNiG3/AF3xIF6o4krDO0sGYyxsUZXp33Csu+2/cdxffBxczqhQUUoqWkd5FBIf5rqf
+84BZ9QyS0lakg5SI6sqPe6am+cH7gG21sEKSSeDJaWnKKGFTEY1v0N7EX++oX7A+MICNJWVVXDVS
+iefloTGbA3XbdgT0IJ9umJ6DMJ4sljNetSJ3QESBWYMD03G4Njiejhb8O1QpG4aN7erd7k2P19sQ
+UcktXkWUpEyAPGqkljdkC7i1tr2H64kFrKM0FbRklncxOYjIFI12/qIO4NiLjzjsWYINIdmiKM7a
+iL37AePbHYxrTMcgy2tra7NMyNLO4nqmTXEvzIhtpF7bXHY32GLvDC0n41nWYwRQiA1Qp0BQgqqL
+udJ7km3nbDzRTUGXJLA1O1PCp1KTvewubH63P64Ucirsrov9PZMzzGKJkmkmqmEiD1a5CVA9zYDH
+VlQ/iWLh/hDMp4JIxUVVVUaISBZ9UjKDYdCAPptbCnksNZDk3OgnnSJbNKqSMoYtcattu1v084HZ
+XSVvEc9DTNGY6JZWI0qSLsxJP72+2NJSkESVEMC6oUcrJBGLIwAAtbyd9/8AxgEtp54Z6Wq+IkmR
+Td4w2gm2/UWubXHn3xPUVSZlFG0LGFo1GuJxchbq1t+xKg/c774p5lDJSV8tKqu6wykbLfftf7bY
+qTVUUermIyncWKnYHwbbWP7YKZspzJY+IHzSbSFdCpGgne4FvY7YcZ6/Lwmmn5dRSVo0zxJs1+hI
+Hc77j29sZjR10RgYPURqD1XoGPnfBTLM0y6Iu9ZURoVN40D6r+SQL74IfKsGtyiSnqiGnLomu27h
+WHqHboL/AHwPqszpqX4GMgScqoDuG+WSzMVsT8vXr07Y9pnkzCJGT007AEXHUYoVnwj8QRZZJSa2
+eE2kLbWIubjv0xA+ZHKKqlhf0jQPzApuDITc/p498UcqnWGojg0FpKaN6b0i9rSsBfxso/XAHKsy
+m4arPhqm8lHKbI56jwCfPg9+h7YLZCUrOJM3rYVCpJJFcHqbR7n2ubYBkVwyghgcdj1lGrqB7Y7H
+PWmZcXcQzw8LViSSqsks5p0cG5tqIJt5Av8ApjPqzOVzP4Onn5q5PRII44lPqmKiwP1PfwMWaqgk
+zrNa2orZ3WngmlVL7l9LHb2GIsnoIsxzOGijg11EpVISz2Rb+1sdsZaRwJLJmdJOZKJqaNVCR9NF
+v+X26Xwxw5V8PNNNqAMjEhdPa1uvfpipwtw/W5S9XJXGD1xqq8kntfFXIM5nr66NJWYqIBKfXqsW
+Yj/GMgJmEFIlZJJJKgOtjYG5BvgDmy5fWIsSqysN9VwoP2xTzETyZ9UtPPOsD1GjlwyFQCSRf9sV
+s5y1KCipqmHnM0qgsrSNcbnf9sUSxJGkXK+HL7W2kU4lyKjpxmLc2Pl3bYSDY/fARXmE1Ml5wZgp
+vrvpubdxiWGvndJG5sn5ZAIZUPU28YK2eGNUjUKAFsLAYDS5TVPxfHmQCmmWMIfXuNjvbAzhBK2p
+p/iZqyURf0IoCg/XFeHjyoIvJSRm9Z8KLN/1f+sEOFZTU9RSslTGZIrete5GBuU5xBkmY5xGI9B0
+w8tCTb5PfztvftgnmcnJyiqm6lIWbb6YzQ5j8ZmM9XVMBqRRpU+EsMQa7lWcDMaQzkxg6ypAHTYf
+r1647C5wTVKckk9Ooidrt59K+cdjG560zJszmgzWvpFLcs1E50/Ut+2C/wDpvE9dxqhnaRUpoxIm
+k6V1Wt9+pxQraiWHNKxAy6TUSNYAX+Y4hGazQOXjkKPcWIUA46o3qeQJVLFzgA8TfMw8gf5wqUeX
+UnC9VG0NR8Ss6pTOxYflKt21G3knGY/jlYkrSisYMRvva+Pj8enMISSfmsGvd2Fh9rb4kQUrpBLm
+sjJOsaLUrJqL2DAEnF+rytcxyempoaiMJSxgcxZl9zc7++EavqFeZFWUPZAGcbAnrgxktetPRVlR
+K9lMOhfSSGNxt0xYLf8AD0zZlTTx1lOY4ggMazDe1/fEcHCeahahUnSTmFStpL2AJJ/vgcK2ikkG
+qRNYuRt/fBbhOsp480SplkPKQFV0xsxdiPAB8/tgpny+s/hzKooq6ygKQ1z6r9iPI7YQYpKk1JWF
+maJ6nnX3Ngf7YbeJc1pqioi5UDNoU3MkDqQb9r2wt0dRURVuo0ZaMA6Ry33J/fED5XcS0Iy6agcO
+zGIpqA2PbClyBWTy8nS0Q0tbTv06DFOQ5hPNeLLppBffTG21/rhhy+prcvp1pxkVVqOxLwi7j9MA
+X4IkP4JLYN/xDf8AauOwf4ekb8Pe+Tmm/NNkZQCdhv8A/eMdjnv1WU1mVLUZvWOayRr1Eh0xREke
+o4rNw9LJJphhrJPcx6ft1x+gB/Ok+uPJOhxrtIwaPheqFi9FNt0u4GLMfCjsdT0qL9ZhjZx1xKOm
+HZGJfwpKjgiGmNuh5mL8GVV8dPyhIqxnZo1b0kfTGvY7DoYz/CqkkmKnF+3qxbp8lmpk0R8oIP6Q
+WGNcHXEgw6GVigqX/mzb9t2Nv3xLHlkqtdahh773/vjUR1x9jph0Mz/DCSCssqnvbe+JVy+YA2q6
+hSetgMaZH/MGJG64lCdkdLJDROpnme8hN2t4HtjsOI6Y7GVf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030301.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=2;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030301.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAUEBgIDBwEI/8QAPhAAAgEDAwIDBQQHBgcAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcQeBobEWI0J0kbLBFSQzNpLRNEViZHLS4f/EABgBAAMBAQAAAAAA
+AAAAAAAAAAECAwAE/8QAGxEBAQADAQEBAAAAAAAAAAAAAQACESExEgP/2gAMAwEAAhEDEQA/AOfa
+71R1Guu6iq61qSol1KFC3LgBQ5A4B7VoTrLWEtHibVtWeRsEP7a42kZqBrkrx9S6oVYj+9zZx/5t
+S3cnhY2nfnk54xThNqdfpfro/wCc6pg8H+/yVKi6u1ido4/7U1VHOBlL1zk+uCe/yqsMQTwMCm+l
+WlxPEbqOFZ44Zo1kVlJ7/COOeew/OtobPK76Lq2uK0WqG91O4tLOUeMpuZGMobIPunjjHn9K6ZpG
+uJrWnR3lreTFHHYucqexBrnl9C/T9jDE19PAJ3luVhlbLx5AAXOfMHn55p90AulwaXE0Kpb392m+
+4gWXcAVJ94jPu5B+X0qho5cue8jdcDPc5/4iX/Wa89puQf8AHl/1nFbvCqJYXS3wnAXbJBMYZEBz
+tYYPoPIg0+ylrL2xN7fNdxgSuFAbIMx57YPpXk1/cGMnxZ1YE+6zkcj5+lZxqk95K0UoOxNmV5AO
+eR8+wrCZ3BaIxE8c7u33H0pHypjxks2sX0iu1vNcP57BMwIP5YqFda5fKvvXkySZGMTvtGfmDisL
+5LyJxIcF2OXjjdsFfLngA9uaiuLSS3WSCFZI5R+sBJ930Gc4GDx91RTZdI1/6Lv7i60m4eeSV3W5
+ZdzOX42r5n60UdDoItAZUMRXxmI2NuA4HnRSlm+a+ov8y6p+9zfzmlhpn1F/mXVf3yb+c0sNVnpI
+tA9vE8DtLM28vEq/4YHmT555Pyq1dGdZXHTDvbz2VrdW29ZGSZPfGORtYA88557VXrO4sFsJ4Xsp
+JbssGifxjtUeeVA5+ua0NDNJMzCPwYye2eFHp6mhCbXmoTaxqzapqss91C8pVxIwLBO4VT2GBwOK
+zeSGSATWyypIARMqcRAfskEck47k+fNaNNs45b6Nbm5FvDuG6fAIXHyzzTnqTTbe2ubaKDUra6gI
+3NPBs3k+rKpxn0yf4VuStfbD7SrJ7SC0j0y/e78IIqrtfLAYz3yR55qPb6lq08NzbpNHLLcS+JLI
+ibUX3VXaSO/C9l49Se1KenrCK7sVkt42htXJU5P6yUA494jy4+EcfWrpZW62yqsaBVxjGOMVnrIA
+SvRZ9Q027u4sPIhYMxlzsl+a4+EjtxVku7YXlvvhaW7IG/ZE48ROPLBAP4H5UltUaZuYpVbJ+Mna
+f6dqYxLNY3PjowYYIAHwsP60oJPxq9ciFTKC7hx8KDdhT2OQeCMetQhYWjtMUimubcYZUjyEkJ/b
+P/zjPlTzrjVbax0a2uru2ZhJJ4ayW52sDtznn+B8/SklnfSvaw3MMkbwxBcmR9hx9ASfu9KCrNrV
+0PoeJU0Bssj7p2PHuleAMEY7jH30Vl0pqL3WmzucEi4YExowGcA+f1orbl1fNfUXHU2rD/vJv5zS
+vjHenHUao3VWqBTtU3soJPl75pXLC0Xxefb50+57KDanvsxA5HHrTu2WyWxFzcTQ+Ix+AkZPz45H
+5Uv0m3W8neORFKxxl+3PFNbG0sLqORo9PeRkI91SCW+nNCDY3t/o02nC3ggeOYgb5Vy27nPY4xUz
+SNc6fsvY0vdOkuYok2yqPdMh5Oe/B5FSLDStLvIXkGnsgRiCJAB2GT51gx6agWEyWMmJoxKv6sdi
+SB5/KtC6B017NLpVs8UbRW77mRGYMyqWJAJ7E1YmtwkAkWQMCOMcfhVI0/TZLPVoIbNvAt1RZSoB
+yc84POKfdQa7a6DpcF1JBLK7yeGyhsYGCQc+nGKMkyiEyhVeSN0UYGE2kfjQzNJbJGOMc5FIz1HE
+lxZxysie1QRypz339v6U9hk2hCcEj186PsPKr9bReNo1paEkxrIzhWOeccmrJpPSEGg2yspSeYnc
+qZJEfAyefyPrSXraRXt7SVYgg3Mdq9j2pPfahcXkhu5faEkdcsGXBxjsRnyxxUf0y+auGP1dc6ei
+Kaa2Qi5mc7UQgDn50VXugbiW66fkfOQty6DMh7ALRWHZuCabgHUjgdVatkce2TZAOM++aWSStN8R
+OF+EelMupuOq9X/fZv5zSk1UjPumI/Ek1AjHiezFY8+bE1OtdJ1G2t7janvsE8PBHcHJ/pUHpm5j
+tXuGkKjcFAyfrVnt9dtnMmCMISCcd8elHUmT2jSHXJbWFhEVnBYOquORhQO/0JqBfaVqzNaeHYs6
+Jbxox2r3Gcj8asmndQWmoRu0Q2mPggjBOKbWGr2l3aGSKRXibIO49j689q2pfqmwSR/2s6hgSsMY
+OPpS/rm2ur7TLOKwDNIJSzjcAMYx5/WlM3UFppuv3XjbypVPeTBHw/Wmp6004xBGknVMZ2lMj69/
+nTaId9qFrustDq1kkYJlsIIYnDYI8ROTj1GTjNT4PtO1qCVh7NZvE4wY2Rvr3zkUm6qNvc6zNfWk
+viRTkMRtIIOMH8qTSTF4UjKjKE8juc0tUBLoV31M2t6NaTSRiOUF96qcjuBxWnTryW502O3kuRPI
+qfEWy3y488AfhVae5jt9PgihbeyjJC+Xmc1nF1ZqUUHgItsqbdvEABI+o5pP0x+o4KeXffs3ji/R
+d3dmO+6kIxgYHA7fdRVc+zPXbi46XkDRwII7p1UImBghW9fVjRSBrkF7VPVek7C617U5ZJLgM11I
+Thlxyx+VRP0K00zBPFusH/qX/wBaKKbdqy2H2XaBL70kt6/B4MqgfgtbE+zDp9/ajm8HhyFFxKOA
+B9KKKnlk7qByplz0zZW93LEktxtVioO4Zx/CtDaJbxgxrNPs4ONwwfuxRRVabaxoVtgnxJgR8x/t
+Wdv05aTTRxtLOFJxww/2ooowpA6WsRK8Xi3G0MR8S+v0p9p/2d6LOoeWS8Yny8RR+S0UVPNdRJrH
+0VoEGYxYI+P2pDuJ++tc3SGgjcw06IEemfWiiuP7y37W/MFrj0jomnWWlSxW9ssaGdmIBPfC/wC1
+FFFdGK6hmH03/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030302.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030301.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0303___SL030302__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0303___SL030302__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
@@ -1,0 +1,891 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0303___SL030302__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="q1">Residence</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">3</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0303</Param>
+<Param name="viewid">SL030302.TIF</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0303 SL030302.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>4ab8f826ebf1fe986927c56d992d5cb8</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0303</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0303___SL030302__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0303%5DSL030302.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0303%5DSL030302.TIF</ItemUrlEncoded><TitleForTagging>407%20N.%20Ann%20Arbor%20St.</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="3" name="S_SDLHOMES_X_SL0617___SL061701__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF</Url></Next>
+<Prev><Url index="1" name="S_SDLHOMES_X_SL0303___SL030301__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF</Url></Prev>
+<Self><Url index="2" name="S_SDLHOMES_X_SL0303___SL030302__TIF">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF</Url></Self>
+<TotalResults>10</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260768</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;q1=Residence;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0303]SL030302.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAUEBgIDBwEI/8QAPhAAAgEDAwIDBQQHBgcAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcQeBobEWI0J0kbLBFSQzNpLRNEViZHLS4f/EABgBAAMBAQAAAAAA
+AAAAAAAAAAECAwAE/8QAGxEBAQADAQEBAAAAAAAAAAAAAQACESExEgP/2gAMAwEAAhEDEQA/AOfa
+71R1Guu6iq61qSol1KFC3LgBQ5A4B7VoTrLWEtHibVtWeRsEP7a42kZqBrkrx9S6oVYj+9zZx/5t
+S3cnhY2nfnk54xThNqdfpfro/wCc6pg8H+/yVKi6u1ido4/7U1VHOBlL1zk+uCe/yqsMQTwMCm+l
+WlxPEbqOFZ44Zo1kVlJ7/COOeew/OtobPK76Lq2uK0WqG91O4tLOUeMpuZGMobIPunjjHn9K6ZpG
+uJrWnR3lreTFHHYucqexBrnl9C/T9jDE19PAJ3luVhlbLx5AAXOfMHn55p90AulwaXE0Kpb392m+
+4gWXcAVJ94jPu5B+X0qho5cue8jdcDPc5/4iX/Wa89puQf8AHl/1nFbvCqJYXS3wnAXbJBMYZEBz
+tYYPoPIg0+ylrL2xN7fNdxgSuFAbIMx57YPpXk1/cGMnxZ1YE+6zkcj5+lZxqk95K0UoOxNmV5AO
+eR8+wrCZ3BaIxE8c7u33H0pHypjxks2sX0iu1vNcP57BMwIP5YqFda5fKvvXkySZGMTvtGfmDisL
+5LyJxIcF2OXjjdsFfLngA9uaiuLSS3WSCFZI5R+sBJ930Gc4GDx91RTZdI1/6Lv7i60m4eeSV3W5
+ZdzOX42r5n60UdDoItAZUMRXxmI2NuA4HnRSlm+a+ov8y6p+9zfzmlhpn1F/mXVf3yb+c0sNVnpI
+tA9vE8DtLM28vEq/4YHmT555Pyq1dGdZXHTDvbz2VrdW29ZGSZPfGORtYA88557VXrO4sFsJ4Xsp
+JbssGifxjtUeeVA5+ua0NDNJMzCPwYye2eFHp6mhCbXmoTaxqzapqss91C8pVxIwLBO4VT2GBwOK
+zeSGSATWyypIARMqcRAfskEck47k+fNaNNs45b6Nbm5FvDuG6fAIXHyzzTnqTTbe2ubaKDUra6gI
+3NPBs3k+rKpxn0yf4VuStfbD7SrJ7SC0j0y/e78IIqrtfLAYz3yR55qPb6lq08NzbpNHLLcS+JLI
+ibUX3VXaSO/C9l49Se1KenrCK7sVkt42htXJU5P6yUA494jy4+EcfWrpZW62yqsaBVxjGOMVnrIA
+SvRZ9Q027u4sPIhYMxlzsl+a4+EjtxVku7YXlvvhaW7IG/ZE48ROPLBAP4H5UltUaZuYpVbJ+Mna
+f6dqYxLNY3PjowYYIAHwsP60oJPxq9ciFTKC7hx8KDdhT2OQeCMetQhYWjtMUimubcYZUjyEkJ/b
+P/zjPlTzrjVbax0a2uru2ZhJJ4ayW52sDtznn+B8/SklnfSvaw3MMkbwxBcmR9hx9ASfu9KCrNrV
+0PoeJU0Bssj7p2PHuleAMEY7jH30Vl0pqL3WmzucEi4YExowGcA+f1orbl1fNfUXHU2rD/vJv5zS
+vjHenHUao3VWqBTtU3soJPl75pXLC0Xxefb50+57KDanvsxA5HHrTu2WyWxFzcTQ+Ix+AkZPz45H
+5Uv0m3W8neORFKxxl+3PFNbG0sLqORo9PeRkI91SCW+nNCDY3t/o02nC3ggeOYgb5Vy27nPY4xUz
+SNc6fsvY0vdOkuYok2yqPdMh5Oe/B5FSLDStLvIXkGnsgRiCJAB2GT51gx6agWEyWMmJoxKv6sdi
+SB5/KtC6B017NLpVs8UbRW77mRGYMyqWJAJ7E1YmtwkAkWQMCOMcfhVI0/TZLPVoIbNvAt1RZSoB
+yc84POKfdQa7a6DpcF1JBLK7yeGyhsYGCQc+nGKMkyiEyhVeSN0UYGE2kfjQzNJbJGOMc5FIz1HE
+lxZxysie1QRypz339v6U9hk2hCcEj186PsPKr9bReNo1paEkxrIzhWOeccmrJpPSEGg2yspSeYnc
+qZJEfAyefyPrSXraRXt7SVYgg3Mdq9j2pPfahcXkhu5faEkdcsGXBxjsRnyxxUf0y+auGP1dc6ei
+Kaa2Qi5mc7UQgDn50VXugbiW66fkfOQty6DMh7ALRWHZuCabgHUjgdVatkce2TZAOM++aWSStN8R
+OF+EelMupuOq9X/fZv5zSk1UjPumI/Ek1AjHiezFY8+bE1OtdJ1G2t7janvsE8PBHcHJ/pUHpm5j
+tXuGkKjcFAyfrVnt9dtnMmCMISCcd8elHUmT2jSHXJbWFhEVnBYOquORhQO/0JqBfaVqzNaeHYs6
+Jbxox2r3Gcj8asmndQWmoRu0Q2mPggjBOKbWGr2l3aGSKRXibIO49j689q2pfqmwSR/2s6hgSsMY
+OPpS/rm2ur7TLOKwDNIJSzjcAMYx5/WlM3UFppuv3XjbypVPeTBHw/Wmp6004xBGknVMZ2lMj69/
+nTaId9qFrustDq1kkYJlsIIYnDYI8ROTj1GTjNT4PtO1qCVh7NZvE4wY2Rvr3zkUm6qNvc6zNfWk
+viRTkMRtIIOMH8qTSTF4UjKjKE8juc0tUBLoV31M2t6NaTSRiOUF96qcjuBxWnTryW502O3kuRPI
+qfEWy3y488AfhVae5jt9PgihbeyjJC+Xmc1nF1ZqUUHgItsqbdvEABI+o5pP0x+o4KeXffs3ji/R
+d3dmO+6kIxgYHA7fdRVc+zPXbi46XkDRwII7p1UImBghW9fVjRSBrkF7VPVek7C617U5ZJLgM11I
+Thlxyx+VRP0K00zBPFusH/qX/wBaKKbdqy2H2XaBL70kt6/B4MqgfgtbE+zDp9/ajm8HhyFFxKOA
+B9KKKnlk7qByplz0zZW93LEktxtVioO4Zx/CtDaJbxgxrNPs4ONwwfuxRRVabaxoVtgnxJgR8x/t
+Wdv05aTTRxtLOFJxww/2ooowpA6WsRK8Xi3G0MR8S+v0p9p/2d6LOoeWS8Yny8RR+S0UVPNdRJrH
+0VoEGYxYI+P2pDuJ++tc3SGgjcw06IEemfWiiuP7y37W/MFrj0jomnWWlSxW9ssaGdmIBPfC/wC1
+FFFdGK6hmH03/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030302.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/618,418/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>618</w>
+    <h>418</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck check="yes" allowed="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_x class="fieldsRef">2</istruct_x>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0303]SL030302.TIF</istruct_isentryid>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<m_iid class="fieldsRef">SL030302.TIF</m_iid>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_flm class="fieldsRef">2013-02-08 18:59:39</m_flm>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<m_id class="fieldsRef">SL0303</m_id>
+<m_caption class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0303-2</istruct_isentryidv>
+<istruct_y class="fieldsRef">1</istruct_y>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<m_fn class="fieldsRef">SL030302</m_fn>
+<istruct_m class="fieldsRef">SL030302</istruct_m>
+<istruct_caption class="fieldsRef"/>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<use class="imgInfHashRef">access</use>
+<ext class="imgInfHashRef">jp2</ext>
+<height class="imgInfHashRef">1672</height>
+<modified class="imgInfHashRef">2013-02-08 18:59:39</modified>
+<width class="imgInfHashRef">2472</width>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/03/03/02/SL030302/SL030302.jp2</filename>
+<basename class="imgInfHashRef">SL030302</basename>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<md5 class="imgInfHashRef">a76d46da45e057f05629b3350b7f699f</md5>
+<u class="imgInfHashRef">1</u>
+<type class="imgInfHashRef">image</type>
+<size class="imgInfHashRef">563245</size>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<master class="imgInfHashRef">0</master>
+<access class="imgInfHashRef">1</access>
+<levels class="imgInfHashRef">4</levels>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="4"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=4;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=4;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:4/0/native.jpg</Part><LevelWidth>154</LevelWidth><LevelHeight>104</LevelHeight><LevelMaxDim>154</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:3/0/native.jpg</Part><LevelWidth>309</LevelWidth><LevelHeight>209</LevelHeight><LevelMaxDim>309</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:2/0/native.jpg</Part><LevelWidth>618</LevelWidth><LevelHeight>418</LevelHeight><LevelMaxDim>618</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1236</LevelWidth><LevelHeight>836</LevelHeight><LevelMaxDim>1236</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;start=1;resnum=3;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2472</LevelWidth><LevelHeight>1672</LevelHeight><LevelMaxDim>2472</LevelMaxDim></Level><MaxWidth>2472</MaxWidth><MaxHeight>1672</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_ownership;q1=Dieterle%252C%2520Kathy;select1=phrase" target="_blank">Dieterle, Kathy</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>17:16</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>Two story, gable front and wing, Folk House. Partial width porch is now enclosed. One over one windows, several in pairs. Small window over porch. Aluminum siding. One story addition to rear. Barn and two other outbuildings at rear.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_date_construction;q1=1910%2520ca.;select1=phrase" target="_blank">1910 ca.</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>Remodeled in 1935. The 1920 city directory lists Frank and Winifred Dieterle on "west side Ann Arbor one north of tracks". They remained there through 1947, when it is listed as Frank Dieterle Est. It was then purchased by Earl S. Clark. The current owner is K.S. Dieterle.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; Bird's Eye View of Saline, 1872; Tax Rolls: 1931 and 1935.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 101</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>101</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>407 N. Ann Arbor St.</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value><Value>Two story, gable front and wing, Folk House. Partial width porch is now enclosed. One over one windows, several in pairs. Small window over porch. Aluminum siding. One story addition to rear. Barn and two other outbuildings at rear.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL030302_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0303:SL030302.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0303:SL030302.TIF" canvas-index="2" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">sdlhomes_date_construction</Variable>
+<Variable name="fq1">1910 ca.</Variable>
+<Variable name="sort">sdlhomes_present_usage</Variable>
+<Variable name="rgn1">sdlhomes_present_usage</Variable>
+<Variable name="select1">phrase</Variable>
+<Variable name="c">sdlhomes</Variable>
+<Variable name="q1">Residence</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">3</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sdlhomes</Variable>
+<Variable name="entryid">x-sl0303</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SDLHOMES-X-SL0303 SL030302.TIF</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>SL030301.TIF</Label><Value>SL030301.TIF</Value></Option><Option index="1"><Label>SL030302.TIF</Label><Value>SL030302.TIF</Value><Focus>true</Focus></Option><Name>relview</Name><Default>SL030302.TIF</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030301.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABJAGQDASIA
+AhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABQYDBAcAAQII/8QAORAAAgECBAUCBAQFAgcAAAAA
+AQIDBBEABRIhBhMxQVEiYRQycYEVI5GhFjNCscEHJDRiorLR4fD/xAAXAQEBAQEAAAAAAAAAAAAA
+AAAAAQID/8QAGREBAQEBAQEAAAAAAAAAAAAAABEBEiEx/9oADAMBAAIRAxEAPwAzw/xVmb5vnTV9
+XW1lLDSuyxwvbksHIHixsv74srxRXz8GUzQZoz1zQJy5UJMkstrtsR0HQnz7YQ4q3Mmqc5oaSyfG
+VD89idLMuo+kHwRcknYWwWyzL80hqpsoeAkTIj1TRSBdEF7KisxsdVrdjt37ZgK5Xm3ElfWGaozm
+ajpeXHKElnNgrD03YKbEgX7de2C8mf5rRxyVSz6oafSZllq9W9+guATfpgVT1dVRyZlDEY4ZDI0R
+Mg1CFUARRzASB3tq29++F/Qme5qf9qTltGeXJyiBzH7knxfsPPvhAYoOMM7zmsVYZa1YOXeTlSqr
+Ndj8rObDxfc7Gwxb/G85FYY6nMKuKIT7wRz/AJiggEAuRuB3sB1Jvtim1M8VYCiwaZIToTT+XJYb
+DpdWO4ttYgYmzGthkoy1IzxNSrFKYZ9mOkldI9z08be+AZcuziWuikWjrZw8pIJmm5nw6jbV16k9
+MQc/iHK5ifjJqkWUtFObgg3HpbrfATLoacV0MCSiKpiRZTMRsHbsRfoSTfxt0w5VGYg0VNWzoiGK
+VVdg1wfVaxuNiG3/AF3xIF6o4krDO0sGYyxsUZXp33Csu+2/cdxffBxczqhQUUoqWkd5FBIf5rqf
+84BZ9QyS0lakg5SI6sqPe6am+cH7gG21sEKSSeDJaWnKKGFTEY1v0N7EX++oX7A+MICNJWVVXDVS
+iefloTGbA3XbdgT0IJ9umJ6DMJ4sljNetSJ3QESBWYMD03G4Njiejhb8O1QpG4aN7erd7k2P19sQ
+UcktXkWUpEyAPGqkljdkC7i1tr2H64kFrKM0FbRklncxOYjIFI12/qIO4NiLjzjsWYINIdmiKM7a
+iL37AePbHYxrTMcgy2tra7NMyNLO4nqmTXEvzIhtpF7bXHY32GLvDC0n41nWYwRQiA1Qp0BQgqqL
+udJ7km3nbDzRTUGXJLA1O1PCp1KTvewubH63P64Ucirsrov9PZMzzGKJkmkmqmEiD1a5CVA9zYDH
+VlQ/iWLh/hDMp4JIxUVVVUaISBZ9UjKDYdCAPptbCnksNZDk3OgnnSJbNKqSMoYtcattu1v084HZ
+XSVvEc9DTNGY6JZWI0qSLsxJP72+2NJSkESVEMC6oUcrJBGLIwAAtbyd9/8AxgEtp54Z6Wq+IkmR
+Td4w2gm2/UWubXHn3xPUVSZlFG0LGFo1GuJxchbq1t+xKg/c774p5lDJSV8tKqu6wykbLfftf7bY
+qTVUUermIyncWKnYHwbbWP7YKZspzJY+IHzSbSFdCpGgne4FvY7YcZ6/Lwmmn5dRSVo0zxJs1+hI
+Hc77j29sZjR10RgYPURqD1XoGPnfBTLM0y6Iu9ZURoVN40D6r+SQL74IfKsGtyiSnqiGnLomu27h
+WHqHboL/AHwPqszpqX4GMgScqoDuG+WSzMVsT8vXr07Y9pnkzCJGT007AEXHUYoVnwj8QRZZJSa2
+eE2kLbWIubjv0xA+ZHKKqlhf0jQPzApuDITc/p498UcqnWGojg0FpKaN6b0i9rSsBfxso/XAHKsy
+m4arPhqm8lHKbI56jwCfPg9+h7YLZCUrOJM3rYVCpJJFcHqbR7n2ubYBkVwyghgcdj1lGrqB7Y7H
+PWmZcXcQzw8LViSSqsks5p0cG5tqIJt5Av8ApjPqzOVzP4Onn5q5PRII44lPqmKiwP1PfwMWaqgk
+zrNa2orZ3WngmlVL7l9LHb2GIsnoIsxzOGijg11EpVISz2Rb+1sdsZaRwJLJmdJOZKJqaNVCR9NF
+v+X26Xwxw5V8PNNNqAMjEhdPa1uvfpipwtw/W5S9XJXGD1xqq8kntfFXIM5nr66NJWYqIBKfXqsW
+Yj/GMgJmEFIlZJJJKgOtjYG5BvgDmy5fWIsSqysN9VwoP2xTzETyZ9UtPPOsD1GjlwyFQCSRf9sV
+s5y1KCipqmHnM0qgsrSNcbnf9sUSxJGkXK+HL7W2kU4lyKjpxmLc2Pl3bYSDY/fARXmE1Ml5wZgp
+vrvpubdxiWGvndJG5sn5ZAIZUPU28YK2eGNUjUKAFsLAYDS5TVPxfHmQCmmWMIfXuNjvbAzhBK2p
+p/iZqyURf0IoCg/XFeHjyoIvJSRm9Z8KLN/1f+sEOFZTU9RSslTGZIrete5GBuU5xBkmY5xGI9B0
+w8tCTb5PfztvftgnmcnJyiqm6lIWbb6YzQ5j8ZmM9XVMBqRRpU+EsMQa7lWcDMaQzkxg6ypAHTYf
+r1647C5wTVKckk9Ooidrt59K+cdjG560zJszmgzWvpFLcs1E50/Ut+2C/wDpvE9dxqhnaRUpoxIm
+k6V1Wt9+pxQraiWHNKxAy6TUSNYAX+Y4hGazQOXjkKPcWIUA46o3qeQJVLFzgA8TfMw8gf5wqUeX
+UnC9VG0NR8Ss6pTOxYflKt21G3knGY/jlYkrSisYMRvva+Pj8enMISSfmsGvd2Fh9rb4kQUrpBLm
+sjJOsaLUrJqL2DAEnF+rytcxyempoaiMJSxgcxZl9zc7++EavqFeZFWUPZAGcbAnrgxktetPRVlR
+K9lMOhfSSGNxt0xYLf8AD0zZlTTx1lOY4ggMazDe1/fEcHCeahahUnSTmFStpL2AJJ/vgcK2ikkG
+qRNYuRt/fBbhOsp480SplkPKQFV0xsxdiPAB8/tgpny+s/hzKooq6ygKQ1z6r9iPI7YQYpKk1JWF
+maJ6nnX3Ngf7YbeJc1pqioi5UDNoU3MkDqQb9r2wt0dRURVuo0ZaMA6Ry33J/fED5XcS0Iy6agcO
+zGIpqA2PbClyBWTy8nS0Q0tbTv06DFOQ5hPNeLLppBffTG21/rhhy+prcvp1pxkVVqOxLwi7j9MA
+X4IkP4JLYN/xDf8AauOwf4ekb8Pe+Tmm/NNkZQCdhv8A/eMdjnv1WU1mVLUZvWOayRr1Eh0xREke
+o4rNw9LJJphhrJPcx6ft1x+gB/Ok+uPJOhxrtIwaPheqFi9FNt0u4GLMfCjsdT0qL9ZhjZx1xKOm
+HZGJfwpKjgiGmNuh5mL8GVV8dPyhIqxnZo1b0kfTGvY7DoYz/CqkkmKnF+3qxbp8lmpk0R8oIP6Q
+WGNcHXEgw6GVigqX/mzb9t2Nv3xLHlkqtdahh773/vjUR1x9jph0Mz/DCSCssqnvbe+JVy+YA2q6
+hSetgMaZH/MGJG64lCdkdLJDROpnme8hN2t4HtjsOI6Y7GVf/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030301.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=3;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0303%20SL030302.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAUEBgIDBwEI/8QAPhAAAgEDAwIDBQQHBgcAAAAA
+AQIDAAQRBRIhBjETQVEUIjJhcQeBobEWI0J0kbLBFSQzNpLRNEViZHLS4f/EABgBAAMBAQAAAAAA
+AAAAAAAAAAECAwAE/8QAGxEBAQADAQEBAAAAAAAAAAAAAQACESExEgP/2gAMAwEAAhEDEQA/AOfa
+71R1Guu6iq61qSol1KFC3LgBQ5A4B7VoTrLWEtHibVtWeRsEP7a42kZqBrkrx9S6oVYj+9zZx/5t
+S3cnhY2nfnk54xThNqdfpfro/wCc6pg8H+/yVKi6u1ido4/7U1VHOBlL1zk+uCe/yqsMQTwMCm+l
+WlxPEbqOFZ44Zo1kVlJ7/COOeew/OtobPK76Lq2uK0WqG91O4tLOUeMpuZGMobIPunjjHn9K6ZpG
+uJrWnR3lreTFHHYucqexBrnl9C/T9jDE19PAJ3luVhlbLx5AAXOfMHn55p90AulwaXE0Kpb392m+
+4gWXcAVJ94jPu5B+X0qho5cue8jdcDPc5/4iX/Wa89puQf8AHl/1nFbvCqJYXS3wnAXbJBMYZEBz
+tYYPoPIg0+ylrL2xN7fNdxgSuFAbIMx57YPpXk1/cGMnxZ1YE+6zkcj5+lZxqk95K0UoOxNmV5AO
+eR8+wrCZ3BaIxE8c7u33H0pHypjxks2sX0iu1vNcP57BMwIP5YqFda5fKvvXkySZGMTvtGfmDisL
+5LyJxIcF2OXjjdsFfLngA9uaiuLSS3WSCFZI5R+sBJ930Gc4GDx91RTZdI1/6Lv7i60m4eeSV3W5
+ZdzOX42r5n60UdDoItAZUMRXxmI2NuA4HnRSlm+a+ov8y6p+9zfzmlhpn1F/mXVf3yb+c0sNVnpI
+tA9vE8DtLM28vEq/4YHmT555Pyq1dGdZXHTDvbz2VrdW29ZGSZPfGORtYA88557VXrO4sFsJ4Xsp
+JbssGifxjtUeeVA5+ua0NDNJMzCPwYye2eFHp6mhCbXmoTaxqzapqss91C8pVxIwLBO4VT2GBwOK
+zeSGSATWyypIARMqcRAfskEck47k+fNaNNs45b6Nbm5FvDuG6fAIXHyzzTnqTTbe2ubaKDUra6gI
+3NPBs3k+rKpxn0yf4VuStfbD7SrJ7SC0j0y/e78IIqrtfLAYz3yR55qPb6lq08NzbpNHLLcS+JLI
+ibUX3VXaSO/C9l49Se1KenrCK7sVkt42htXJU5P6yUA494jy4+EcfWrpZW62yqsaBVxjGOMVnrIA
+SvRZ9Q027u4sPIhYMxlzsl+a4+EjtxVku7YXlvvhaW7IG/ZE48ROPLBAP4H5UltUaZuYpVbJ+Mna
+f6dqYxLNY3PjowYYIAHwsP60oJPxq9ciFTKC7hx8KDdhT2OQeCMetQhYWjtMUimubcYZUjyEkJ/b
+P/zjPlTzrjVbax0a2uru2ZhJJ4ayW52sDtznn+B8/SklnfSvaw3MMkbwxBcmR9hx9ASfu9KCrNrV
+0PoeJU0Bssj7p2PHuleAMEY7jH30Vl0pqL3WmzucEi4YExowGcA+f1orbl1fNfUXHU2rD/vJv5zS
+vjHenHUao3VWqBTtU3soJPl75pXLC0Xxefb50+57KDanvsxA5HHrTu2WyWxFzcTQ+Ix+AkZPz45H
+5Uv0m3W8neORFKxxl+3PFNbG0sLqORo9PeRkI91SCW+nNCDY3t/o02nC3ggeOYgb5Vy27nPY4xUz
+SNc6fsvY0vdOkuYok2yqPdMh5Oe/B5FSLDStLvIXkGnsgRiCJAB2GT51gx6agWEyWMmJoxKv6sdi
+SB5/KtC6B017NLpVs8UbRW77mRGYMyqWJAJ7E1YmtwkAkWQMCOMcfhVI0/TZLPVoIbNvAt1RZSoB
+yc84POKfdQa7a6DpcF1JBLK7yeGyhsYGCQc+nGKMkyiEyhVeSN0UYGE2kfjQzNJbJGOMc5FIz1HE
+lxZxysie1QRypz339v6U9hk2hCcEj186PsPKr9bReNo1paEkxrIzhWOeccmrJpPSEGg2yspSeYnc
+qZJEfAyefyPrSXraRXt7SVYgg3Mdq9j2pPfahcXkhu5faEkdcsGXBxjsRnyxxUf0y+auGP1dc6ei
+Kaa2Qi5mc7UQgDn50VXugbiW66fkfOQty6DMh7ALRWHZuCabgHUjgdVatkce2TZAOM++aWSStN8R
+OF+EelMupuOq9X/fZv5zSk1UjPumI/Ek1AjHiezFY8+bE1OtdJ1G2t7janvsE8PBHcHJ/pUHpm5j
+tXuGkKjcFAyfrVnt9dtnMmCMISCcd8elHUmT2jSHXJbWFhEVnBYOquORhQO/0JqBfaVqzNaeHYs6
+Jbxox2r3Gcj8asmndQWmoRu0Q2mPggjBOKbWGr2l3aGSKRXibIO49j689q2pfqmwSR/2s6hgSsMY
+OPpS/rm2ur7TLOKwDNIJSzjcAMYx5/WlM3UFppuv3XjbypVPeTBHw/Wmp6004xBGknVMZ2lMj69/
+nTaId9qFrustDq1kkYJlsIIYnDYI8ROTj1GTjNT4PtO1qCVh7NZvE4wY2Rvr3zkUm6qNvc6zNfWk
+viRTkMRtIIOMH8qTSTF4UjKjKE8juc0tUBLoV31M2t6NaTSRiOUF96qcjuBxWnTryW502O3kuRPI
+qfEWy3y488AfhVae5jt9PgihbeyjJC+Xmc1nF1ZqUUHgItsqbdvEABI+o5pP0x+o4KeXffs3ji/R
+d3dmO+6kIxgYHA7fdRVc+zPXbi46XkDRwII7p1UImBghW9fVjRSBrkF7VPVek7C617U5ZJLgM11I
+Thlxyx+VRP0K00zBPFusH/qX/wBaKKbdqy2H2XaBL70kt6/B4MqgfgtbE+zDp9/ajm8HhyFFxKOA
+B9KKKnlk7qByplz0zZW93LEktxtVioO4Zx/CtDaJbxgxrNPs4ONwwfuxRRVabaxoVtgnxJgR8x/t
+Wdv05aTTRxtLOFJxww/2ooowpA6WsRK8Xi3G0MR8S+v0p9p/2d6LOoeWS8Yny8RR+S0UVPNdRJrH
+0VoEGYxYI+P2pDuJ++tc3SGgjcw06IEemfWiiuP7y37W/MFrj0jomnWWlSxW9ssaGdmIBPfC/wC1
+FFFdGK6hmH03/9k=
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0303:SL030302.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0303:SL030302.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0617___SL061701__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0617___SL061701__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
@@ -1,0 +1,888 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0617___SL061701__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="q1">Residence</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">4</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0617</Param>
+<Param name="viewid">SL061701.TIF</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0617 SL061701.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>cb5391a71c8698c6caa9cbb6fc4b91fa</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0617</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0617___SL061701__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0617%5DSL061701.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0617%5DSL061701.TIF</ItemUrlEncoded><TitleForTagging>204%20W.%20Henry</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="4" name="S_SDLHOMES_X_SL0617___SL061702__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF</Url></Next>
+<Prev><Url index="2" name="S_SDLHOMES_X_SL0303___SL030302__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0303;viewid=SL030302.TIF</Url></Prev>
+<Self><Url index="3" name="S_SDLHOMES_X_SL0617___SL061701__TIF">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF</Url></Self>
+<TotalResults>10</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260769</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;q1=Residence;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0617]SL061701.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABQYABAcCAwH/xAA2EAACAQMDAgQEBQMDBQAAAAAB
+AgMABBEFEiEGMRNBUWEHIoGRFBUjMnFCocEWUrElMzVy4f/EABcBAQEBAQAAAAAAAAAAAAAAAAAB
+AgP/xAAZEQEBAQEBAQAAAAAAAAAAAAAAARExAhL/2gAMAwEAAhEDEQA/AHW+1a/TVbyIXsqIk7Ko
+EmMKPLGKGz9TTLEzLrEufZ9zD6DmhXUkDP1FqbzFniE7bVBAC9v6cfN/PehclzcPpgaG4Qnt4ZjC
+/wBx/msSA8erLuTG3UrtGAz+8YI/j19q836v1AqAl1ds27GckZ/xS9balGwPjogcJ5/49KI+OPAU
+OCxIHLHhSfSmAqmu6pIp/wCrXAdeSgJ3du3PerFrreoT8jU7hvUBsFT6EUvtatfrtj4VP02IXli3
+AQD1Pn6DHrRi+6WkhtbZ7eRvG2nYOVICjgcHA4+nl27MBL82vgOb64+r1z+d3eCRqE5x3/UpEm1e
+9XMVwSYk5M6A9u3zL5H3qqmrRWiF4pUkzwAH4Iyfv5UwaD+fXhKj8fOCw4JkNULnqDW3uFgt72Y+
+bMknzBaSI9dW4t1aR1ikMh/TBP0P1rm36hME8hDlg42ZAzjB7iritCk1vUdhVNRuTIeB+oQR9KAa
+h1BrsBlKa7fEIOCHAzx5CqkNyNUVp5d7AKAA3G4nyAHlXFzYNasSGb51JZXPBPt9/XNTBqXw6vrr
+VukYrm+ne4uPGkVpJDkkBjj+1SvH4Yjw+jYxjH68n/NSsXqlPqe4ibXNStmJDiVm/wC2T6e3alS9
+limVW7N/tyV3ex9/59abOqkWfqK88OREmSUryxywPfihL2+LPEoVghMcgCkDg4BPoea6RkJtLSKa
+aBww27QWbuMEZ+/FedzqBhK+DISqvwVUsFI5JPl/99hVjTYbXwwZ5CHRiSoOCcDAGP6s5A+9GtI0
+uxv+pHt4oIQkEXivnn5wVxgZxnnmgYNCt4E/DSiOULbQiTww24vI5J3cd+Ae/maNLdhYTNKA80Ss
+AhbCrg/t9yfOs36tvZ9NXwbSd7dkuvCZkYjcqgsO3OctRjoW4gbp+9uruVp5DKIY0kJPJUYwP5NA
+I6g1ODEr3VsttPC4QmKQs0nqMbQMj+ewx5ClyOzsNbYRxXEdvNCrOSIyfEUAkgKOd2ew960D4kKl
+zFZwsSwWM4yhUA7hyB28qymG1kB8eNyCjNsdTgjBqxVRGJ7jJ86sxAOCuD9qZYukwzaZG0rPJfok
+rbUHyBmI7efbPlVXqLRR07rk9kWdkQJhmxk7hnyq6COmSJLptsuChTILBSdzZ/vXdwL6VS6IpSMZ
+aQtnCj696r9OG4k3Qxxybdx+ZRwe3HP186PTPaNcm0B2eCRjcOS3v9fKsh/+G+7/AEkodtzfiJOS
+MZ59KlWOi/8AwGORiZxnnn0PPtgfSpXK9Ui9WWU9x1FqBcL4BlIVgQMEgdxg5PvxQSN9VeO5RLpS
+hXMgdgzEYwTu7EZUj2x3pp1c6dN1FrK6pMUhhk3I6zDIOB8u0HPvSTcX0Flfyx2ksM0blMO8ZwVL
+fMCM+pB4711jKpDctaEuwLsGXDYz8pycnAPr5V76PrNlp2qNfym5dijDEcbYDFhwc9xivBtRtYiI
+1mjRVmO0heCA2AfbgE49x3rue0/MtC01rREFw88sbsrY34Xdz796o71XULHWrt3WO8UBjIBFAM/t
+CjueAMH70e6VkWzsbc28MjBZzL+HdGeV5MBRjGFAHfk1m9ybu2cHc67sjduOTzRHSdK1fVIZXtY5
+JBGcMBJg9vQnmmDYdT0m86gjE+qCSzWJSBgrL555VQD9s1m1zb2Gh6gNKnu3lizuecQMuzcSSCp5
+yAc0M1TQ9W0iCKa/geFJG2qS4OTjPkaDLKxMnPY0kGtFYNU6h0SbRr21ubOxjjjciYKflbzU4Oce
+1AviQ/i9V3iE7WPgj+Bhcn7UhqN7HOCfXFXIriQTMZpJJeAPmJbjHHemKa9BmgSyaF2bCTlm+bAK
++o7Z5FG1tIn05WWBpHwWdJSB9j9u9AdF1C0it2e7td0UT+Jv8IHt3XI5Hl96ZdZ1uxXplJrGVZnk
+wuVGQg88gjg98dvXyqB16CRYumV2srBpnb5ey5xxUqr8M5zc9HRHaVCTSIB7A8VK53qlvqDpmGfq
+u+vzZlzKx3Kz7d+P6lPbtjIyD7YrO+oE/AXs1tEgSA8qrKSyn2b/ACKY+uN46r1TJYK03rweBSTd
+xnxRtJOT2z2rr5ZU3hfl2zg+fvThBqcVidNs4mt1SFWldo1IYExEHOeOc96U5U/bnuea4EaxlvnI
+xzgjGftVovatF+Kkga1TMaxqC2cndj5s/XNPPR1jJp+hxy3skcHi3BdGLAMBtHORz2HakCCTflYR
+iIEkBmGf7+ZxTZYLHfWsX4uVpLf9zELgLx249qlVz8Rr9zeR2qzmSOLAJBJQsV5OPI4PNIke7Y5H
+JPlVzUGimvnMRKpuJBckgjPGM8+neqW3njPFWAlpVnd3au8VtPKgOCyRlgD6ZAqzqdjcWF3JBcwv
+DKAjFHGCAQCK9tE6s13Rbc2um3TQwyNudEUfMfXJ7GqVxqN5qt8095K80r4BZjlsAYH9qD5cROIh
+IqnkhR75zX20eUuLUyKgkYA7zgD+faiP5VfX0SKltOVZgAEhdsY4/wBtXL7pTWLLUEklsGZflYGC
+M7cADuPLgc+9QbV0RpL6D08LKRy8glZ2J8iccYHb+Kle/S94t/pkl8sTRi4mL7GOSvAGD9qlcr0J
++q6Peaj1JqxOlSOqT/pOw2JIuByGxzzntQi86OuW0x58zxXZkKi0igdhtB77sedSpWpQmzdNdQmT
+adH1FwpIBFu5H04pyf4U2SRoz3l+SQCVWLODjkcCpUq31Rdg+FOlRxhjJduxHZ14+2Kuw/D+G2ha
+K2ur2BT3CDIP0K1KlTaBMvwms3bcL+8X1At8/wCK6h+FOmRNmS41CUegh2/4qVKfVBiH4f6EhjP5
+bO2wADxN5z9AKL2WiWGkF2stOeJm/cYrdsn25FSpU2i8qSPz4E4/90b/AIqTWUkqFVZo89yImJ+l
+SpTTBHTrZbS2MaF2yxYlgQc1KlSsj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061701.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/520,372/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>520</w>
+    <h>372</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0617]SL061701.TIF</istruct_isentryid>
+<istruct_x class="fieldsRef">1</istruct_x>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<m_caption class="fieldsRef"/>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_iid class="fieldsRef">SL061701.TIF</m_iid>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_m class="fieldsRef">SL061701</istruct_m>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_caption class="fieldsRef"/>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0617-1</istruct_isentryidv>
+<m_searchable class="fieldsRef">1</m_searchable>
+<m_id class="fieldsRef">SL0617</m_id>
+<m_fn class="fieldsRef">SL061701</m_fn>
+<m_flm class="fieldsRef">2013-02-08 18:59:39</m_flm>
+<md5 class="imgInfHashRef">5c7d9bc65058c16af3a8c75681f7d09c</md5>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<use class="imgInfHashRef">access</use>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/06/17/01/SL061701/SL061701.jp2</filename>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<master class="imgInfHashRef">0</master>
+<width class="imgInfHashRef">2080</width>
+<type class="imgInfHashRef">image</type>
+<height class="imgInfHashRef">1488</height>
+<levels class="imgInfHashRef">4</levels>
+<u class="imgInfHashRef">1</u>
+<size class="imgInfHashRef">421754</size>
+<access class="imgInfHashRef">1</access>
+<basename class="imgInfHashRef">SL061701</basename>
+<modified class="imgInfHashRef">2013-02-08 18:59:39</modified>
+<ext class="imgInfHashRef">jp2</ext>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="4"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=4;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=4;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:4/0/native.jpg</Part><LevelWidth>130</LevelWidth><LevelHeight>93</LevelHeight><LevelMaxDim>130</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:3/0/native.jpg</Part><LevelWidth>260</LevelWidth><LevelHeight>186</LevelHeight><LevelMaxDim>260</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:2/0/native.jpg</Part><LevelWidth>520</LevelWidth><LevelHeight>372</LevelHeight><LevelMaxDim>520</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1040</LevelWidth><LevelHeight>744</LevelHeight><LevelMaxDim>1040</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;start=1;resnum=4;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2080</LevelWidth><LevelHeight>1488</LevelHeight><LevelMaxDim>2080</LevelMaxDim></Level><MaxWidth>2080</MaxWidth><MaxHeight>1488</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_ownership;q1=Armbruster%252C%2520Lee%2520and%2520Donna;select1=phrase" target="_blank">Armbruster, Lee and Donna</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>4:21</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>Two story, cross gabled, vernacular, Queen Anne style house. Shingled returns on gables. Full width porch wraps around to entry door on east facade. Small peak on porch roof above entryway. Windows are one light over one. One story addition to west rear with an entry door. Concrete block foundation. One car, hipped roof garage with a clipped gable at rear.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_date_construction;q1=1910%2520ca.;select1=phrase" target="_blank">1910 ca.</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>Anna Wolper owned the house 1914-1935. Other occupants: Ward Earnst 1941; Frank Karn 1947; John Schaffer; Leonard Morton.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1914, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; Tax Rolls: 1931 and 1935.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 187</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>187</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value><Value>Two story, cross gabled, vernacular, Queen Anne style house. Shingled returns on gables. Full width porch wraps around to entry door on east facade. Small peak on porch roof above entryway. Windows are one light over one. One story addition to west rear with an entry door. Concrete block foundation. One car, hipped roof garage with a clipped gable at rear.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL061701_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0617:SL061701.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0617:SL061701.TIF" canvas-index="1" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">sdlhomes_date_construction</Variable>
+<Variable name="fq1">1910 ca.</Variable>
+<Variable name="sort">sdlhomes_present_usage</Variable>
+<Variable name="rgn1">sdlhomes_present_usage</Variable>
+<Variable name="select1">phrase</Variable>
+<Variable name="c">sdlhomes</Variable>
+<Variable name="q1">Residence</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">4</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sdlhomes</Variable>
+<Variable name="entryid">x-sl0617</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SDLHOMES-X-SL0617 SL061701.TIF</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>SL061701.TIF</Label><Value>SL061701.TIF</Value><Focus>true</Focus></Option><Option index="1"><Label>SL061702.TIF</Label><Value>SL061702.TIF</Value></Option><Name>relview</Name><Default>SL061701.TIF</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABQYABAcCAwH/xAA2EAACAQMDAgQEBQMDBQAAAAAB
+AgMABBEFEiEGMRNBUWEHIoGRFBUjMnFCocEWUrElMzVy4f/EABcBAQEBAQAAAAAAAAAAAAAAAAAB
+AgP/xAAZEQEBAQEBAQAAAAAAAAAAAAAAARExAhL/2gAMAwEAAhEDEQA/AHW+1a/TVbyIXsqIk7Ko
+EmMKPLGKGz9TTLEzLrEufZ9zD6DmhXUkDP1FqbzFniE7bVBAC9v6cfN/PehclzcPpgaG4Qnt4ZjC
+/wBx/msSA8erLuTG3UrtGAz+8YI/j19q836v1AqAl1ds27GckZ/xS9balGwPjogcJ5/49KI+OPAU
+OCxIHLHhSfSmAqmu6pIp/wCrXAdeSgJ3du3PerFrreoT8jU7hvUBsFT6EUvtatfrtj4VP02IXli3
+AQD1Pn6DHrRi+6WkhtbZ7eRvG2nYOVICjgcHA4+nl27MBL82vgOb64+r1z+d3eCRqE5x3/UpEm1e
+9XMVwSYk5M6A9u3zL5H3qqmrRWiF4pUkzwAH4Iyfv5UwaD+fXhKj8fOCw4JkNULnqDW3uFgt72Y+
+bMknzBaSI9dW4t1aR1ikMh/TBP0P1rm36hME8hDlg42ZAzjB7iritCk1vUdhVNRuTIeB+oQR9KAa
+h1BrsBlKa7fEIOCHAzx5CqkNyNUVp5d7AKAA3G4nyAHlXFzYNasSGb51JZXPBPt9/XNTBqXw6vrr
+VukYrm+ne4uPGkVpJDkkBjj+1SvH4Yjw+jYxjH68n/NSsXqlPqe4ibXNStmJDiVm/wC2T6e3alS9
+limVW7N/tyV3ex9/59abOqkWfqK88OREmSUryxywPfihL2+LPEoVghMcgCkDg4BPoea6RkJtLSKa
+aBww27QWbuMEZ+/FedzqBhK+DISqvwVUsFI5JPl/99hVjTYbXwwZ5CHRiSoOCcDAGP6s5A+9GtI0
+uxv+pHt4oIQkEXivnn5wVxgZxnnmgYNCt4E/DSiOULbQiTww24vI5J3cd+Ae/maNLdhYTNKA80Ss
+AhbCrg/t9yfOs36tvZ9NXwbSd7dkuvCZkYjcqgsO3OctRjoW4gbp+9uruVp5DKIY0kJPJUYwP5NA
+I6g1ODEr3VsttPC4QmKQs0nqMbQMj+ewx5ClyOzsNbYRxXEdvNCrOSIyfEUAkgKOd2ew960D4kKl
+zFZwsSwWM4yhUA7hyB28qymG1kB8eNyCjNsdTgjBqxVRGJ7jJ86sxAOCuD9qZYukwzaZG0rPJfok
+rbUHyBmI7efbPlVXqLRR07rk9kWdkQJhmxk7hnyq6COmSJLptsuChTILBSdzZ/vXdwL6VS6IpSMZ
+aQtnCj696r9OG4k3Qxxybdx+ZRwe3HP186PTPaNcm0B2eCRjcOS3v9fKsh/+G+7/AEkodtzfiJOS
+MZ59KlWOi/8AwGORiZxnnn0PPtgfSpXK9Ui9WWU9x1FqBcL4BlIVgQMEgdxg5PvxQSN9VeO5RLpS
+hXMgdgzEYwTu7EZUj2x3pp1c6dN1FrK6pMUhhk3I6zDIOB8u0HPvSTcX0Flfyx2ksM0blMO8ZwVL
+fMCM+pB4711jKpDctaEuwLsGXDYz8pycnAPr5V76PrNlp2qNfym5dijDEcbYDFhwc9xivBtRtYiI
+1mjRVmO0heCA2AfbgE49x3rue0/MtC01rREFw88sbsrY34Xdz796o71XULHWrt3WO8UBjIBFAM/t
+CjueAMH70e6VkWzsbc28MjBZzL+HdGeV5MBRjGFAHfk1m9ybu2cHc67sjduOTzRHSdK1fVIZXtY5
+JBGcMBJg9vQnmmDYdT0m86gjE+qCSzWJSBgrL555VQD9s1m1zb2Gh6gNKnu3lizuecQMuzcSSCp5
+yAc0M1TQ9W0iCKa/geFJG2qS4OTjPkaDLKxMnPY0kGtFYNU6h0SbRr21ubOxjjjciYKflbzU4Oce
+1AviQ/i9V3iE7WPgj+Bhcn7UhqN7HOCfXFXIriQTMZpJJeAPmJbjHHemKa9BmgSyaF2bCTlm+bAK
++o7Z5FG1tIn05WWBpHwWdJSB9j9u9AdF1C0it2e7td0UT+Jv8IHt3XI5Hl96ZdZ1uxXplJrGVZnk
+wuVGQg88gjg98dvXyqB16CRYumV2srBpnb5ey5xxUqr8M5zc9HRHaVCTSIB7A8VK53qlvqDpmGfq
+u+vzZlzKx3Kz7d+P6lPbtjIyD7YrO+oE/AXs1tEgSA8qrKSyn2b/ACKY+uN46r1TJYK03rweBSTd
+xnxRtJOT2z2rr5ZU3hfl2zg+fvThBqcVidNs4mt1SFWldo1IYExEHOeOc96U5U/bnuea4EaxlvnI
+xzgjGftVovatF+Kkga1TMaxqC2cndj5s/XNPPR1jJp+hxy3skcHi3BdGLAMBtHORz2HakCCTflYR
+iIEkBmGf7+ZxTZYLHfWsX4uVpLf9zELgLx249qlVz8Rr9zeR2qzmSOLAJBJQsV5OPI4PNIke7Y5H
+JPlVzUGimvnMRKpuJBckgjPGM8+neqW3njPFWAlpVnd3au8VtPKgOCyRlgD6ZAqzqdjcWF3JBcwv
+DKAjFHGCAQCK9tE6s13Rbc2um3TQwyNudEUfMfXJ7GqVxqN5qt8095K80r4BZjlsAYH9qD5cROIh
+IqnkhR75zX20eUuLUyKgkYA7zgD+faiP5VfX0SKltOVZgAEhdsY4/wBtXL7pTWLLUEklsGZflYGC
+M7cADuPLgc+9QbV0RpL6D08LKRy8glZ2J8iccYHb+Kle/S94t/pkl8sTRi4mL7GOSvAGD9qlcr0J
++q6Peaj1JqxOlSOqT/pOw2JIuByGxzzntQi86OuW0x58zxXZkKi0igdhtB77sedSpWpQmzdNdQmT
+adH1FwpIBFu5H04pyf4U2SRoz3l+SQCVWLODjkcCpUq31Rdg+FOlRxhjJduxHZ14+2Kuw/D+G2ha
+K2ur2BT3CDIP0K1KlTaBMvwms3bcL+8X1At8/wCK6h+FOmRNmS41CUegh2/4qVKfVBiH4f6EhjP5
+bO2wADxN5z9AKL2WiWGkF2stOeJm/cYrdsn25FSpU2i8qSPz4E4/90b/AIqTWUkqFVZo89yImJ+l
+SpTTBHTrZbS2MaF2yxYlgQc1KlSsj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061701.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=4;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061701.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAYEBQIDBwgB/8QAPxAAAgEDAgMGAgUHDQAAAAAA
+AQIDAAQRBSEGEjEHEyJBUWEUcSOBkbHBJDJCQ6HR8BUWMzdEVHJ0g7LC4fH/xAAYAQADAQEAAAAA
+AAAAAAAAAAABAgMABP/EAB0RAAICAwEBAQAAAAAAAAAAAAABAhESITEDUUH/2gAMAwEAAhEDEQA/
+AKPWeI+Im4m1u00/Xr3vVvZUW3M5jSJASAFYtgdAOm1LQ4x4o734ccR6scjmDd+SWP27DO3XfrUX
+jCXk4v4gQDdtRlyR1wGO3y3qsuFufhleVPolIK9AAcAYGOu2PlTaGoYl464mdxE2u30SN4SWuWLp
+jz2OfLp51qHG3E0ckjRcQalKkYVgWuHGRnrgnz9KV+8Ik7wOGIx161LVY57Nm/Xhs8qoACOnX7sV
+jUdv4N1ZNWtoGueJL9714TzW3xZ5epAf5kYOD88U1NDqVrYGPT9SuJZCFAe7lMmOUbkepbzrzdp0
+N6DzWokWaMEhk2PTP17b11TQNb+Ote9t7hopFPiVT5+uOgz1pJyx/DLzy4ybq3EXEWlSqr3M7OMt
+yq+centj93lSe3G+vPcPdXOpalFbn+ihhmIBPnsTkjpVnrtnLcuhkusRuSWZH3Aydwv3n3NVU2io
+NMSW1S2l72Vl5nmGR6eeAuMnoKhkMoMrbnjPXpIxLHxRqcTjJ5TM2G326Hb/ALFSouN9Wgu2Mmva
+nITg921yxCbZO4wM+1K0lpBGs9w93E/JkIqk+JidsbdMb59qxhlgilVZYlJyrFgSSuce9Ua1RqGy
+7461hLf6DW9SMjHC5uXIX7etQrfjfiEmQvxHqBboi/EONwP4+ylm+kIuWJb9LmAB6fxiosTqGIYj
+lwSQR19qMYaAen+yXUr3WOCviNQuZLidbqSPvJJC5IGMbnPrRULsPwOz4kfmm9lI+W1FMIzg/GLl
+eONcOSM383T/ABmqYsAoQO+MnJx0+qrrjaUS8ba2TGq4vZR4RjOGIzVL3K/DxuJB3jMQU5Tkehz5
+045geXAAq30LS7rXJn0+zVGnK8wB6hV3YjzqtggkuZ+7jj5n3JA8/Wujdn/D19Za7aahc2pjiZ5U
+WQuASQMFSp/D0zQlJIKKzR9M07Tr69TVJpntbIxs09sjJLv0TBI5dzudyMbU9a1pmncMQWl5ZRTi
+2nj5m3ByOoB26jIwep96whVLri2RHdpYmvj4GwVxzdMYp24n0yG90R+ccqweJeUDHUDHsKi3Y6VN
+HMRxRayxATWrwyDbxMFBX3IGwPoaj3WgNc6fJeRiEx3bErHDMGWMeXOw67jy6VX31qk3E5tweVfh
+i5x681V2r2K2OmyTxGOOXvgvM3TFIofB3L6V2oW+nwQyRrM0syN4Qi+AAerH132FUgkKygqSCpzz
+KcHPrTxqOi28eix3Ziyz2gd26ZbAwR9dJAhJkWNGB5wM4U5X2q0PhJm69mW5ZJ1BBYkMCck753+2
+ooAOQM58qkLGoQrljysGJxjY7UXKW4lJhcKjDKqzZI9iR5+dOgM9Fdhv9Xp/zsv/ABorPsR5P5hO
+UYspvpSCRgnZfKilJvpx3jiwto+INQeOOTmN5NJNJj1c7D296XVht1mVZjNHCduZF5yNvfH2Uw8V
+3c1xxdqlqocQC8kV5AhblPMcHbpWUNm1vEwL98O5ZQHOTzlcAgnoNztQycUWUb4LIl+Eu+eILtlc
+k7NThNxhr+jxWlvPpllDIo76CSSEs/KxzkHPQ+1JsVhK92kNx9GC3IzMdh9Yp57Q7VI7yxA6xWUM
+WxyMBc5rOrAiDF2haz8X3jm2RTksLeFY2LH9LmwTnND8V6heXiTXN3K4GB3RJIYZ3BJOd6SlIMq7
+eYqyi/OBouKQbsZb7U7a6vhcWlmmnTqpVisjyhgT08R2+qvllqVu19GurRi7tAxZ0t2CsdiBs3z9
+aW7iX8uiYHbJzXwS5uCaWmHR0riniDS+IYbSz043EQS2aLEsXKV9MeR296SNQsI7O0soyoIRsO4b
+kyfIk1stWMdleTI3K627EEeRrY+rXFtpNnLgTtcIVlSTBV/PcY3/AGYpVaZmkWuqSw3XBYtRZ/BS
+xSCSGJoge/AB5mEnVj6jyxXPyQ7DYZcZ2HQ+wq5s5JHnkuIoZGUKwYhi6qSD0zuPrqkZHjYjbwbZ
+9KpHolaPSfYapXs+Ibr8bKf9tFHYamOz0g/32b8KKzJvpzbVLW3g4n1SZIWDSXMokxIcOOc/++1V
+dxObWBnboNs4z126Vr4h4kWHiPVI1tiSt3KuS2M4c0vXutz3a8gRY022G+4NLhJsup0iNewS28x5
+5BkkkY9c0065xbY6zpgiEUyXKd0A0mCCqx8h3G+c70nSSSTOXdizHzrDlPpVMb6JZvURhgdt/ntW
+w3IVTjrUYFtvavpyRjHWmowd4zODgk1uibmmRQ6jmIGWOAPnWyw025urqMJbTSLzDm5NtvPenccP
+2mspGxs/hJox3bCCN5VYDGNlHz33yaSUkhkmyguZodLkmsLmeKXni5We1kEi4bfZqsntoDp0UKTc
+8Ma4OCA59MHy61Mk4NsYeaS4h4gdDjeLT+6UH5vg0ahplramB9Kg1BgOXwyplgAMHONs/I1CclxD
+JFFFFLa3URZsWhfAQjAI9NvOl2ZViunQ5ZVcjbYmn+CO7to3xapbo7kzCV8u3p8j91K+taZySXFy
+kqynn53AOcA9KPn6K6YJRo732Gb9nQ2/tk34UUdhoZezsBgR+WTHf6qKsyD6V+o9j/Dt7qV1dyXW
+pCSeV5HCypgFiSceDpWmHsU4YLeK51Q/66fglFFBvQyJ8XY7wnAxJiupTn9bNn8KlR9lPCY8PwLn
+nO5L9PlttRRXJKTvpREtOy3g6FQP5HjcqMZdiSfnvvUuLgLhaEHutEtFyN/Bn76KKtbATouGNFgQ
+pHp1sEznHdKRn7K3vp8MUHdW2bZSf1Kqv4UUUJcNbsgScPW86/S3V4/nvIP3VgOGLJWBWa5U58nH
+7qKK5qQ1s3W3DtrFcd6bi6kIOyvJkdPTFS30OwkVg0CEMdwVGPsxRRV4JUBtky0tYbSARQII0znl
+UAD9lFFFdC4RfT//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061702.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061701.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0617___SL061702__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
+++ b/samples/data/s/sdlhomes/S_SDLHOMES_X_SL0617___SL061702__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3.xml
@@ -1,0 +1,888 @@
+
+
+<!DOCTYPE Top><Top xmlns:dlxs="http://www.umdl.umich.edu/dlxs" identifier="S_SDLHOMES_X_SL0617___SL061702__TIF__xz5536d312bcb5e17f0911755b9b3bc5a3">
+
+ <!-- XSL fallback files -->
+  <XslFallbackFileList>
+    <Filename>xsl2htmlutils.xsl</Filename>
+    <Filename>feedback.xsl</Filename>
+    <Filename>htmlhead.xsl</Filename>
+    <Filename>displayheader.xsl</Filename>
+    <Filename>entry_imagetools.xsl</Filename>
+    <Filename>fieldvalues.xsl</Filename>
+    <Filename>social.xsl</Filename>
+    <Filename>entry.xsl</Filename>
+    <Filename>panzoom.xsl</Filename>
+  </XslFallbackFileList>
+
+  <!--  <Filename>bbopenutils.xsl</Filename> -->
+
+  <!-- Custom OPTIONAL XML for top-level file entry.xml -->
+  <CustomXml/>
+
+<DlxsGlobals><CurrentCgi><Param name="fn1">sdlhomes_date_construction</Param>
+<Param name="fq1">1910 ca.</Param>
+<Param name="sort">sdlhomes_present_usage</Param>
+<Param name="rgn1">sdlhomes_present_usage</Param>
+<Param name="select1">phrase</Param>
+<Param name="c">sdlhomes</Param>
+<Param name="q1">Residence</Param>
+<Param name="subview">detail</Param>
+<Param name="resnum">5</Param>
+<Param name="start">1</Param>
+<Param name="view">entry</Param>
+<Param name="lastview">reslist</Param>
+<Param name="lasttype">boolean</Param>
+<Param name="cc">sdlhomes</Param>
+<Param name="entryid">x-sl0617</Param>
+<Param name="viewid">SL061702.TIF</Param>
+<Param name="debug">xml</Param>
+<Param name="size">50</Param>
+<Param name="chaperone">S-SDLHOMES-X-SL0617 SL061702.TIF</Param>
+</CurrentCgi>
+<CurrentUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF</CurrentUrl>
+<UserAgent>node-fetch/1.0 (+https://github.com/bitinn/node-fetch)</UserAgent>
+<ReferrerHref/>
+<Sid>bcba4c82c63a615024d26cf4d988d7d1</Sid>
+
+<EffectiveLanguage>en</EffectiveLanguage>
+<LanguageOptions><OptionalLanguage>en</OptionalLanguage></LanguageOptions>
+<LangMap>
+  
+  <!-- bbopenutils.xsl which serves bbopen.xsl, bbname.xsl -->
+<!-- "items1" used by bbresults_nav.xsl SliceSummary -->
+<!-- "portfolio" used by bbresults_nav.xsl CollectionName -->
+<lookup id="bbopenutils">
+<item key="portfolio">portfolio</item>
+<item key="porthelp"><b>Help</b> For Using Portfolios</item>
+<item key="bbopenpageheader">Portfolios</item>
+<item key="bbnamepageheader">Add to a New
+or Existing Portfolio</item>
+<item key="yourport">your portfolios</item>
+<item key="pubport">all public portfolios</item>
+<item key="bbagname">portfolio name</item>
+<item key="action">action</item>
+<item key="items1">items</item>
+<item key="shared">public</item>
+<item key="username">owner(s)</item>
+<item key="open3">open</item>
+<item key="add3">add</item>
+<item key="savename">save name</item>
+<item key="saveowners">save owners</item>
+<item key="bbdel3">delete...</item>
+<item key="bbexportprep3">download...</item>
+<item key="viewable">viewable by public</item>
+<item key="instructionbbname">To create a <b>new</b> portfolio with the selected images, enter a name in the <b>text box</b> and click <b>Submit</b>.<br/>To <b>add</b> the selected images to an <b>existing</b> portfolio, find the portfolio name in the table below and click <b>add</b>.</item>
+<item key="0">no</item>
+<item key="1">yes</item>
+<item key="switch0">make public</item>
+<item key="switch1">make private</item>
+<item key="none present">None present.</item>
+</lookup>
+
+<!-- bbdel.xsl bbdelconf.xsl-->
+<lookup id="bbdel">
+<item key="successdel">Portfolio successfully deleted.</item>
+<item key="instructionbbdel">You may open a portfolio or close this window.</item>
+<item key="yes">Yes</item>
+<item key="no">No</item>
+<item key="instructionbbdelconf">Permanently delete portfolio?</item>
+<item key="name">Name of portfolio</item>
+</lookup>
+
+<!-- bbexport.xsl -->
+<lookup id="bbexport">
+<item key="exportfull-image">media</item>
+
+<item key="exportdescription">record</item>
+<item key="accessdenied">The media was not included due
+to a lack of access privileges. Sorry. You may view the record.</item>
+
+<item key="index">index</item>
+<item key="of"> of </item>
+<item key="viewonline">view online</item>
+<item key="exportPageTitle">export </item>
+<item key="guidelinesbuttontext">guidelines</item>
+<item key="guidelinesTitle">Guidelines For Use</item>
+<item key="portlastmod">portfolio last modified: </item>
+<item key="forhelp">For help or to request permission to publish: </item>
+
+</lookup>
+
+<!-- bbexportprep.xsl -->
+<lookup id="bbexportprep">
+<item key="returntoportfolios">return to the list of portfolios</item>
+<item key="morehelp">More Help</item>
+<item key="imagesize">image size</item>
+<item key="imagesizesmall">small</item>
+<item key="imagesizemedium">medium (presentation)</item>
+<item key="imagesizelarge">large</item>
+<item key="imagesizelargest">largest</item>
+<item key="download">download</item>
+<item key="whendone1P1">When done, all of the
+images (and/or other media) will reside on your computer for convenient
+use. HTML pages are also included for viewing records and easy
+navigation of images.</item>
+<item key="long">The download may take several minutes to complete.</item>
+<item key="portfoliodownloadsteps">Portfolio Download</item>
+<item key="bbexportpreppageheader">Portfolio Download</item>
+<item key="portfoliosdisabled">Portfolio functionality is
+turned off.</item>
+<item key="exportdisabled">Portfolio export functionality is turned
+off.</item>
+<item key="toomanyitemstodownload">Only the first $count items will be downloaded.</item>
+</lookup>
+
+<!-- displayheader_results.xsl -->
+<!-- <lookup id="displayheader_results_LEGACY">
+<item key="thumbnail">images with captions</item>
+<item key="thumbfull">images with record</item>
+<item key="reslist">captions only</item>
+<item key="bbthumbnail">images with captions</item>
+<item key="bbthumbfull">images with record</item>
+<item key="bbreslist">captions only</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+ -->
+<lookup id="displayheader_results">
+<item key="thumbnail">grid</item>
+<item key="thumbfull">grid + details</item>
+<item key="reslist">list</item>
+<item key="icon-thumbnail">icon-th</item>
+<item key="icon-thumbfull">icon-picture</item>
+<item key="icon-reslist">icon-th-list</item>
+<item key="bbthumbnail">grid</item>
+<item key="bbthumbfull">grid + details</item>
+<item key="bbreslist">list</item>
+<item key="icon-bbthumbnail">icon-th</item>
+<item key="icon-bbthumbfull">icon-picture</item>
+<item key="icon-bbreslist">icon-th-list</item>
+<item key="prep">prep tables in use</item>
+</lookup>
+
+<!-- groups.xsl -->
+<lookup id="groups">
+<item key="groups">collection groups list</item>
+<item key="selectgroup">Select a collection group</item>
+<item key="instructiongroupspick">Collections are arranged into groups for searching. Click on a group name to search the collections in that group. A collection may include some content outside of the group's definition, and a collection could appear in more than one group. Click the title of a specific collection to search it alone. Sometimes it is advantageous to search a single collection. For example, search field and sorting options are often specific to the collection, allowing for a more refined search. </item>
+<item key="more">more</item>
+<item key="instructiongroupspick2">Some collections have a very narrow focus. Other collections are broader, and may encompass many sub-collections.  Occassionally an image appears in multiple collections, though generally there is a single authoritative source for each image.</item>
+<item key="collections">collections</item>
+<item key="media">images/media</item>
+<item key="records2">records</item>
+
+</lookup>
+
+
+<!-- searchutils.xsl -->
+<lookup id="searchutils">
+<item key="see">see search tips</item>
+
+<item key="instructioncollspick1">Select one or more databases to search. Click the database name to search it alone, often in more detail.</item>
+<item key="instructionsearch1">To search, enter a word or phrase in a box below and select a field from the menu.</item>
+<item key="instructionsearch2">It is not necessary to use more than one box.</item>
+<item key="instructionsearch3">You can search all the databases in this group, or use the <b>list of databases</b> to restrict your search to a subset.</item>
+<item key="newgroup">select a new group to search</item>
+<item key="in">in</item>
+<item key="rangehelp">e.g., 1954 to 1961, -825 to -800.</item>
+<item key="only">has digital media</item>
+<item key="PleaseSelectColl">Please select at least one database to search.</item>
+</lookup>
+
+<!-- browse.xsl, index.xsl -->
+<lookup id="browse">
+<item key="browse">Browse</item>
+</lookup>
+
+<!-- collinfo.xsl -->
+<!-- index.xsl -->
+<lookup id="index">
+<item key="home">Home</item>
+<item key="collinfo">database info</item>
+<item key="closewindow">CLOSE WINDOW</item>
+<item key="thiscoll">this collection</item>
+<!-- <item key="browseallimages">Browse all media</item>
+<item key="browseallrecords">Browse all records</item>
+<item key="browsesampleimages">Browse sample media</item>
+<item key="browsesamplerecords">Browse sample records</item>
+<item key="browsemediaaddsmods">Browse newest additions and updates</item>
+<item key="browsemostviewed">Browse most viewed</item> -->
+<item key="browseallimages">All media</item>
+<item key="browseallrecords">All records</item>
+<item key="browsesampleimages">Sample media</item>
+<item key="browsesamplerecords">Sample records</item>
+<item key="browsemediaaddsmods">Newest additions and updates</item>
+<item key="browsemostviewed">Most viewed</item>
+<item key="access">Collection Access</item>
+<item key="access1">Access to this collection is restricted to authorized users.</item>
+<item key="access2">This collection is open to the public. You may have
+additional privileges if you log in.</item>
+<item key="access3">You are an authorized user of this collection.</item>
+<item key="access4">Access restricted.</item>
+<item key="sendcomments">Send comments on this collection to</item>
+<item key="brief">Collection Size</item>
+<item key="searchmulti">Search Multiple Collections</item>
+<item key="selectagroup1">Select a group</item>
+<item key="selectagroup2">of collections to search simultaneously. Search this collection together with others.</item>
+<item key="numberof">Number of Images and Records Online</item>
+<item key="images">Online Images/Media</item>
+<item key="records">Records</item>
+</lookup>
+
+<!-- noresults.xsl -->
+<lookup id="noresults">
+<item key="noresults">No Results</item>
+<item key="type_ic_range">ranges from</item>
+<item key="type_ic_exact">is exactly</item>
+<item key="type_default">contains the term(s)</item>
+<item key="type_allmedia"> media was added or updated within </item>
+<item key="days"> day(s).</item>
+<item key="to">to</item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="results">
+<item key="and">and</item>
+<item key="view">view</item>
+<item key="record">record</item>
+<item key="digitalformat">digital format</item>
+<item key="notavail">not available</item>
+<item key="portfolioempty">This portfolio has no items.</item>
+<item key="missing">no longer available</item>
+<item key="restricted">Restricted.</item>
+<item key="trytolocate">try to locate</item>
+<item key="notifymaintainer">notify maintainer</item>
+<item key="nosortvalue">no sort value</item>
+</lookup>
+
+
+<!-- thumbfull.xsl -->
+<lookup id="thumbfull">
+<item key="instructionthumbfullresults">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data to the left.</item>
+<item key="descriptive">&lt;text</item>
+</lookup>
+
+<!-- reslist.xsl -->
+<lookup id="reslist">
+<item key="view4">view full record for <b>item</b></item>
+</lookup>
+
+<!-- displayheader.xsl -->
+<lookup id="displayheader">
+<item key="newsearch">advanced search</item>
+<item key="quicksearch">Quick Search</item>
+</lookup>
+
+<!-- results_nav.xsl -->
+<lookup id="results_nav">
+<item key="to1">to</item>
+<item key="of">of</item>
+<item key="hits">hits</item>
+
+<item key="login0">You are not logged in.</item>
+<item key="login1">You are logged in.</item>
+
+<item key="prev">previous</item>
+<item key="next">next</item>
+
+<item key="portfour">Portfolio storage is temporary.</item>
+<item key="portone">Portfolio storage is long term.</item>
+<item key="portthree">You do not own this portfolio.</item>
+<item key="porttwo">You do not own this portfolio.</item>
+
+</lookup>
+
+<!-- bbcustomorder.xsl -->
+<lookup id="bbcustomorder">
+<item key="instructionbbcustomorder">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="nocaption">no caption or caption too long.</item>
+</lookup>
+
+<!-- entry.xsl -->
+<lookup id="entry">
+<item key="bookmarkhelp">bookmark:</item>
+<item key="downloadmedia">download largest size</item>
+<item key="downloadmediacurrentsize">download current size</item>
+<item key="newwindow">new window</item>
+<item key="viewmediaonly">view media only</item>
+<item key="otherviewsnothumb">view</item>
+
+<item key="other">other views</item>
+<item key="other views">other views</item>
+<item key="other-views">other views</item>
+
+<item key="full image">full image</item>
+<item key="full-image">full-image</item>
+
+<item key="description">description</item>
+
+<item key="backtoresults">back to results</item>
+<item key="previtem">&lt;&lt; previous item</item>
+<item key="nextitem">next item >></item>
+<item key="addport">add to portfolio</item>
+<item key="removeport">remove from portfolio</item>
+<item key="relatedports">portfolio inclusions</item>
+
+<item key="feedbacklink">Problems/comments about this item?</item>
+<item key="feedbackreply">To request a reply, please provide your email address.</item>
+<item key="feedbackcomments">Comments?</item>
+<item key="feedbackusername">Include your user name?</item>
+<item key="feedback">Feedback</item>
+
+
+</lookup>
+
+<!-- entry_imagetools.xsl -->
+<lookup id="entry_imagetools">
+
+<item key="video.sense">view</item>
+<item key="video">video</item>
+<item key="video.icon">icon-film</item>
+
+<item key="audio.sense">listen to</item>
+<item key="audio">audio</item>
+<item key="audio.icon">icon-volume-down</item>
+
+<item key="svg.sense">view</item>
+<item key="svg">flash movie</item>
+<item key="svg.icon">icon-film</item>
+
+<item key="doc.sense">view</item>
+<item key="doc">related document</item>
+<item key="doc.icon">icon-file</item>
+
+<item key="pdf.sense">view</item>
+<item key="pdf">PDF document</item>
+<item key="pdf.icon">icon-file</item>
+
+<item key="url.sense">view</item>
+<item key="url">linked content in new window</item>
+<item key="url.icon">icon-share</item>
+
+<item key="image.sense">view</item>
+<item key="image">image</item>
+<item key="image.icon">icon-picture</item>
+
+<item key="size">size</item>
+
+<item key="nomedia">Sorry, digital media is not available for this item.</item>
+
+<item key="panzoomhelp">How to interact with this image...</item>
+<item key="tozoomin">zoom in: double-click</item>
+<item key="tozoomout">zoom out: shift-double-click</item>
+<item key="topan">pan: drag</item>
+<item key="zoom">zoom</item>
+<item key="sizes">image sizes</item>
+
+
+</lookup>
+
+
+
+<!-- tips.xsl -->
+
+<lookup id="searchtips">
+<item key="searchtips">search tips</item>
+<item key="instructionsearchtips"><p><b>Matching words:</b> The search
+engine attempts to match any word or phrase exactly as you put it in
+the box.</p><p> e.g.: <i>Picasso and Rembrandt</i> in a box will look
+for</p><p> "Picasso and Rembrandt"</p><p>and produced no
+results.</p><p><b>Punctuation: </b>All punctuation is treated as an
+empty space.</p><p><b>Case</b>: The search engine is not case
+sensitive.</p><p><b>Wildcards:</b> Use wildcard * to expand word
+stems. This is a good way to search for variations on a
+word.</p><p><b>Choose image collections</b>: Limit your search to only
+those collections you choose in the image collections list.</p></item>
+</lookup>
+
+<!-- results.xsl -->
+<lookup id="BbagOptionsMenu">
+<item key="bbom.check">check all</item>
+<item key="bbom.uncheck">uncheck all</item>
+<item key="bbom.bbname">add checked to portfolio...</item>
+<item key="bbom.remove">remove checked from portfolio</item>
+</lookup>
+
+<lookup id="viewinstruct">
+<item key="thumbnail1">Use checkboxes to select images for adding to a
+portfolio, then click the "add to portfolio" button. Click on
+thumbnails to view larger images and full records.</item>
+<item key="thumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="thumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="thumbfull1">Click on thumbnails to view larger images and full records. <br/>Click "descriptive info" link to view record data in this space.</item>
+<item key="reslist1">Use checkboxes to select records for adding to a portfolio, then click the "add to portfolio" button. Click "view full record" link the full record.</item>
+<item key="reslist0">Click "view full record" link the full record.</item>
+<item key="bbthumbnail1">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbnail0">Click on thumbnails to view larger images and full records.</item>
+<item key="bbthumbfull0">Click on thumbnails to view larger images and full records. Click "descriptive info" link to view record data in this space.</item>
+<item key="bbthumbfull1">Click on the thumbnail image to display a
+large image. Click on the "descriptive info" link beneath any thumbnail image to see detailed record information in this space.</item>
+<item key="bbreslist1">Click "view full record" link the full record.</item>
+<item key="bbreslist0">Click "view full record" link the full record</item>
+<item key="bbcustomorder1">To change the position of any image record in this portfilio, select it's title in the list, and click an appropriate directional arrow to move it up or down.  When you are done, click the save custom order button to return to the previous display.</item>
+<item key="bbcustomorder0"/>
+<item key="bbexport1">The portfolio package is ready for download as a ZIP file.</item>
+
+<item key="medianodownload">sorry, media is not available for
+download.</item>
+<item key="bbexport0"/>
+</lookup>
+
+<lookup id="sort">
+<item key="sort">sort</item>
+<item key="sortnot2">too many results to sort</item>
+<item key="customize">customize order...</item>
+</lookup>
+
+<lookup id="misc">
+
+<!-- alt tags for graphics -->
+
+<!-- login/out -->
+<item key="login">login</item>
+<item key="logout">logout</item>
+
+<!-- open portfolio -->
+<item key="portfolios">portfolios</item>
+
+<!-- contact / help -->
+<item key="contact">contact</item>
+<item key="Contact">Contact</item>
+<item key="help">help</item>
+
+<!-- appears in "index", "searchutils"-->
+<item key="search2">Search</item>
+
+<item key="databases">Databases</item>
+<item key="collhome">collection home</item>
+
+<item key="close">close</item>
+
+<item key="multiple">Multiple Collections</item>
+
+
+</lookup>
+
+<lookup id="SearchFormOpsMenu">
+<item key="And">And</item>
+<item key="Or">Or</item>
+<item key="Not">Not</item>
+<item key="and not">And Not</item>
+</lookup>
+
+<lookup id="SearchFormSelMenu">
+<item key="ends">Ends with</item>
+<item key="contains">Contains</item>
+<item key="phrase">Contains the phrase</item>
+<item key="starts">Starts with</item>
+<item key="any">Contains any of these words</item>
+<item key="all">Contains all of these words</item>
+<item key="ic_exact">Exactly matches</item>
+<item key="regex">Matches</item>
+</lookup>
+
+
+<!-- moaaic-group, searchmaps.xsl -->
+<lookup id="searchmaps">
+<item key="searchmaps">Search for maps</item>
+<item key="instructionsearch1">Enter an exact word or phrase.</item>
+</lookup>
+
+<lookup id="NoResults">
+<item key="sorrynoresults">Sorry, no results were found when searching
+for items where...</item>
+<item key="pleasetry">Please try again.</item>
+<item key="mediaonly">Including an image or other media.</item>
+</lookup>
+
+</LangMap>
+
+<TemplatePath>/l1/dev/roger/web/i/image/entry.xml</TemplatePath>
+<TemplateName>entry</TemplateName>
+<XcollMode>singlecoll</XcollMode>
+
+<CurrentScriptName>/cgi/i/image/image-idx</CurrentScriptName>
+<ScriptName application="text">/cgi/t/text/text-idx</ScriptName>
+<ScriptName application="pageviewer">/cgi/t/text/pageviewer-idx</ScriptName>
+<ScriptName application="ww">/cgi/t/text/ww2-idx</ScriptName>
+<ScriptName application="findaid">/cgi/f/findaid/findaid-idx</ScriptName>
+<ScriptName application="image">/cgi/i/image/image-idx</ScriptName>
+
+
+
+<BookmarkableUrl/>
+<AuthenticationEnabled>1</AuthenticationEnabled>
+<UserAuthenticated>0</UserAuthenticated>
+<AuthenticatedUsername/>
+<SupportedAuthSystems><System>um</System></SupportedAuthSystems>
+<QuickBrowse/>
+<Feed>
+  <FeedLink type="short"/>
+  <FeedLink type="long"/>
+</Feed>
+<TaggingEnabled>0</TaggingEnabled>
+<CollGroupMembership>:localhist-ic:</CollGroupMembership>
+<EncodingType/>
+
+
+<HeadLinks>
+  <!-- <CssLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css</CssLink> -->
+  <CssLink><CssLink>/i/image/bootstrap/css/bootstrap.min.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass.css</CssLink></CssLink>
+  <CssLink><CssLink>/i/image/css/imageclass-specific.css</CssLink>
+<CssLink>/s/sdlhomes/css/imageclass-specific.css</CssLink></CssLink>
+
+  <BootstrapLink>//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js</BootstrapLink>
+  <BootstrapLink>/i/image/jquery/jquery-migrate-1.2.1.js</BootstrapLink>
+  <BootstrapLink>//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js</BootstrapLink>
+  <!-- <BootstrapLink>/i/image/bootstrap/js/bootstrap.js</BootstrapLink> -->
+  <JavaScriptUrl>/i/image/js/jquery.placeholder.js</JavaScriptUrl>
+
+  <ApiUrl>/cgi/i/image/api</ApiUrl>
+  <Timestamp>20180409</Timestamp>
+
+  <AssetDebug>yes</AssetDebug>
+
+
+</HeadLinks>
+</DlxsGlobals>
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+<EntryId>SL0617</EntryId>
+<RestrictStatus>access2</RestrictStatus>
+
+<AccessRestrictions>
+    <Status>public</Status>
+    <Public href="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?auth=world;sort=sdlhomes_photo_date;q1=sdlhomes;type=boolean;rgn1=ic_all;view=reslist;c=sdlhomes">416</Public>
+    <Authorized>0</Authorized>
+    <Restricted>0</Restricted>
+</AccessRestrictions>
+
+
+<EntryWindowName>S_SDLHOMES_X_SL0617___SL061702__TIF</EntryWindowName>
+<ItemUrl>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?id=S-SDLHOMES-X-SL0617%5DSL061702.TIF</ItemUrl><ItemUrlEncoded>https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fid%3DS-SDLHOMES-X-SL0617%5DSL061702.TIF</ItemUrlEncoded><TitleForTagging>204%20W.%20Henry</TitleForTagging>
+<Home>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=index;c=sdlhomes</Home>
+<Help>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=help;c=sdlhomes</Help>
+<!-- <JavaScriptUrl>/i/image/js/imageclass.js</JavaScriptUrl> -->
+<JavaScriptUrl>//www.google.com/recaptcha/api.js</JavaScriptUrl>
+<!-- <JavaScriptUrl>/i/image/js/feedback.js</JavaScriptUrl> -->
+<DivView><View name="full-image"><InitialStatus>visible</InitialStatus>
+<Visibility div="full-image">show</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="description"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">show</Visibility>
+<Visibility div="other-views">hide</Visibility></View><View name="other-views"><InitialStatus>hidden</InitialStatus>
+<Visibility div="full-image">hide</Visibility>
+<Visibility div="description">hide</Visibility>
+<Visibility div="other-views">show</Visibility></View></DivView>
+<Next><Url index="5" name="S_SDLHOMES_X_SL0817___SL081701__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0817;viewid=SL081701.TIF</Url></Next>
+<Prev><Url index="3" name="S_SDLHOMES_X_SL0617___SL061701__TIF" marker="5536d312bcb5e17f0911755b9b3bc5a3">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF</Url></Prev>
+<Self><Url index="4" name="S_SDLHOMES_X_SL0617___SL061702__TIF">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;debug=xml;size=50;q1=Residence;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF</Url></Self>
+<TotalResults>10</TotalResults>
+<ContactLink>'m'+'a'+'i'+'l'+'t'+'o'+':'+'s'+'d'+'l'+'p'+'h'+'o'+'t'+'o'+'s'+'-'+'h'+'e'+'l'+'p'+'@'+'u'+'m'+'i'+'c'+'h'+'.'+'e'+'d'+'u'</ContactLink>
+<ContactText>E-mail Help</ContactText>
+<LoginLink><Url>https://roger.quod.lib.umich.edu/cgi/dlxslogin/go?target=https%3A%2F%2Froger.quod.lib.umich.edu%2Fcgi%2Fi%2Fimage%2Fimage-idx%3Fkey_authret%3D1632260769</Url><Mode>login</Mode></LoginLink>
+<SearchLink>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;q1=Residence;page=search;view=reslist</SearchLink>
+<BackLink identifier="Q_SDLHOMES_X_SDLHOMES_PRESENT_USAGE___RESIDENCE___0001">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;debug=xml;size=50;q1=Residence;view=reslist;type=boolean;start=1</BackLink>
+<Banner><Text>Saline Historic Homes</Text></Banner>
+<BookBagForm action="add"><HiddenVars><Variable name="page">bbname</Variable>
+<Variable name="bbidno">S-SDLHOMES-X-SL0617]SL061702.TIF</Variable>
+</HiddenVars><ActionAllowed>1</ActionAllowed></BookBagForm>
+<Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAYEBQIDBwgB/8QAPxAAAgEDAgMGAgUHDQAAAAAA
+AQIDAAQRBSEGEjEHEyJBUWEUcSOBkbHBJDJCQ6HR8BUWMzdEVHJ0g7LC4fH/xAAYAQADAQEAAAAA
+AAAAAAAAAAABAgMABP/EAB0RAAICAwEBAQAAAAAAAAAAAAABAhESITEDUUH/2gAMAwEAAhEDEQA/
+AKPWeI+Im4m1u00/Xr3vVvZUW3M5jSJASAFYtgdAOm1LQ4x4o734ccR6scjmDd+SWP27DO3XfrUX
+jCXk4v4gQDdtRlyR1wGO3y3qsuFufhleVPolIK9AAcAYGOu2PlTaGoYl464mdxE2u30SN4SWuWLp
+jz2OfLp51qHG3E0ckjRcQalKkYVgWuHGRnrgnz9KV+8Ik7wOGIx161LVY57Nm/Xhs8qoACOnX7sV
+jUdv4N1ZNWtoGueJL9714TzW3xZ5epAf5kYOD88U1NDqVrYGPT9SuJZCFAe7lMmOUbkepbzrzdp0
+N6DzWokWaMEhk2PTP17b11TQNb+Ote9t7hopFPiVT5+uOgz1pJyx/DLzy4ybq3EXEWlSqr3M7OMt
+yq+centj93lSe3G+vPcPdXOpalFbn+ihhmIBPnsTkjpVnrtnLcuhkusRuSWZH3Aydwv3n3NVU2io
+NMSW1S2l72Vl5nmGR6eeAuMnoKhkMoMrbnjPXpIxLHxRqcTjJ5TM2G326Hb/ALFSouN9Wgu2Mmva
+nITg921yxCbZO4wM+1K0lpBGs9w93E/JkIqk+JidsbdMb59qxhlgilVZYlJyrFgSSuce9Ua1RqGy
+7461hLf6DW9SMjHC5uXIX7etQrfjfiEmQvxHqBboi/EONwP4+ylm+kIuWJb9LmAB6fxiosTqGIYj
+lwSQR19qMYaAen+yXUr3WOCviNQuZLidbqSPvJJC5IGMbnPrRULsPwOz4kfmm9lI+W1FMIzg/GLl
+eONcOSM383T/ABmqYsAoQO+MnJx0+qrrjaUS8ba2TGq4vZR4RjOGIzVL3K/DxuJB3jMQU5Tkehz5
+045geXAAq30LS7rXJn0+zVGnK8wB6hV3YjzqtggkuZ+7jj5n3JA8/Wujdn/D19Za7aahc2pjiZ5U
+WQuASQMFSp/D0zQlJIKKzR9M07Tr69TVJpntbIxs09sjJLv0TBI5dzudyMbU9a1pmncMQWl5ZRTi
+2nj5m3ByOoB26jIwep96whVLri2RHdpYmvj4GwVxzdMYp24n0yG90R+ccqweJeUDHUDHsKi3Y6VN
+HMRxRayxATWrwyDbxMFBX3IGwPoaj3WgNc6fJeRiEx3bErHDMGWMeXOw67jy6VX31qk3E5tweVfh
+i5x681V2r2K2OmyTxGOOXvgvM3TFIofB3L6V2oW+nwQyRrM0syN4Qi+AAerH132FUgkKygqSCpzz
+KcHPrTxqOi28eix3Ziyz2gd26ZbAwR9dJAhJkWNGB5wM4U5X2q0PhJm69mW5ZJ1BBYkMCck753+2
+ooAOQM58qkLGoQrljysGJxjY7UXKW4lJhcKjDKqzZI9iR5+dOgM9Fdhv9Xp/zsv/ABorPsR5P5hO
+UYspvpSCRgnZfKilJvpx3jiwto+INQeOOTmN5NJNJj1c7D296XVht1mVZjNHCduZF5yNvfH2Uw8V
+3c1xxdqlqocQC8kV5AhblPMcHbpWUNm1vEwL98O5ZQHOTzlcAgnoNztQycUWUb4LIl+Eu+eILtlc
+k7NThNxhr+jxWlvPpllDIo76CSSEs/KxzkHPQ+1JsVhK92kNx9GC3IzMdh9Yp57Q7VI7yxA6xWUM
+WxyMBc5rOrAiDF2haz8X3jm2RTksLeFY2LH9LmwTnND8V6heXiTXN3K4GB3RJIYZ3BJOd6SlIMq7
+eYqyi/OBouKQbsZb7U7a6vhcWlmmnTqpVisjyhgT08R2+qvllqVu19GurRi7tAxZ0t2CsdiBs3z9
+aW7iX8uiYHbJzXwS5uCaWmHR0riniDS+IYbSz043EQS2aLEsXKV9MeR296SNQsI7O0soyoIRsO4b
+kyfIk1stWMdleTI3K627EEeRrY+rXFtpNnLgTtcIVlSTBV/PcY3/AGYpVaZmkWuqSw3XBYtRZ/BS
+xSCSGJoge/AB5mEnVj6jyxXPyQ7DYZcZ2HQ+wq5s5JHnkuIoZGUKwYhi6qSD0zuPrqkZHjYjbwbZ
+9KpHolaPSfYapXs+Ibr8bKf9tFHYamOz0g/32b8KKzJvpzbVLW3g4n1SZIWDSXMokxIcOOc/++1V
+dxObWBnboNs4z126Vr4h4kWHiPVI1tiSt3KuS2M4c0vXutz3a8gRY022G+4NLhJsup0iNewS28x5
+5BkkkY9c0065xbY6zpgiEUyXKd0A0mCCqx8h3G+c70nSSSTOXdizHzrDlPpVMb6JZvURhgdt/ntW
+w3IVTjrUYFtvavpyRjHWmowd4zODgk1uibmmRQ6jmIGWOAPnWyw025urqMJbTSLzDm5NtvPenccP
+2mspGxs/hJox3bCCN5VYDGNlHz33yaSUkhkmyguZodLkmsLmeKXni5We1kEi4bfZqsntoDp0UKTc
+8Ma4OCA59MHy61Mk4NsYeaS4h4gdDjeLT+6UH5vg0ahplramB9Kg1BgOXwyplgAMHONs/I1CclxD
+JFFFFLa3URZsWhfAQjAI9NvOl2ZViunQ5ZVcjbYmn+CO7to3xapbo7kzCV8u3p8j91K+taZySXFy
+kqynn53AOcA9KPn6K6YJRo732Gb9nQ2/tk34UUdhoZezsBgR+WTHf6qKsyD6V+o9j/Dt7qV1dyXW
+pCSeV5HCypgFiSceDpWmHsU4YLeK51Q/66fglFFBvQyJ8XY7wnAxJiupTn9bNn8KlR9lPCY8PwLn
+nO5L9PlttRRXJKTvpREtOy3g6FQP5HjcqMZdiSfnvvUuLgLhaEHutEtFyN/Bn76KKtbATouGNFgQ
+pHp1sEznHdKRn7K3vp8MUHdW2bZSf1Kqv4UUUJcNbsgScPW86/S3V4/nvIP3VgOGLJWBWa5U58nH
+7qKK5qQ1s3W3DtrFcd6bi6kIOyvJkdPTFS30OwkVg0CEMdwVGPsxRRV4JUBtky0tYbSARQII0znl
+UAD9lFFFdC4RfT//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061702.TIF/full/!100,100/0/default.jpg</Url><ThumbInfo/>
+<OpenPortfolio><Url>https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?page=bbopen</Url></OpenPortfolio>
+<MediaInfo><Initial>
+    <MediaLink>/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/628,424/0/native.jpg</MediaLink>
+    <res>2</res>
+    <w>628</w>
+    <h>424</h>
+</Initial>
+<MediaHost>https://roger.quod.lib.umich.edu</MediaHost>
+<AuthCheck allowed="yes" check="yes">1: world access allowed</AuthCheck>
+<Debug/>
+<ic_collid class="fieldsRef">sdlhomes</ic_collid>
+<m_flm class="fieldsRef">2013-02-08 18:59:46</m_flm>
+<m_id class="fieldsRef">SL0617</m_id>
+<istruct_mt class="fieldsRef">IMAGE:::DYNAMIC2</istruct_mt>
+<m_entryauth class="fieldsRef">WORLD</m_entryauth>
+<m_iid class="fieldsRef">SL061702.TIF</m_iid>
+<istruct_face class="fieldsRef">UNSPEC</istruct_face>
+<istruct_isentryidv class="fieldsRef">S-SDLHOMES-X-SL0617-2</istruct_isentryidv>
+<m_searchable class="fieldsRef">1</m_searchable>
+<istruct_ms class="fieldsRef">P</istruct_ms>
+<istruct_stty class="fieldsRef">SUMM</istruct_stty>
+<istruct_x class="fieldsRef">2</istruct_x>
+<istruct_caption class="fieldsRef"/>
+<istruct_mo class="fieldsRef">TIF</istruct_mo>
+<istruct_m class="fieldsRef">SL061702</istruct_m>
+<istruct_y class="fieldsRef">1</istruct_y>
+<istruct_stid class="fieldsRef">0</istruct_stid>
+<m_fn class="fieldsRef">SL061702</m_fn>
+<istruct_isentryid class="fieldsRef">S-SDLHOMES-X-SL0617]SL061702.TIF</istruct_isentryid>
+<istruct_me class="fieldsRef">JP2</istruct_me>
+<m_caption class="fieldsRef"/>
+<filename class="imgInfHashRef">s/sdlhomes/pairtree_root/SL/06/17/02/SL061702/SL061702.jp2</filename>
+<md5 class="imgInfHashRef">005dadc60168f4d501b4490e7fb49b90</md5>
+<ext class="imgInfHashRef">jp2</ext>
+<access class="imgInfHashRef">1</access>
+<basename class="imgInfHashRef">SL061702</basename>
+<collid class="imgInfHashRef">sdlhomes</collid>
+<type class="imgInfHashRef">image</type>
+<width class="imgInfHashRef">2512</width>
+<mimetype class="imgInfHashRef">image/jp2</mimetype>
+<levels class="imgInfHashRef">4</levels>
+<height class="imgInfHashRef">1696</height>
+<modified class="imgInfHashRef">2013-02-08 18:59:46</modified>
+<master class="imgInfHashRef">0</master>
+<u class="imgInfHashRef">1</u>
+<loaded class="imgInfHashRef">2013-11-25 02:17:27</loaded>
+<use class="imgInfHashRef">access</use>
+<size class="imgInfHashRef">580462</size>
+<HighestQualityLevelAllowed>2</HighestQualityLevelAllowed>
+<Levels>4</Levels>
+<Zoomable>no</Zoomable>
+<Pan>no</Pan>
+<Type>image</Type>
+<Ext>jp2</Ext>
+<MimeType>image/jp2</MimeType>
+</MediaInfo>
+<ImageSizeTool><Level level="4"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=4;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=4;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:4/0/native.jpg</Part><LevelWidth>157</LevelWidth><LevelHeight>106</LevelHeight><LevelMaxDim>157</LevelMaxDim></Level><Level level="3"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=3;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=3;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:3/0/native.jpg</Part><LevelWidth>314</LevelWidth><LevelHeight>212</LevelHeight><LevelMaxDim>314</LevelMaxDim></Level><Level level="2"><Part name="Current">yes</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=2;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=2;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:2/0/native.jpg</Part><LevelWidth>628</LevelWidth><LevelHeight>424</LevelHeight><LevelMaxDim>628</LevelMaxDim></Level><Level level="1"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=1;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=1;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:1/0/native.jpg</Part><LevelWidth>1256</LevelWidth><LevelHeight>848</LevelHeight><LevelMaxDim>1256</LevelMaxDim></Level><Level level="0"><Part name="Current">no</Part>
+<Part name="DownloadLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=0;view=entry;subview=download;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF;evl=full-image;quality=0;view=entry;subview=detail;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;start=1;resnum=5;lastview=reslist;lasttype=boolean</Part>
+<Part name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:0/0/native.jpg</Part><LevelWidth>2512</LevelWidth><LevelHeight>1696</LevelHeight><LevelMaxDim>2512</LevelMaxDim></Level><MaxWidth>2512</MaxWidth><MaxHeight>1696</MaxHeight></ImageSizeTool>
+<RevertSizeTool><!-- cannot revert until image has been zoomed. --></RevertSizeTool>
+<MediaEquivsTool/>
+<Record name="entry"><Section name="About this home" class="about_this_home"><Field abbrev="sdlhomes_usgs_map" searchfield="false" sortfield="false"><Values><Value>Saline Quadrangle</Value></Values><Label display="on">USGS Map</Label></Field><Field abbrev="sdlhomes_street_no" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Street and No.</Label></Field><Field abbrev="sdlhomes_municipal_unit" searchfield="false" sortfield="false"><Values><Value>Saline</Value></Values><Label display="on">Municipal Unit</Label></Field><Field abbrev="sdlhomes_county" searchfield="false" sortfield="false"><Values><Value>Washtenaw</Value></Values><Label display="on">County</Label></Field><Field abbrev="sdlhomes_orig_usage" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_orig_usage;q1=Residence;select1=phrase" target="_blank">Residence</Value></Values><Label display="on">Original Usage</Label></Field><Field abbrev="sdlhomes_present_usage" searchfield="true" sortfield="true"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_present_usage;q1=Residence;select1=phrase" target="_blank"><Highlight searchfield="true" class="hilite1" seq="1">Residence</Highlight></Value></Values><Label display="on">Present Usage</Label></Field><Field abbrev="sdlhomes_ownership" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_ownership;q1=Armbruster%252C%2520Lee%2520and%2520Donna;select1=phrase" target="_blank">Armbruster, Lee and Donna</Value></Values><Label display="on">Ownership</Label></Field></Section><Section name="About this photograph" class="about_this_photograph"><Field abbrev="sdlhomes_photo_neg_no" searchfield="false" sortfield="false"><Values><Value>4:21</Value></Values><Label display="on">Photo Negative No.</Label></Field><Field abbrev="sdlhomes_photo_date" searchfield="false" sortfield="false"><Values><Value>January, 1994</Value></Values><Label display="on">Photo Date</Label></Field><Field abbrev="sdlhomes_photo_view" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value></Values><Label display="on">Photo View</Label></Field></Section><Section name="About the construction" class="about_the_construction"><Field abbrev="sdlhomes_desc" searchfield="false" sortfield="false"><Values><Value>Two story, cross gabled, vernacular, Queen Anne style house. Shingled returns on gables. Full width porch wraps around to entry door on east facade. Small peak on porch roof above entryway. Windows are one light over one. One story addition to west rear with an entry door. Concrete block foundation. One car, hipped roof garage with a clipped gable at rear.</Value></Values><Label display="on">Description</Label></Field><Field abbrev="sdlhomes_date_construction" searchfield="false" sortfield="false"><Values><Value link="https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?c=sdlhomes;type=boolean;view=reslist;rgn1=sdlhomes_date_construction;q1=1910%2520ca.;select1=phrase" target="_blank">1910 ca.</Value></Values><Label display="on">Date Of Construction</Label></Field><Field abbrev="sdlhomes_context" searchfield="false" sortfield="false"><Values><Value>Anna Wolper owned the house 1914-1935. Other occupants: Ward Earnst 1941; Frank Karn 1947; John Schaffer; Leonard Morton.</Value></Values><Label display="on">Context</Label></Field><Field abbrev="sdlhomes_ref" searchfield="false" sortfield="false"><Values><Value>City Directories: 1878, 1894, 1899, 1912, 1914, 1916, 1920, 1926, 1941, 1945. Assessor's files: 1947 and current; U.S. Census: 1910, 1920. Sanborn Maps: 1888, 1893, 1899, 1912, 1921, 1929; Tax Rolls: 1931 and 1935.</Value></Values><Label display="on">Bibliographic Reference</Label></Field><Field abbrev="sdlhomes_form_source" searchfield="false" sortfield="false"><Values><Value>MICHIGAN DEPARTMENT OF STATE KG 187</Value></Values><Label display="on">Form Source</Label></Field></Section><Section name="About this record" class="about_this_record"><Field abbrev="sdlhomes_survey_dt" searchfield="false" sortfield="false"><Values><Value>May, 1994</Value></Values><Label display="on">Survey Date</Label></Field><Field abbrev="sdlhomes_surveyor" searchfield="false" sortfield="false"><Values><Value>K. Glynn &amp; S. Kosky</Value></Values><Label display="on">Surveyor</Label></Field><Field abbrev="sdlhomes_recorder_dt" searchfield="false" sortfield="false"><Values><Value>April, 1994</Value></Values><Label display="on">Recorder Date</Label></Field><Field abbrev="sdlhomes_card_no" searchfield="false" sortfield="false"><Values><Value>187</Value></Values><Label display="on">Card No.</Label></Field><Field abbrev="dlxs_ri" searchfield="false" sortfield="false"><Values><Value>The University of Michigan Library provides access to these materials for educational and research purposes. These materials may be under copyright. If you decide to use any of these materials, you are responsible for making your own legal assessment and securing any necessary permission. If you have questions about the collection, please contact <a href="mailto:sdlphotos-help@umich.edu">Saline Digital Collections help</a>. If you have concerns about the inclusion of an item in this collection, please contact <a href="mailto:LibraryIT-info@umich.edu">Library Information Technology</a>.</Value></Values><Label display="on">Copyright</Label></Field></Section></Record>
+<Record name="special"><Section name="default" class="default"><Field abbrev="dlxs_ma" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_ti" searchfield="false" sortfield="false"><Values><Value>204 W. Henry</Value></Values><Label display="on">Title</Label></Field><Field abbrev="dc_de" searchfield="false" sortfield="false"><Values><Value>South and east facades taken facing northwest</Value><Value>Two story, cross gabled, vernacular, Queen Anne style house. Shingled returns on gables. Full width porch wraps around to entry door on east facade. Small peak on porch roof above entryway. Windows are one light over one. One story addition to west rear with an entry door. Concrete block foundation. One car, hipped roof garage with a clipped gable at rear.</Value></Values><Label display="on">Description</Label></Field></Section></Record>
+<MediaDownloadLink><URL name="mediadownloadlink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/res:0/0/native.jpg?attachment=1</URL><Filename>SL061702_sdlhomes.JPG</Filename></MediaDownloadLink>
+<MiradorConfig manifest-href="https://quod.lib.umich.edu/cgi/i/image/api/manifest/sdlhomes:SL0617:SL061702.TIF" embed-href="https://quod.lib.umich.edu/cgi/i/image/api/embed/sdlhomes:SL0617:SL061702.TIF" canvas-index="2" mode="multiple"/>
+
+<inserttextentryinfo><div><!-- entryinfo.txt is a file that is inserted into entry.xml by the
+middleware and a PI called CHUNK. It is optional at group and coll
+levels. It is a requirement to have this file (at the class level) as
+a placeholder. Otherwise, if there is not an entryinfo.txt file at the
+coll or group level, an assertion error will occur. Alternatively, the
+CHUNK PI could be removed from entry.tpl and bbentry.tpl. -->
+</div></inserttextentryinfo>
+<RelatedViewsMenu><Name>viewid</Name>
+<HiddenVars><Variable name="fn1">sdlhomes_date_construction</Variable>
+<Variable name="fq1">1910 ca.</Variable>
+<Variable name="sort">sdlhomes_present_usage</Variable>
+<Variable name="rgn1">sdlhomes_present_usage</Variable>
+<Variable name="select1">phrase</Variable>
+<Variable name="c">sdlhomes</Variable>
+<Variable name="q1">Residence</Variable>
+<Variable name="subview">detail</Variable>
+<Variable name="resnum">5</Variable>
+<Variable name="start">1</Variable>
+<Variable name="view">entry</Variable>
+<Variable name="lastview">reslist</Variable>
+<Variable name="lasttype">boolean</Variable>
+<Variable name="cc">sdlhomes</Variable>
+<Variable name="entryid">x-sl0617</Variable>
+<Variable name="debug">xml</Variable>
+<Variable name="size">50</Variable>
+<Variable name="chaperone">S-SDLHOMES-X-SL0617 SL061702.TIF</Variable>
+</HiddenVars>
+<Instruct w="other">Related Views</Instruct>
+<Option index="0"><Label>SL061701.TIF</Label><Value>SL061701.TIF</Value></Option><Option index="1"><Label>SL061702.TIF</Label><Value>SL061702.TIF</Value><Focus>true</Focus></Option><Name>relview</Name><Default>SL061702.TIF</Default></RelatedViewsMenu>
+<RelatedViews><View>
+<Name>unspecified | summary</Name>
+<Row y="1">
+<Column x="1" y="1" blank="no" thumb="yes"><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061701.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABIAGQDASIA
+AhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABQYABAcCAwH/xAA2EAACAQMDAgQEBQMDBQAAAAAB
+AgMABBEFEiEGMRNBUWEHIoGRFBUjMnFCocEWUrElMzVy4f/EABcBAQEBAQAAAAAAAAAAAAAAAAAB
+AgP/xAAZEQEBAQEBAQAAAAAAAAAAAAAAARExAhL/2gAMAwEAAhEDEQA/AHW+1a/TVbyIXsqIk7Ko
+EmMKPLGKGz9TTLEzLrEufZ9zD6DmhXUkDP1FqbzFniE7bVBAC9v6cfN/PehclzcPpgaG4Qnt4ZjC
+/wBx/msSA8erLuTG3UrtGAz+8YI/j19q836v1AqAl1ds27GckZ/xS9balGwPjogcJ5/49KI+OPAU
+OCxIHLHhSfSmAqmu6pIp/wCrXAdeSgJ3du3PerFrreoT8jU7hvUBsFT6EUvtatfrtj4VP02IXli3
+AQD1Pn6DHrRi+6WkhtbZ7eRvG2nYOVICjgcHA4+nl27MBL82vgOb64+r1z+d3eCRqE5x3/UpEm1e
+9XMVwSYk5M6A9u3zL5H3qqmrRWiF4pUkzwAH4Iyfv5UwaD+fXhKj8fOCw4JkNULnqDW3uFgt72Y+
+bMknzBaSI9dW4t1aR1ikMh/TBP0P1rm36hME8hDlg42ZAzjB7iritCk1vUdhVNRuTIeB+oQR9KAa
+h1BrsBlKa7fEIOCHAzx5CqkNyNUVp5d7AKAA3G4nyAHlXFzYNasSGb51JZXPBPt9/XNTBqXw6vrr
+VukYrm+ne4uPGkVpJDkkBjj+1SvH4Yjw+jYxjH68n/NSsXqlPqe4ibXNStmJDiVm/wC2T6e3alS9
+limVW7N/tyV3ex9/59abOqkWfqK88OREmSUryxywPfihL2+LPEoVghMcgCkDg4BPoea6RkJtLSKa
+aBww27QWbuMEZ+/FedzqBhK+DISqvwVUsFI5JPl/99hVjTYbXwwZ5CHRiSoOCcDAGP6s5A+9GtI0
+uxv+pHt4oIQkEXivnn5wVxgZxnnmgYNCt4E/DSiOULbQiTww24vI5J3cd+Ae/maNLdhYTNKA80Ss
+AhbCrg/t9yfOs36tvZ9NXwbSd7dkuvCZkYjcqgsO3OctRjoW4gbp+9uruVp5DKIY0kJPJUYwP5NA
+I6g1ODEr3VsttPC4QmKQs0nqMbQMj+ewx5ClyOzsNbYRxXEdvNCrOSIyfEUAkgKOd2ew960D4kKl
+zFZwsSwWM4yhUA7hyB28qymG1kB8eNyCjNsdTgjBqxVRGJ7jJ86sxAOCuD9qZYukwzaZG0rPJfok
+rbUHyBmI7efbPlVXqLRR07rk9kWdkQJhmxk7hnyq6COmSJLptsuChTILBSdzZ/vXdwL6VS6IpSMZ
+aQtnCj696r9OG4k3Qxxybdx+ZRwe3HP186PTPaNcm0B2eCRjcOS3v9fKsh/+G+7/AEkodtzfiJOS
+MZ59KlWOi/8AwGORiZxnnn0PPtgfSpXK9Ui9WWU9x1FqBcL4BlIVgQMEgdxg5PvxQSN9VeO5RLpS
+hXMgdgzEYwTu7EZUj2x3pp1c6dN1FrK6pMUhhk3I6zDIOB8u0HPvSTcX0Flfyx2ksM0blMO8ZwVL
+fMCM+pB4711jKpDctaEuwLsGXDYz8pycnAPr5V76PrNlp2qNfym5dijDEcbYDFhwc9xivBtRtYiI
+1mjRVmO0heCA2AfbgE49x3rue0/MtC01rREFw88sbsrY34Xdz796o71XULHWrt3WO8UBjIBFAM/t
+CjueAMH70e6VkWzsbc28MjBZzL+HdGeV5MBRjGFAHfk1m9ybu2cHc67sjduOTzRHSdK1fVIZXtY5
+JBGcMBJg9vQnmmDYdT0m86gjE+qCSzWJSBgrL555VQD9s1m1zb2Gh6gNKnu3lizuecQMuzcSSCp5
+yAc0M1TQ9W0iCKa/geFJG2qS4OTjPkaDLKxMnPY0kGtFYNU6h0SbRr21ubOxjjjciYKflbzU4Oce
+1AviQ/i9V3iE7WPgj+Bhcn7UhqN7HOCfXFXIriQTMZpJJeAPmJbjHHemKa9BmgSyaF2bCTlm+bAK
++o7Z5FG1tIn05WWBpHwWdJSB9j9u9AdF1C0it2e7td0UT+Jv8IHt3XI5Hl96ZdZ1uxXplJrGVZnk
+wuVGQg88gjg98dvXyqB16CRYumV2srBpnb5ey5xxUqr8M5zc9HRHaVCTSIB7A8VK53qlvqDpmGfq
+u+vzZlzKx3Kz7d+P6lPbtjIyD7YrO+oE/AXs1tEgSA8qrKSyn2b/ACKY+uN46r1TJYK03rweBSTd
+xnxRtJOT2z2rr5ZU3hfl2zg+fvThBqcVidNs4mt1SFWldo1IYExEHOeOc96U5U/bnuea4EaxlvnI
+xzgjGftVovatF+Kkga1TMaxqC2cndj5s/XNPPR1jJp+hxy3skcHi3BdGLAMBtHORz2HakCCTflYR
+iIEkBmGf7+ZxTZYLHfWsX4uVpLf9zELgLx249qlVz8Rr9zeR2qzmSOLAJBJQsV5OPI4PNIke7Y5H
+JPlVzUGimvnMRKpuJBckgjPGM8+neqW3njPFWAlpVnd3au8VtPKgOCyRlgD6ZAqzqdjcWF3JBcwv
+DKAjFHGCAQCK9tE6s13Rbc2um3TQwyNudEUfMfXJ7GqVxqN5qt8095K80r4BZjlsAYH9qD5cROIh
+IqnkhR75zX20eUuLUyKgkYA7zgD+faiP5VfX0SKltOVZgAEhdsY4/wBtXL7pTWLLUEklsGZflYGC
+M7cADuPLgc+9QbV0RpL6D08LKRy8glZ2J8iccYHb+Kle/S94t/pkl8sTRi4mL7GOSvAGD9qlcr0J
++q6Peaj1JqxOlSOqT/pOw2JIuByGxzzntQi86OuW0x58zxXZkKi0igdhtB77sedSpWpQmzdNdQmT
+adH1FwpIBFu5H04pyf4U2SRoz3l+SQCVWLODjkcCpUq31Rdg+FOlRxhjJduxHZ14+2Kuw/D+G2ha
+K2ur2BT3CDIP0K1KlTaBMvwms3bcL+8X1At8/wCK6h+FOmRNmS41CUegh2/4qVKfVBiH4f6EhjP5
+bO2wADxN5z9AKL2WiWGkF2stOeJm/cYrdsn25FSpU2i8qSPz4E4/90b/AIqTWUkqFVZo89yImJ+l
+SpTTBHTrZbS2MaF2yxYlgQc1KlSsj//Z
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061701.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/full/0/native.jpg</Url></Column>
+<Column x="2" y="1" blank="no" thumb="yes"><Focus>true</Focus><Url name="EntryLink">https://roger.quod.lib.umich.edu/cgi/i/image/image-idx?fn1=sdlhomes_date_construction;fq1=1910%20ca.;sort=sdlhomes_present_usage;rgn1=sdlhomes_present_usage;select1=phrase;c=sdlhomes;q1=Residence;subview=detail;resnum=5;start=1;view=entry;lastview=reslist;lasttype=boolean;cc=sdlhomes;entryid=x-sl0617;viewid=SL061702.TIF;debug=xml;size=50;chaperone=S-SDLHOMES-X-SL0617%20SL061702.TIF</Url><Url name="Thumb">data:image/jpeg;base64,/9j/4AAQSkZJRgABAQIATgBOAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABEAGQDASIA
+AhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAYEBQIDBwgB/8QAPxAAAgEDAgMGAgUHDQAAAAAA
+AQIDAAQRBSEGEjEHEyJBUWEUcSOBkbHBJDJCQ6HR8BUWMzdEVHJ0g7LC4fH/xAAYAQADAQEAAAAA
+AAAAAAAAAAABAgMABP/EAB0RAAICAwEBAQAAAAAAAAAAAAABAhESITEDUUH/2gAMAwEAAhEDEQA/
+AKPWeI+Im4m1u00/Xr3vVvZUW3M5jSJASAFYtgdAOm1LQ4x4o734ccR6scjmDd+SWP27DO3XfrUX
+jCXk4v4gQDdtRlyR1wGO3y3qsuFufhleVPolIK9AAcAYGOu2PlTaGoYl464mdxE2u30SN4SWuWLp
+jz2OfLp51qHG3E0ckjRcQalKkYVgWuHGRnrgnz9KV+8Ik7wOGIx161LVY57Nm/Xhs8qoACOnX7sV
+jUdv4N1ZNWtoGueJL9714TzW3xZ5epAf5kYOD88U1NDqVrYGPT9SuJZCFAe7lMmOUbkepbzrzdp0
+N6DzWokWaMEhk2PTP17b11TQNb+Ote9t7hopFPiVT5+uOgz1pJyx/DLzy4ybq3EXEWlSqr3M7OMt
+yq+centj93lSe3G+vPcPdXOpalFbn+ihhmIBPnsTkjpVnrtnLcuhkusRuSWZH3Aydwv3n3NVU2io
+NMSW1S2l72Vl5nmGR6eeAuMnoKhkMoMrbnjPXpIxLHxRqcTjJ5TM2G326Hb/ALFSouN9Wgu2Mmva
+nITg921yxCbZO4wM+1K0lpBGs9w93E/JkIqk+JidsbdMb59qxhlgilVZYlJyrFgSSuce9Ua1RqGy
+7461hLf6DW9SMjHC5uXIX7etQrfjfiEmQvxHqBboi/EONwP4+ylm+kIuWJb9LmAB6fxiosTqGIYj
+lwSQR19qMYaAen+yXUr3WOCviNQuZLidbqSPvJJC5IGMbnPrRULsPwOz4kfmm9lI+W1FMIzg/GLl
+eONcOSM383T/ABmqYsAoQO+MnJx0+qrrjaUS8ba2TGq4vZR4RjOGIzVL3K/DxuJB3jMQU5Tkehz5
+045geXAAq30LS7rXJn0+zVGnK8wB6hV3YjzqtggkuZ+7jj5n3JA8/Wujdn/D19Za7aahc2pjiZ5U
+WQuASQMFSp/D0zQlJIKKzR9M07Tr69TVJpntbIxs09sjJLv0TBI5dzudyMbU9a1pmncMQWl5ZRTi
+2nj5m3ByOoB26jIwep96whVLri2RHdpYmvj4GwVxzdMYp24n0yG90R+ccqweJeUDHUDHsKi3Y6VN
+HMRxRayxATWrwyDbxMFBX3IGwPoaj3WgNc6fJeRiEx3bErHDMGWMeXOw67jy6VX31qk3E5tweVfh
+i5x681V2r2K2OmyTxGOOXvgvM3TFIofB3L6V2oW+nwQyRrM0syN4Qi+AAerH132FUgkKygqSCpzz
+KcHPrTxqOi28eix3Ziyz2gd26ZbAwR9dJAhJkWNGB5wM4U5X2q0PhJm69mW5ZJ1BBYkMCck753+2
+ooAOQM58qkLGoQrljysGJxjY7UXKW4lJhcKjDKqzZI9iR5+dOgM9Fdhv9Xp/zsv/ABorPsR5P5hO
+UYspvpSCRgnZfKilJvpx3jiwto+INQeOOTmN5NJNJj1c7D296XVht1mVZjNHCduZF5yNvfH2Uw8V
+3c1xxdqlqocQC8kV5AhblPMcHbpWUNm1vEwL98O5ZQHOTzlcAgnoNztQycUWUb4LIl+Eu+eILtlc
+k7NThNxhr+jxWlvPpllDIo76CSSEs/KxzkHPQ+1JsVhK92kNx9GC3IzMdh9Yp57Q7VI7yxA6xWUM
+WxyMBc5rOrAiDF2haz8X3jm2RTksLeFY2LH9LmwTnND8V6heXiTXN3K4GB3RJIYZ3BJOd6SlIMq7
+eYqyi/OBouKQbsZb7U7a6vhcWlmmnTqpVisjyhgT08R2+qvllqVu19GurRi7tAxZ0t2CsdiBs3z9
+aW7iX8uiYHbJzXwS5uCaWmHR0riniDS+IYbSz043EQS2aLEsXKV9MeR296SNQsI7O0soyoIRsO4b
+kyfIk1stWMdleTI3K627EEeRrY+rXFtpNnLgTtcIVlSTBV/PcY3/AGYpVaZmkWuqSw3XBYtRZ/BS
+xSCSGJoge/AB5mEnVj6jyxXPyQ7DYZcZ2HQ+wq5s5JHnkuIoZGUKwYhi6qSD0zuPrqkZHjYjbwbZ
+9KpHolaPSfYapXs+Ibr8bKf9tFHYamOz0g/32b8KKzJvpzbVLW3g4n1SZIWDSXMokxIcOOc/++1V
+dxObWBnboNs4z126Vr4h4kWHiPVI1tiSt3KuS2M4c0vXutz3a8gRY022G+4NLhJsup0iNewS28x5
+5BkkkY9c0065xbY6zpgiEUyXKd0A0mCCqx8h3G+c70nSSSTOXdizHzrDlPpVMb6JZvURhgdt/ntW
+w3IVTjrUYFtvavpyRjHWmowd4zODgk1uibmmRQ6jmIGWOAPnWyw025urqMJbTSLzDm5NtvPenccP
+2mspGxs/hJox3bCCN5VYDGNlHz33yaSUkhkmyguZodLkmsLmeKXni5We1kEi4bfZqsntoDp0UKTc
+8Ma4OCA59MHy61Mk4NsYeaS4h4gdDjeLT+6UH5vg0ahplramB9Kg1BgOXwyplgAMHONs/I1CclxD
+JFFFFLa3URZsWhfAQjAI9NvOl2ZViunQ5ZVcjbYmn+CO7to3xapbo7kzCV8u3p8j91K+taZySXFy
+kqynn53AOcA9KPn6K6YJRo732Gb9nQ2/tk34UUdhoZezsBgR+WTHf6qKsyD6V+o9j/Dt7qV1dyXW
+pCSeV5HCypgFiSceDpWmHsU4YLeK51Q/66fglFFBvQyJ8XY7wnAxJiupTn9bNn8KlR9lPCY8PwLn
+nO5L9PlttRRXJKTvpREtOy3g6FQP5HjcqMZdiSfnvvUuLgLhaEHutEtFyN/Bn76KKtbATouGNFgQ
+pHp1sEznHdKRn7K3vp8MUHdW2bZSf1Kqv4UUUJcNbsgScPW86/S3V4/nvIP3VgOGLJWBWa5U58nH
+7qKK5qQ1s3W3DtrFcd6bi6kIOyvJkdPTFS30OwkVg0CEMdwVGPsxRRV4JUBtky0tYbSARQII0znl
+UAD9lFFFdC4RfT//2Q==
+</Url><Url name="ThumbLink" foo="bar">/cgi/i/image/api/tile/sdlhomes:SL0617:SL061702.TIF/full/!100,100/0/default.jpg</Url><Caption/>
+
+<Type>image</Type><AuthCheck allowed="yes">1: world access allowed</AuthCheck><Url name="MediaLink">/cgi/i/image/api/image/sdlhomes:SL0617:SL061702.TIF/full/full/0/native.jpg</Url></Column>
+</Row>
+
+</View>
+</RelatedViews>
+
+<Portfolios type="private"/>
+<Portfolios type="public"/>
+
+<ExtraIECSS test="lt IE 10">/i/image/vendor/Leaflet.Pancontrol/src/L.Control.Pan.ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 10">/i/image/css/ie.css</ExtraIECSS>
+<ExtraIECSS test="lt IE 8">/i/image/css/ie7.css</ExtraIECSS>
+
+<Assets>
+    <script type="text/javascript" src="js/_entry.js" timestamp="1586292740">
+        <script type="text/javascript" src="vendor/jquery.sticky-kit.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Rubberband/jquery.bp.rubberband.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/imageclass.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery_cookie.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/feedback.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="bootstrap/js/bootbox.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/jquery.trap.min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-1.5.1/leaflet-src.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.Pancontrol/src/L.Control.Pan.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/strftime-min.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="vendor/Leaflet-IIIF-UM/leaflet-iiif.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/image_viewer.js" timestamp="1586292740"/>
+        <script type="text/javascript" src="js/entry.js" timestamp="1586292740"/>
+    </script>
+    <link rel="stylesheet" type="text/css" href="css/_entry.css" timestamp="1586292740">
+        <link rel="stylesheet" type="text/css" href="css/entry.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet-1.5.1/leaflet.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.Pancontrol/src/L.Control.Pan.css" timestamp="1586292740"/>
+        <link rel="stylesheet" type="text/css" href="vendor/Leaflet.contextmenu/dist/leaflet.contextmenu.css" timestamp="1586292740"/>
+    </link>
+</Assets>
+
+<!-- CHUNK filename="entry.assets.chnk" optional="0" -->
+
+<CollName><Full>Saline Historic Homes</Full><Brief>Saline Historic Homes</Brief></CollName>
+
+
+
+</Top>

--- a/samples/scripts/transform-xml-qui.mjs
+++ b/samples/scripts/transform-xml-qui.mjs
@@ -37,11 +37,11 @@ console.log("=>", dataFilePath);
 
 // clear out the target path
 let targetFilePath = `${rootPath}/samples/qui/`;
-if (!fs.existsSync(targetFilePath)) {
-  fs.mkdirSync(targetFilePath);
-}
 if ( argv.collid ) {
   targetFilePath += `${argv.collid.substr(0, 1)}/${argv.collid}/`;
+}
+if (!fs.existsSync(targetFilePath)) {
+  fs.mkdirSync(targetFilePath);
 }
 await $`find ${targetFilePath} -type f | xargs rm -f`;
 

--- a/samples/styles/entry.css
+++ b/samples/styles/entry.css
@@ -35,12 +35,16 @@ a[aria-current="page"] {
 sl-button::part(base) {
   outline: none;
   height: auto;
-  padding: var(--space-small) var(--space-large);
-  background: var(--color-blue-100);
-  color: var(--color-teal-400);
+  /* padding: var(--space-small) var(--space-large); */
+  /* background: var(--color-blue-100); */
+  /* color: var(--color-teal-400); */
+  min-height: 2.5rem;
+  align-items: center;
+  background: #eee;
+  color: initial;
   font-size: 1rem;
   line-height: 1.5;
-  font-weight: 700;
+  font-weight: var(--bold);
   font-family: var(--font-base-family);
   border: 2px outset var(--color-neutral-100);
   border-radius: var(--radius-default);

--- a/samples/styles/entry.css
+++ b/samples/styles/entry.css
@@ -35,9 +35,6 @@ a[aria-current="page"] {
 sl-button::part(base) {
   outline: none;
   height: auto;
-  /* padding: var(--space-small) var(--space-large); */
-  /* background: var(--color-blue-100); */
-  /* color: var(--color-teal-400); */
   min-height: 2.5rem;
   align-items: center;
   background: #eee;

--- a/samples/xsl/i/image/uplift/qbat/qbat.entry.xsl
+++ b/samples/xsl/i/image/uplift/qbat/qbat.entry.xsl
@@ -247,7 +247,7 @@
   <xsl:template name="build-download-action-shoelace">
     <xsl:if test="qui:download-options/qui:download-item">
       <sl-dropdown id="dropdown-action">
-        <sl-button slot="trigger" caret="caret" class="primary">Download</sl-button>
+        <sl-button slot="trigger" caret="caret">Download</sl-button>
         <sl-menu>
           <xsl:for-each select="qui:download-options/qui:download-item">
             <sl-menu-item data-href="{@href}">

--- a/samples/xsl/i/image/uplift/qbat/qbat.reslist.xsl
+++ b/samples/xsl/i/image/uplift/qbat/qbat.reslist.xsl
@@ -148,11 +148,19 @@
       <h3 class="[ mt-2 ]">Filters</h3>
       <div class="[ side-panel__box ]">
         <xsl:for-each select="$filters//qui:field">
-          <details>
+          <xsl:variable name="key" select="@key" />
+          <details class="panel">
+            <xsl:if test="qui:values/qui:value[@selected='true']">
+              <xsl:attribute name="open">open</xsl:attribute>
+            </xsl:if>
             <summary><xsl:value-of select="qui:label" /></summary>
             <xsl:for-each select="qui:values/qui:value[position() &lt;= 10]">
               <div class="[ flex ][ gap-0_5 ]">
-                <input type="checkbox" id="{ @key }-{ position() }" name="{@key}" value="{ . }" />
+                <input type="checkbox" id="{ $key }-{ position() }" name="{$key}" value="{ . }" style="margin-top: 4px">
+                  <xsl:if test="@selected = 'true'">
+                    <xsl:attribute name="checked">checked</xsl:attribute>
+                  </xsl:if>
+                </input>
                 <label for="{ @key }-{ position() }">
                   <xsl:value-of select="." /><xsl:text> </xsl:text>
                   <span class="filters__count">

--- a/samples/xsl/i/image/uplift/qui/qui.reslist.xsl
+++ b/samples/xsl/i/image/uplift/qui/qui.reslist.xsl
@@ -206,7 +206,7 @@
   </xsl:template>
 
   <xsl:template match="MediaInfo" mode="iiif-link">
-    <xsl:variable name="collid" select="collid" />
+    <xsl:variable name="collid" select="ic_collid" />
     <xsl:variable name="m_id" select="m_id" />
     <xsl:variable name="m_iid" select="m_iid" />
     <xsl:if test="normalize-space(istruct_ms) = 'P'">

--- a/static/styles.css
+++ b/static/styles.css
@@ -63,7 +63,8 @@ a:hover {
 }
 
 :focus {
-  border: solid 2px var(--color-indigo-400); /** TODO: FOCUS **/
+  /** TODO: FOCUS **/
+  box-shadow: 0 0 0 2px var(--color-indigo-400);
 }
 
 address {
@@ -74,6 +75,11 @@ address {
 
 details > summary {
   list-style: none;
+  cursor: pointer;
+}
+
+/* is this CUBE? */
+details.panel > summary {
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
Added:

- sdlhomes
  - search results with selected facet
  - entry
- sclaudubon
  - search results which originally had multiple search terms (but only one is showing)
  - the same search using facets and search term
  - entry

Updates:

- changed focus style to use `box-shadow`
- made the styling of side panel details more specific, to avoid the really wide main section details
- on search results, default a panel to open if there's a selected value
- on the entry, the download button is no longer styled as primary
- (over on DLXS) the embedded image viewer no longer renders its own title, avoiding some alliteration
