### PR TITLE
Updates to reslist view

### DIFF
--- a/src/js/image/handlers/action-results-select-items.js
+++ b/src/js/image/handlers/action-results-select-items.js
@@ -1,7 +1,7 @@
 import { ScreenReaderMessenger } from "../../sr-messaging";
 
 const _handleSelectAllItems = function(target) {
-  let checked = target.checked;
+  let checked = target.dataset.checked = ! ( target.dataset.checked == 'true' );
   document.querySelectorAll('input[name="bbidno"]').forEach((input) => {
     input.checked = checked;
   })

--- a/styles/image/reslist.css
+++ b/styles/image/reslist.css
@@ -41,6 +41,19 @@ input#results-pagination {
   padding: 0 0.5rem;
 }
 
+button[data-action="select-all"]::before {
+  font-family: var(--material);
+  font-size: 24px;
+  color: inherit;
+  vertical-align: middle;
+  line-height: 1;
+  content: "\e835"; /* check_box_outline_blank */
+}
+
+button[data-action="select-all"][data-checked="true"]::before {
+  content: "\e834"; /* check_box */
+}
+
 .button_group {
   display: flex;
   flex-direction: column;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1018,7 +1018,6 @@ h3,
   color: var(--color-neutral-400);
   line-height: 1.1;
   font-weight: var(--bold);
-  /* font-size: 32px; */
   font-size: 24px;
   font-family: var(--font-base-family);
   display: flex;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -425,6 +425,10 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   width: 80%;
 }
 
+.search-summary {
+  flex-basis: 50%;
+}
+
 .search-results__edit {
   background-color: var(--color-blue-100);
   padding: var(--text-small);
@@ -434,8 +438,42 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
 .search-results__tools {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   flex-flow: row wrap;
   align-items: flex-start;
+}
+
+@media screen and (max-width: 700px) {
+  .search {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .search-container {
+    width: 100%;
+  }
+
+  .search-container .flex {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .search-container select {
+    width: 100%;
+  }
+
+  .search-container input[type="search"] {
+    width: 100%;
+  }
+
+  .search-results__tools {
+    justify-content: flex-end;
+  }
+
+  .search-summary {
+    flex-basis: 100%;
+  }
 }
 
 .results-list--small {
@@ -451,6 +489,12 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   text-decoration: none;
   color: var(--color-neutral-400);
   margin-bottom: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .results-list--small a {
+    flex-direction: column;
+  }
 }
 
 .results-list--small:last-child {
@@ -474,6 +518,13 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   /* border-bottom: 1px solid var(--color-neutral-100); */
 }
 
+@media (max-width: 700px) {
+  .results > div {
+    grid-template-columns: 1fr 1fr;
+    max-width: none;
+  }
+}
+
 .results dt {
   font-weight: var(--bold);
 }
@@ -490,6 +541,17 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
 
 .results dd + dd {
   grid-column: 2/3;
+}
+
+@media (max-width: 700px) {
+
+  .results dt, .results dd {
+    grid-column-start: 1;
+  }
+
+  .results dd + dd {
+    grid-column-start: 1;
+  }
 }
 
 .results-list__content > dt {
@@ -624,6 +686,12 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   max-width: 80%;
 }
 
+@media screen and (max-width: 751px) {
+  .side-panel__box {
+    max-width: none;
+  }
+}
+
 .side-panel__box--wrapper {
   padding: 1em;
 }
@@ -677,6 +745,14 @@ details > div {
 .pagination__item a:hover {
   background: var(--color-teal-500);
   color: white;
+}
+
+.pagination__item a[disabled] {
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.pagination__item a[disabled]:hover {
 }
 
 a[class*="previous"]::before {
@@ -830,6 +906,10 @@ a[class*="next"]::after {
 
 .p-half {
   padding: 0.5em;
+}
+
+.pr-0 {
+  padding-right: 0;
 }
 
 .pr-1 {
@@ -1226,11 +1306,12 @@ main {
   }
 
   .side-panel {
-    width: 15%;
+    /* width: 15%; */
+    font-size: 0.875rem;
   }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 751px) {
   .side-panel {
     width: 100%;
   }
@@ -1243,11 +1324,11 @@ main {
 
 @media (min-width: 600px) and (max-width: 1000px) {
   .main-panel {
-    width: 80%;
+    /* width: 80%; */
   }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 751px) {
   .main-panel {
     width: 100%;
   }

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -4,6 +4,8 @@
   <xsl:variable name="search-form" select="//qui:form[@id='collection-search']" />
   <xsl:variable name="sort-options" select="//qui:form[@id='sort-options']" />
   <xsl:variable name="xc" select="//qui:block[@slot='results']/@data-xc" />
+  <xsl:variable name="has-results" select="//qui:nav[@role='results']/@total &gt; 0" />
+  <xsl:variable name="nav" select="//qui:nav[@role='results']" />
 
   <xsl:template name="build-extra-styles">
     <xsl:comment>DUBIOUS EXCEPTIONS</xsl:comment>
@@ -21,9 +23,13 @@
         <xsl:call-template name="build-collection-heading" />
         <xsl:call-template name="build-breadcrumbs" />
         <xsl:call-template name="build-search-form" />
-        <xsl:call-template name="build-search-summary" />
+        <!-- <xsl:call-template name="build-search-summary" />
         <xsl:if test="//qui:nav[@role='results']/@total &gt; 0">
           <xsl:call-template name="build-search-tools" />
+        </xsl:if> -->
+        <xsl:call-template name="build-results-summary-sort" />
+        <xsl:if test="$has-results">
+          <xsl:call-template name="build-portfolio-actions" />
         </xsl:if>
         <xsl:call-template name="build-results-list" />
         <xsl:call-template name="build-results-pagination" />
@@ -33,37 +39,46 @@
 
   </xsl:template>
 
+  <xsl:template name="build-results-summary-sort">
+    <xsl:call-template name="build-search-tools" />
+  </xsl:template>
+
   <xsl:template name="build-search-summary">
-    <xsl:variable name="nav" select="//qui:nav[@role='results']" />
-    <xsl:choose>
-      <xsl:when test="$nav/@total = 0">
-        <h2 class="results-heading">
-          <span class="[ bold ]">No results</span>
-          <xsl:text> match your search.</xsl:text>
-        </h2>
-      </xsl:when>
-      <xsl:otherwise>
-        <h2 class="results-heading">
-          <xsl:value-of select="$nav/@start" />
-          <xsl:text> to </xsl:text>
-          <xsl:value-of select="$nav/@end" />
-          <xsl:text> of </xsl:text>
-          <xsl:value-of select="$nav/@total" />
-          <xsl:text> results</xsl:text>
-        </h2>
-      </xsl:otherwise>
-    </xsl:choose>
+    <div class="search-summary">
+      <xsl:choose>
+        <xsl:when test="$nav/@total = 0">
+          <h2 class="results-heading">
+            <span class="[ bold ]">No results</span>
+            <xsl:text> match your search.</xsl:text>
+          </h2>
+        </xsl:when>
+        <xsl:otherwise>
+          <h2 class="results-heading">
+            <xsl:value-of select="$nav/@start" />
+            <xsl:text> to </xsl:text>
+            <xsl:value-of select="$nav/@end" />
+            <xsl:text> of </xsl:text>
+            <xsl:value-of select="$nav/@total" />
+            <xsl:text> results</xsl:text>
+          </h2>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:call-template name="build-search-summary-body" />
+    </div>
+  </xsl:template>
+
+  <xsl:template name="build-search-summary-body">
     <p>
       <!-- needs to address advanced search -->
       <xsl:text>Showing results for </xsl:text>
       <xsl:for-each select="$search-form/qui:control[@slot='clause'][normalize-space(qui:input[@slot='q']/@value)]">
         <xsl:variable name="select" select="qui:input[@slot='select']/@value" />
         <xsl:if test="qui:input[@slot='op']">
-          <xsl:text> </xsl:text>
+          <xsl:text></xsl:text>
           <span class="[ lowercase ]">
             <xsl:value-of select="qui:input[@slot='op']/@label" />
           </span>
-          <xsl:text> </xsl:text>
+          <xsl:text></xsl:text>
         </xsl:if>
         <xsl:choose>
           <xsl:when test="$select = 'all'"></xsl:when>
@@ -102,29 +117,14 @@
     <xsl:if test="$nav/@total = 0">
       <xsl:call-template name="build-search-hints" />
     </xsl:if>
-
   </xsl:template>
 
   <xsl:template name="build-search-tools">
-    <xsl:apply-templates select="//qui:callout" />
     <div class="[ search-results__tools ] [ mb-1 gap-1 ]">
-      <div class="[ flex flex-align-center ]">
-          <input type="checkbox" id="add-portfolio" name="portfolio" data-action="select-all" autocomplete="off" />
-          <label for="add-portfolio" class="visually-hidden"
-            >Select all results for portfolio</label
-          >
-          <button
-            class="[ button button--secondary ] [ flex ]"
-            aria-label="Add items to portfolio"
-            data-action="add-items"
-          >
-            <span class="material-icons" aria-hidden="true">add</span>
-            <span>Add to portfolio</span>
-          </button>
-          <xsl:call-template name="build-extra-portfolio-actions" />
-      </div>
-      <xsl:if test="$sort-options//qui:option">
-        <div class="select-group">
+      <!-- lists tools? -->
+      <xsl:call-template name="build-search-summary" />
+      <xsl:if test="$has-results and $sort-options//qui:option">
+        <div class="[ select-group ][ pr-0 ]">
           <form method="GET" action="/cgi/i/image/image-idx" autocomplete="off">
             <label for="results-sort">Sort by:</label>
             <select
@@ -147,6 +147,21 @@
         </div>
       </xsl:if>
     </div>
+    <!-- <xsl:call-template name="build-portfolio-actions" /> -->
+  </xsl:template>
+
+  <xsl:template name="build-portfolio-actions">
+    <xsl:apply-templates select="//qui:callout" />
+    <div class="[ flex flex-align-center ][ mb-1 gap-0_5 ]">
+      <button class="[ button button--secondary ] [ flex ]" aria-label="Add items to portfolio" data-action="select-all" data-checked="false">
+        <span>Select all items</span>
+      </button>
+      <button class="[ button button--secondary ] [ flex ]" aria-label="Add items to portfolio" data-action="add-items">
+        <span class="material-icons" aria-hidden="true">add</span>
+        <span>Add items to portfolio</span>
+      </button>
+      <xsl:call-template name="build-extra-portfolio-actions" />
+    </div>
   </xsl:template>
 
   <xsl:template name="build-results-list">
@@ -160,16 +175,12 @@
         <div class="pagination__group">
           <xsl:if test="$nav/qui:link">
             <ul class="pagination">
-              <xsl:if test="$nav/qui:link[@rel='previous']">
-                <li class="pagination__item">
-                  <xsl:apply-templates select="$nav/qui:link[@rel='previous']" />
-                </li>
-              </xsl:if>
-              <xsl:if test="$nav/qui:link[@rel='next']">
-                <li class="pagination__item">
-                  <xsl:apply-templates select="$nav/qui:link[@rel='next']" />
-                </li>
-              </xsl:if>
+              <li class="pagination__item">
+                <xsl:apply-templates select="$nav/qui:link[@rel='previous']" />
+              </li>
+              <li class="pagination__item">
+                <xsl:apply-templates select="$nav/qui:link[@rel='next']" />
+              </li>
             </ul>
           </xsl:if>
         </div>
@@ -225,10 +236,11 @@
           </dl>
         </div>
       </a>
-      <label class="[ portfolio-selection ]">
-        <input type="checkbox" name="bbidno" value="{@identifier}" autocomplete="off" />
+      <xsl:variable name="bb-id" select="generate-id()" />
+      <label class="[ portfolio-selection ]" for="bb{$bb-id}">
+        <input id="bb{$bb-id}" type="checkbox" name="bbidno" value="{@identifier}" autocomplete="off" />
         <span class="visually-hidden">Add item to portfolio</span>
-      </label>
+      </div>
     </section>
   </xsl:template>
 
@@ -268,6 +280,7 @@
   <xsl:template match="qui:link[@rel='previous']" priority="100">
     <a>
       <xsl:call-template name="build-href-or-identifier" />
+      <xsl:apply-templates select="@disabled" mode="copy" />
       <svg
           height="18px"
           viewBox="0 0 20 20"
@@ -294,6 +307,7 @@
   <xsl:template match="qui:link[@rel='next']" priority="100">
     <a>
       <xsl:call-template name="build-href-or-identifier" />
+      <xsl:apply-templates select="@disabled" mode="copy" />
       <span>Next</span>
       <svg
           height="18px"
@@ -316,6 +330,11 @@
     </a>
   </xsl:template>
 
+  <xsl:template match="@disabled" mode="copy" priority="100">
+    <xsl:attribute name="disabled">disabled</xsl:attribute>
+    <xsl:attribute name="aria-hidden">true</xsl:attribute>
+    <xsl:attribute name="tabindex">-1</xsl:attribute>
+  </xsl:template>
 
   <xsl:template name="build-navigation"></xsl:template>
 

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -240,7 +240,7 @@
       <label class="[ portfolio-selection ]" for="bb{$bb-id}">
         <input id="bb{$bb-id}" type="checkbox" name="bbidno" value="{@identifier}" autocomplete="off" />
         <span class="visually-hidden">Add item to portfolio</span>
-      </div>
+      </label>
     </section>
   </xsl:template>
 

--- a/templates/image/qui/components/qui.search-form.xsl
+++ b/templates/image/qui/components/qui.search-form.xsl
@@ -115,13 +115,13 @@
   </xsl:template>
 
   <xsl:template match="MediaOnly" mode="search-form">
-    <qui:hidden-input type="hidden" name="med">
-      <xsl:attribute name="value">
-        <xsl:if test="Focus = 'true'">
+    <xsl:if test="Focus = 'true'">
+      <qui:hidden-input type="hidden" name="med">
+        <xsl:attribute name="value">
           <xsl:text>1</xsl:text>
-        </xsl:if>
-      </xsl:attribute>
-    </qui:hidden-input>
+        </xsl:attribute>
+      </qui:hidden-input>
+    </xsl:if>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/templates/image/qui/qui.reslist.xsl
+++ b/templates/image/qui/qui.reslist.xsl
@@ -135,16 +135,25 @@
     <xsl:param name="identifier" />
     <xsl:param name="marker" />
     <xsl:param name="href" />
-    <xsl:if test="normalize-space($href)">
-      <qui:link rel="{$rel}" href="{$href}">
-        <xsl:if test="normalize-space($identifier)">
-          <xsl:attribute name="identifier"><xsl:value-of select="$identifier" /></xsl:attribute>
-        </xsl:if>
-        <xsl:if test="normalize-space($marker)">
-          <xsl:attribute name="marker"><xsl:value-of select="$marker" /></xsl:attribute>
-        </xsl:if>
-      </qui:link>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="normalize-space($href)">
+        <qui:link rel="{$rel}" href="{$href}">
+          <xsl:if test="normalize-space($identifier)">
+            <xsl:attribute name="identifier">
+              <xsl:value-of select="$identifier" />
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:if test="normalize-space($marker)">
+            <xsl:attribute name="marker">
+              <xsl:value-of select="$marker" />
+            </xsl:attribute>
+          </xsl:if>
+        </qui:link>
+      </xsl:when>
+      <xsl:otherwise>
+        <qui:link rel="{$rel}" href="" disabled="disabled" />
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template name="build-results-list">


### PR DESCRIPTION
- add the ghost next/previous when we're at the start/end of the results
- rearrange the summary, sort, and portfolio elements
- add `id/for` to the item select checkboxes
- adjust the breakpoints to avoid too much scrunching in the filters, search form, and metadata (spoilers: this made me miss SCSS)