### PR TITLE
collapse side panel

### DIFF
--- a/src/js/image/bbopen.js
+++ b/src/js/image/bbopen.js
@@ -2,11 +2,12 @@ import { ScreenReaderMessenger } from "../sr-messaging";
 import "../dev.js";
 
 import "./handlers/action-go.js";
+import "./handlers/action-toggle-side-panel.js";
 import "../wait-for-defined-components.js";
 
 window.addEventListener('DOMContentLoaded', (event) => {
 
-  const $main = document.querySelector(".main-panel");
+  const $main = document.querySelector(".main-panel[data-state]");
   const $paginator = document.querySelector("[data-action='paginate']");
 
   $main.dataset.state = 'ready';
@@ -165,11 +166,16 @@ window.addEventListener('DOMContentLoaded', (event) => {
     _updatePagination();
   }
 
+  const _updatePageLink = function($el, isActive) {
+    $el.dataset.active = isActive;
+    $el.querySelector('a').disabled = ! isActive;
+  }
+
   const _updatePagination = function () {
     $paginator.dataset.active = $state.totalPages > 1;
 
-    $paginator.querySelector('[data-action="next-link"]').dataset.active = $state.page < $state.totalPages;
-    $paginator.querySelector('[data-action="previous-link"]').dataset.active = $state.page > 1;
+    _updatePageLink($paginator.querySelector('[data-action="next-link"]'), $state.page < $state.totalPages);
+    _updatePageLink($paginator.querySelector('[data-action="previous-link"]'), $state.page > 1);
 
     $paginator.querySelector('input').max = $state.totalPages;
     $paginator.querySelector('input').value = $state.page;

--- a/src/js/image/handlers/action-toggle-side-panel.js
+++ b/src/js/image/handlers/action-toggle-side-panel.js
@@ -1,0 +1,9 @@
+window.addEventListener('DOMContentLoaded', (event) => {
+  let toggleAction = document.querySelector('[data-action="toggle-side-panel"]');
+  if (toggleAction) {
+    toggleAction.addEventListener('click', (event) => {
+      toggleAction.setAttribute('aria-expanded',
+        ! ( toggleAction.getAttribute('aria-expanded') == 'true') );
+    });
+  }
+})

--- a/src/js/image/main.js
+++ b/src/js/image/main.js
@@ -7,6 +7,7 @@ import "./handlers/action-results-sort.js";
 import "./handlers/action-results-select-items.js";
 import "./handlers/action-results-remove-items.js";
 import "./handlers/action-results-focus.js";
+import "./handlers/action-toggle-side-panel.js";
 
 import "./handlers/action-copy-text.js";
 import "./handlers/action-item-download.js";

--- a/styles/image/bbopen.css
+++ b/styles/image/bbopen.css
@@ -34,5 +34,13 @@ input[type="text"] {
 }
 
 [data-active="false"] {
-  display: none !important;
+  /* display: none !important; */
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+@media screen and (max-width: 645px) {
+  .results-list__blank {
+    display: none;
+  }
 }

--- a/styles/image/reslist.css
+++ b/styles/image/reslist.css
@@ -78,3 +78,37 @@ button[data-action="select-all"][data-checked="true"]::before {
     max-width: none;
   }
 }
+
+button[data-action="toggle-side-panel"] {
+  display: none;
+}
+
+@media screen and (max-width: 751px) {
+
+  button[data-action="toggle-side-panel"] {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  button[data-action="toggle-side-panel"]::after {
+    font-family: "Material Icons";
+    font-size: 24px;
+    color: var(--color-teal-400);
+  }
+
+  button[data-action="toggle-side-panel"][aria-expanded="false"]::after {
+    content: "\e5cf";
+  }
+
+  button[data-action="toggle-side-panel"][aria-expanded="true"]::after {
+    content: "\e5ce";
+  }
+
+  button[data-action="toggle-side-panel"][aria-expanded="false"] ~ * {
+    display: none;
+  }
+
+}

--- a/styles/image/reslist.css
+++ b/styles/image/reslist.css
@@ -91,6 +91,8 @@ button[data-action="toggle-side-panel"] {
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 1rem;
+    margin-top: 1rem;
+    width: 100%;
   }
 
   button[data-action="toggle-side-panel"]::after {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -148,7 +148,8 @@ details > summary::-webkit-details-marker {
   display: none;
 }
 
-details input[type="checkbox"] {
+/* should a checkbox ever shrink? no. */
+input[type="checkbox"] {
   flex-shrink: 0;
 }
 
@@ -196,7 +197,8 @@ select:focus {
 }
 
 .input-group {
-  padding: 0 0.5em 0 0;
+  /* padding: 0 0.5em 0 0; */
+  padding: 0;
   min-width: 60%;
 }
 
@@ -338,6 +340,10 @@ label {
 
 /** Advanced Search **/
 
+.advanced-link {
+  white-space: nowrap;
+}
+
 .advanced-search--form {
   border: solid 1px var(--color-neutral-100);
   padding: 2rem 5.5vw;
@@ -450,6 +456,8 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
   justify-content: space-between;
   align-items: center;
   padding: var(--text-xx-small) 0;
+  padding-top: 0;
+  gap: var(--text-xx-small);
 }
 
 .search-container {
@@ -728,6 +736,7 @@ fieldset.fieldset--grid button[data-action="reset-clause"] {
 
 .button.filter__button {
   flex-direction: column;
+  width: 100%;
 }
 
 /* 

--- a/templates/image/qbat/components/qbat.filters-panel.xsl
+++ b/templates/image/qbat/components/qbat.filters-panel.xsl
@@ -86,7 +86,7 @@
     <xsl:variable name="value" select="qui:values/qui:value" />
     <xsl:if test="true() or not($value/@selected = 'true')">
       <div class="panel" style="padding: 1rem 0">
-        <div class="[ flex ][ gap-0_5 ]">
+        <div class="[ flex flex-align-center ][ gap-0_5 ]">
           <input type="checkbox" id="{ $key }-1" name="{$key}" value="{ normalize-space($value) }" data-action="facet" autocomplete="off" style="margin-top: 4px">
             <xsl:if test="$value/@selected = 'true'">
               <xsl:attribute name="checked">checked</xsl:attribute>

--- a/templates/image/qbat/qbat.bbopen.xsl
+++ b/templates/image/qbat/qbat.bbopen.xsl
@@ -22,8 +22,19 @@
 
   <xsl:template match="qui:main">
 
-    <div class="[ flex flex-flow-row flex-gap-1 ]">
+    <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
+      <div class="side-panel"></div>
+      <div class="main-panel">
+        <xsl:call-template name="build-collection-heading" />
+      </div>
+    </div>
+    <div class="[ flex flex-flow-rw flex-gap-1 ]">
       <div class="side-panel">
+        <button data-action="toggle-side-panel" class="flex button button--ghost" aria-expanded="false">
+          <span class="flex flex-center flex-space-between flex-grow-1">
+            <span>Filters</span>
+          </span>
+        </button>
         <h3 class="[ mt-2 ]">Filters</h3>
         <details class="panel" data-list-expanded="false" data-key="filter">
           <xsl:attribute name="open">open</xsl:attribute>
@@ -60,7 +71,7 @@
         <xsl:call-template name="build-filter-search" />
       </div>
       <div class="main-panel" data-state="loading">
-        <xsl:call-template name="build-collection-heading" />
+        <!-- <xsl:call-template name="build-collection-heading" /> -->
         <!-- <xsl:call-template name="build-breadcrumbs" /> -->
 
         <xsl:call-template name="build-search-summary" />
@@ -193,7 +204,7 @@
 
   <xsl:template name="build-results-pagination">
     <xsl:variable name="max" select="round(count(//qui:section[@identifier]) div 50)" />
-    <nav aria-label="Result navigation" data-action="paginate" class="[ pagination__row ][ flex flex-space-between flex-align-center ]">
+    <nav aria-label="Result navigation" data-action="paginate" class="[ pagination__row ][ flex flex-space-between flex-align-center sticky-bottom ]">
       <xsl:attribute name="data-active">
         <xsl:choose>
           <xsl:when test="$max &gt; 1">

--- a/templates/image/qbat/qbat.index.xsl
+++ b/templates/image/qbat/qbat.index.xsl
@@ -35,11 +35,17 @@
         <xsl:apply-templates select="//qui:panel[@slot='browse']">
           <xsl:with-param name="classes">browse-link</xsl:with-param>
         </xsl:apply-templates>
+
         <xsl:apply-templates select="//qui:panel[@slot='custom']" />
-        <xsl:call-template name="build-filters-panel">
-          <xsl:with-param name="margin-top">mt-0</xsl:with-param>
-        </xsl:call-template>
+        
+        <xsl:if test="//qui:filters-panel/qui:filter[@key != 'med']">
+          <xsl:call-template name="build-filters-panel">
+            <xsl:with-param name="margin-top">mt-0</xsl:with-param>
+          </xsl:call-template>
+        </xsl:if>
+
         <xsl:apply-templates select="//qui:panel[@slot='related-collections']" />
+
         <xsl:apply-templates select="//qui:panel[@slot='access-restrictions']" />
       </div>
       <div class="main-panel">

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -21,6 +21,11 @@
 
     <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
       <div class="side-panel">
+        <button data-action="toggle-side-panel" class="flex button button--secondary" aria-expanded="false" style="width: 100%">
+          <span class="flex flex-center flex-space-between flex-grow-1">
+            <span>Filters</span>
+          </span>
+        </button>
         <h2 class="visually-hidden">Options</h2>
         <xsl:call-template name="build-filters-panel" />
       </div>

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -28,13 +28,16 @@
     </div>
     <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
       <div class="side-panel">
-        <button data-action="toggle-side-panel" class="flex button button--ghost" aria-expanded="false">
-          <span class="flex flex-center flex-space-between flex-grow-1">
-            <span>Filters</span>
-          </span>
-        </button>
-        <h2 class="visually-hidden">Options</h2>
-        <xsl:call-template name="build-filters-panel" />
+        <xsl:if test="//qui:filter">
+          <button data-action="toggle-side-panel" class="flex button button--ghost" aria-expanded="false">
+            <span class="flex flex-center flex-gap-0_5 flex-grow-1">
+              <span class="material-icons" aria-hidden="true">filter_alt</span>
+              <span>Filters</span>
+            </span>
+          </button>
+          <h2 class="visually-hidden">Options</h2>
+          <xsl:call-template name="build-filters-panel" />
+        </xsl:if>
       </div>
       <div class="main-panel">
         <!-- <xsl:call-template name="build-collection-heading" /> -->

--- a/templates/image/qbat/qbat.reslist.xsl
+++ b/templates/image/qbat/qbat.reslist.xsl
@@ -20,8 +20,15 @@
   <xsl:template match="qui:main">
 
     <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
+      <div class="side-panel"></div>
+      <div class="main-panel">
+        <xsl:call-template name="build-collection-heading" />
+        <xsl:call-template name="build-breadcrumbs" />
+      </div>
+    </div>
+    <div class="[ flex flex-flow-rw ][ flex-gap-1 ]">
       <div class="side-panel">
-        <button data-action="toggle-side-panel" class="flex button button--secondary" aria-expanded="false" style="width: 100%">
+        <button data-action="toggle-side-panel" class="flex button button--ghost" aria-expanded="false">
           <span class="flex flex-center flex-space-between flex-grow-1">
             <span>Filters</span>
           </span>
@@ -30,8 +37,8 @@
         <xsl:call-template name="build-filters-panel" />
       </div>
       <div class="main-panel">
-        <xsl:call-template name="build-collection-heading" />
-        <xsl:call-template name="build-breadcrumbs" />
+        <!-- <xsl:call-template name="build-collection-heading" /> -->
+        <!-- <xsl:call-template name="build-breadcrumbs" /> -->
         <xsl:call-template name="build-search-form" />
         <!-- <xsl:call-template name="build-search-summary" />
         <xsl:if test="//qui:nav[@role='results']/@total &gt; 0">

--- a/templates/image/qbat/qbat.static.xsl
+++ b/templates/image/qbat/qbat.static.xsl
@@ -18,7 +18,7 @@
   <xsl:template match="qui:main">
     <xsl:call-template name="build-collection-heading" />
 
-    <div class="[ flex flex-flow-row flex-gap-1 ][ aside--wrap ]">
+    <div class="[ flex flex-flow-rw flex-gap-1 ][ aside--wrap ]">
       <div class="[ aside ]">
         <nav class="[ page-index ]" xx-aria-labelledby="page-index-label">
           <h2 id="page-index-label" class="[ subtle-heading ][ text-black js-toc-ignore ]">Page Index</h2>


### PR DESCRIPTION
Active on `reslist`: at `<=751px` when the side and main panels become 100% width, a _Filters_ button becomes visible to control whether the rest of the side panel is shown.

This is a draft for preview. Need to review:

- what to do when the side panel is empty (is it ever empty?)
- making sure it works with all portfolio views