### PR TITLE
reslist view improvements

### DIFF
--- a/src/js/image/handlers/action-results-focus.js
+++ b/src/js/image/handlers/action-results-focus.js
@@ -16,7 +16,6 @@ window.addEventListener('DOMContentLoaded', (event) => {
         return;
       }
 
-      console.log('AHOY FOCUS', event);
       const y = event.target.offsetTop - ( window.innerHeight / 2);
       window.scrollTo({
         top: y,

--- a/src/js/image/handlers/action-results-focus.js
+++ b/src/js/image/handlers/action-results-focus.js
@@ -1,0 +1,27 @@
+window.addEventListener('DOMContentLoaded', (event) => {
+  document.querySelectorAll('[data-behavior="focus-center"]').forEach((link) => {
+    link.addEventListener('mousedown', (event) => {
+      event.target.closest('a').dataset.mousedown = true;
+    })
+
+    link.addEventListener('focus', (event) => {
+      // alas, block: center isn't supported in Safari. ONE DAY!
+      // event.target.scrollIntoView({ block: 'center' });
+
+      let target = event.target.closest("a");
+      
+      let isMousedown = target.dataset.mousedown == 'true';
+      target.dataset.mousedown = false;
+      if ( isMousedown ) {
+        return;
+      }
+
+      console.log('AHOY FOCUS', event);
+      const y = event.target.offsetTop - ( window.innerHeight / 2);
+      window.scrollTo({
+        top: y,
+        left: 0
+      })
+    })
+  })
+})

--- a/src/js/image/handlers/action-results-sort.js
+++ b/src/js/image/handlers/action-results-sort.js
@@ -1,13 +1,21 @@
-document.addEventListener('change', (event) => {
-  let target = event.target.closest('select#results-sort');
+import { ScreenReaderMessenger } from "../../sr-messaging"; 
+
+document.addEventListener('sl-select', (event) => {
+  let target = event.target.closest('#action-results-sort');
   if ( target ) {
-    const value = target.value;
-    const $form = target.closest("form");
+    const item = event.detail.item;
+    item.checked = !item.checked;
+    const value = item.value;
+    console.log("-- sort", item, value);
+    const $form = document.querySelector('#form-results-sort');
     const fInput = document.createElement('input');
     fInput.setAttribute("type", "hidden");
     fInput.setAttribute("name", 'sort');
     fInput.setAttribute("value", value);
     $form.appendChild(fInput);
+
+    ScreenReaderMessenger.getMessenger().say(`Submitting query to sort results by ${item.innerText}`);
     $form.submit();
+    
   }
 })

--- a/src/js/image/main.js
+++ b/src/js/image/main.js
@@ -6,6 +6,7 @@ import "./handlers/action-facet-selection.js";
 import "./handlers/action-results-sort.js";
 import "./handlers/action-results-select-items.js";
 import "./handlers/action-results-remove-items.js";
+import "./handlers/action-results-focus.js";
 
 import "./handlers/action-copy-text.js";
 import "./handlers/action-item-download.js";

--- a/styles/image/entry.css
+++ b/styles/image/entry.css
@@ -97,46 +97,6 @@ button .material-icons {
   border-color: var(--color-neutral-100);
 } */
 
-sl-button::part(base) {
-  outline: none;
-  height: auto;
-  min-height: 2.5rem;
-  margin: 0; /** must remove margin for Safari */
-  align-items: center;
-  font-size: 1rem;
-  line-height: 1.5;
-  font-weight: var(--bold);
-  font-family: var(--font-base-family);
-  border: 2px outset var(--color-neutral-100);
-  border-radius: var(--radius-default);
-  padding: var(--space-x-small); /* var(--space-xxx-large); */
-  background: var(--color-teal-400);
-  border: solid 1px var(--color-teal-400);
-  color: #fff;
-}
-
-/* :not(.button--disabled) */
-sl-button::part(base):focus, sl-button::part(base):hover {
-  box-shadow: 0 0 0 2px #fff,0 0 0 3px var(--color-neutral-400);
-}
-
-sl-button::part(label) {
-  padding: 0 0.25rem;
-}
-
-sl-button::part(caret) {
-  margin-top: 4px;
-}
-
-sl-menu-item[disabled]::part(base) {
-  color: var(--color-neutral-300);
-}
-
-sl-menu-item:not([disabled])::part(base):hover {
-  background: var(--color-teal-500);
-  color: white;
-}
-
 a.download-link {
   text-decoration: none;;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -494,12 +494,52 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   }
 
   .search-results__tools {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    position: relative;
+    display: block;
+  }
+
+  #action-results-sort {
+    width: 100%;
+  }
+
+  #action-results-sort .sl-button--ghost {
+    width: 100%;
+  }
+
+  sl-button::part(label) {
+    width: 100%;
+  }
+
+  .sl-dropdown-label {
+    width: 100%;
+  }
+
+  .search-results__tools::before, .search-results__tools::after {
+    position: absolute;
+    top: 0;
+    width: 75%;
+    height: 1px;
+    background: var(--color-neutral-100);
+    display: block;
+    content: "";
+    transform: translateX(-50%);
+    left: 50%;
+  }
+
+  .search-results__tools::after {
+    top: auto;
+    bottom: 0;
+  }
+
+  /* .search-results__tools {
     justify-content: flex-end;
   }
 
   .search-summary {
     flex-basis: 100%;
-  }
+  } */
 }
 
 .results-list--small {
@@ -509,6 +549,10 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   margin-bottom: 0.5em;
   display: flex;
   gap: 0.5rem;
+}
+
+.results-list--small:last-of-type {
+  border-bottom: none;
 }
 
 .results-list--small a {
@@ -542,6 +586,31 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   column-gap: 0;
   max-width: 50vw;
   /* border-bottom: 1px solid var(--color-neutral-100); */
+}
+
+.results--jump-toolbar {
+  margin: 1rem;
+  padding: 1rem;
+  background: var(--color-neutral-100);
+  justify-content: center;
+  position:absolute!important;
+  height:1px;
+  width:1px;
+  overflow:hidden;
+  clip:rect(1px 1px 1px 1px);
+  clip:rect(1px,1px,1px,1px)
+}
+
+.results--jump-toolbar:focus-within {
+  position: static !important;
+  height: auto;
+  width: auto;
+  overflow: auto;
+  clip: unset;
+}
+
+.results--jump-toolbar a.button {
+  flex-grow: 0.25;
 }
 
 @media (max-width: 700px) {
@@ -802,6 +871,96 @@ a[class*="next"]::after {
 
 #results-pagination {
   width: 8ch;
+}
+
+.sticky-bottom {
+  position: sticky;
+  padding-bottom: 1rem;
+  bottom: 0;
+  background-color: #fff;
+  box-shadow: 0px -0.5rem 0.5rem -0.5rem rgba(0,0,0,0.1);
+}
+
+/*
+ * Shoelace customizations
+ */
+sl-button {
+  border-radius: var(--radius-default);
+}
+
+sl-button::part(base) {
+  outline: none;
+  height: auto;
+  min-height: 2.5rem;
+  margin: 0; /** must remove margin for Safari */
+  align-items: center;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: var(--bold);
+  font-family: var(--font-base-family);
+  border: 2px outset var(--color-neutral-500);
+  background: white;
+  color: var(--color-neutral-500);
+  border-radius: var(--radius-default);
+  padding: var(--space-x-small); /* var(--space-xxx-large); */
+  color: #fff;
+}
+
+sl-button.sl-button--primary::part(base) {
+  background: var(--color-teal-400);
+  border: solid 1px var(--color-teal-400);
+}
+
+sl-button.sl-button--secondary::part(base) {
+  background: var(--color-neutral-100);
+  border: solid 1px var(--color-neutral-100);
+  color: var(--color-neutral-400); 
+}
+
+sl-button.sl-button--ghost::part(base) {
+  border: solid 1px var(--color-neutral-500);
+  color: var(--color-neutral-500);
+  background: white;
+  text-decoration: none;
+}
+
+/* :not(.button--disabled) */
+sl-button::part(base):focus, sl-button::part(base):hover {
+  box-shadow: 0 0 0 2px #fff,0 0 0 3px var(--color-neutral-400);
+}
+
+sl-button::part(label) {
+  padding: 0 0.25rem;
+}
+
+sl-button::part(caret) {
+  margin-top: 4px;
+}
+
+sl-menu-item[disabled]::part(base) {
+  color: var(--color-neutral-300);
+}
+
+sl-menu-item:not([disabled])::part(base):hover {
+  background: var(--color-teal-500);
+  color: white;
+}
+
+sl-menu-item::part(label) {
+  font-family: var(--font-base-family);
+  color: var(--base-text-color);
+  font-size: var(--text-base-size);
+}
+
+sl-dropdown::part(panel) {
+  max-height: 50vh;
+}
+
+.sl-dropdown-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: normal;
 }
 
 /*
@@ -1204,6 +1363,16 @@ button {
 .button-icon {
   bottom: 0.25em;
   position: relative;
+}
+
+.button--ghost {
+  border: solid 1px var(--color-neutral-500);
+  border-radius: 4px;
+  color: var(--color-neutral-500);
+  background: white;
+  padding: 0.5em 1em;
+  margin: 0.25em;
+  text-decoration: none;
 }
 
 .button + .button {

--- a/templates/image/qbat/qbat.entry.xsl
+++ b/templates/image/qbat/qbat.entry.xsl
@@ -238,7 +238,7 @@
   <xsl:template name="build-download-action-shoelace">
     <xsl:if test="qui:download-options/qui:download-item">
       <sl-dropdown id="dropdown-action">
-        <sl-button slot="trigger" caret="caret">
+        <sl-button slot="trigger" caret="caret" class="sl-button--primary">
           <span class="flex flex-center flex-gap-0_5">
             <span class="material-icons text-xx-small">file_download</span>
             <span class="capitalize">

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -64,7 +64,13 @@
             <xsl:value-of select="$nav/@end" />
             <xsl:text> of </xsl:text>
             <xsl:value-of select="$nav/@total" />
-            <xsl:text> results</xsl:text>
+            <xsl:text> results </xsl:text>
+            <xsl:if test="$nav/@is-truncated='true'">
+              <span>
+                <xsl:text> </xsl:text>
+                <a href="?page=help#truncated-results">(truncated)</a>
+              </span>
+            </xsl:if>
           </h2>
         </xsl:otherwise>
       </xsl:choose>
@@ -296,8 +302,8 @@
 
     <xsl:if test="position() mod 10 = 0 and position() != last()">
       <div class="[ results--jump-toolbar flex flex-gap-0_5 flex-align-center ]">
-        <a href="#maincontent" data-behavior="focus-center" class="button button--ghost">Scroll to Top</a>
-        <a href="#pagination" data-behavior="focus-center" class="button button--ghost">Scroll to Pagination</a>
+        <a href="#maincontent" data-behavior="focus-center" class="button button--ghost">Back to Top</a>
+        <a href="#pagination" data-behavior="focus-center" class="button button--ghost">Go to Pagination</a>
       </div>
     </xsl:if>
 

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -12,6 +12,11 @@
     <link rel="stylesheet" href="{$docroot}styles/image/reslist.css" />
   </xsl:template>
 
+  <xsl:template name="build-extra-scripts">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.64/dist/themes/light.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.64/dist/shoelace.js"></script>
+  </xsl:template>
+
   <xsl:template match="qui:main">
 
     <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
@@ -120,6 +125,38 @@
   </xsl:template>
 
   <xsl:template name="build-search-tools">
+    <div class="[ search-results__tools ][ mb-1 gap-1 ]">
+      <xsl:call-template name="build-search-summary" />
+      <sl-dropdown id="action-results-sort">
+        <sl-button slot="trigger" caret="caret" class="sl-button--ghost">
+          <span class="sl-dropdown-label">
+            <span class="material-icons text-xx-small">sort</span>
+            <span>
+              <span>Sort by </span>
+              <span class="capitalize">
+                <xsl:value-of select="$sort-options//qui:option[@selected]" />
+              </span>
+            </span>
+          </span>
+        </sl-button>
+        <sl-menu>
+          <xsl:for-each select="$sort-options//qui:option">
+            <sl-menu-item value="{@value}">
+              <xsl:if test="@selected='selected'">
+                <xsl:attribute name="checked">checked</xsl:attribute>
+              </xsl:if>
+              <xsl:value-of select="." />
+            </sl-menu-item>
+          </xsl:for-each>
+        </sl-menu>
+      </sl-dropdown>
+      <form id="form-results-sort" method="GET" action="/cgi/i/image/image-idx" autocomplete="off" style="display: none">
+        <xsl:apply-templates select="$sort-options/qui:hidden-input" />
+      </form>
+    </div>
+  </xsl:template>
+
+  <xsl:template name="build-search-tools-xx">
     <div class="[ search-results__tools ] [ mb-1 gap-1 ]">
       <!-- lists tools? -->
       <xsl:call-template name="build-search-summary" />
@@ -171,7 +208,7 @@
   <xsl:template name="build-results-pagination">
     <xsl:variable name="nav" select="//qui:main/qui:nav[@role='results']" />
     <xsl:if test="$nav/@min &lt; $nav/@max">
-      <nav aria-label="Result navigation" class="[ pagination__row ][ flex flex-space-between flex-align-center ]">
+      <nav id="pagination" aria-label="Result navigation" class="[ pagination__row ][ flex flex-space-between flex-align-center sticky-bottom ]">
         <div class="pagination__group">
           <xsl:if test="$nav/qui:link">
             <ul class="pagination">
@@ -211,7 +248,7 @@
         <xsl:apply-templates select="qui:link[@rel='result']" />
       </xsl:variable>
       <xsl:variable name="link" select="exsl:node-set($link-tmp)" />
-      <a class="[ flex ][ flex-grow-1 ]">
+      <a class="[ flex ][ flex-grow-1 ]" data-behavior="focus-center">
         <xsl:attribute name="href">
           <xsl:value-of select="$link//@href" />
         </xsl:attribute>
@@ -256,6 +293,14 @@
         <span class="visually-hidden">Add item to portfolio</span>
       </label>
     </section>
+
+    <xsl:if test="position() mod 10 = 0 and position() != last()">
+      <div class="[ results--jump-toolbar flex flex-gap-0_5 flex-align-center ]">
+        <a href="#maincontent" data-behavior="focus-center" class="button button--ghost">Scroll to Top</a>
+        <a href="#pagination" data-behavior="focus-center" class="button button--ghost">Scroll to Pagination</a>
+      </div>
+    </xsl:if>
+
   </xsl:template>
 
   <xsl:template match="qui:collection">

--- a/templates/image/qui/qui.reslist.xsl
+++ b/templates/image/qui/qui.reslist.xsl
@@ -86,7 +86,7 @@
   <xsl:template name="build-results-navigation">
     <!-- do we have M/N available in the PI handler? -->
     <xsl:variable name="tmp-xml">
-      <qui:nav role="results" total="{//TotalResults}" size="{$sz}" min="1" max="{$max}" current="{$current}" start="{$start}" end="{$end}">
+      <qui:nav role="results" total="{//TotalResults}" size="{$sz}" min="1" max="{$max}" current="{$current}" start="{$start}" end="{$end}" is-truncated="{/Top/SearchSummary/Truncated}">
         <xsl:call-template name="build-results-navigation-link">
           <xsl:with-param name="rel">next</xsl:with-param>
           <xsl:with-param name="identifier" select="/Top/Next/@identifier" />


### PR DESCRIPTION
What was on the table:

- pagination is `position: sticky` to make N=50 (and gobs of metadata) easier to experience (in theory)
- keyboard navigation reveals "skip to top" and "skip to pagination" links every 10 records

Surprises:

- keyboard-tabbing through the results revealed that the sticky pagination could obscure the focused element 🤦‍♂️ 
- now there's a `focus` handler on the results links to move them more into the center of the view, but not if it's been preceded by a `mousedown` in the target

More surprises:

- the Kelsey has even more ridiculously long sort labels, and the sort `<select>` was making me angry
- it has been replaced with `<sl-dropdown>`, in ghost style
- since they're used in more than one view now, the shoelace customizations have been moved from entry.css to styles.css
- shoelace labels should better match the DS
