### PR TITLE
DCP2-230 - extend actions toolbar

### DIFF
--- a/src/js/image/handlers/action-go.js
+++ b/src/js/image/handlers/action-go.js
@@ -8,6 +8,8 @@ document.addEventListener('click', (event) => {
       setTimeout(() => {
         el.scrollIntoView();
       }, 0);
+    } else if ( target.dataset.target ) {
+      window.open(target.dataset.href, target.dataset.target);
     } else {
       location.href = target.dataset.href;
     }

--- a/styles/image/entry.css
+++ b/styles/image/entry.css
@@ -37,10 +37,21 @@ a[aria-current="page"] {
   box-shadow: 0 1px 0 0 #ddd; /* Border bottom */
   margin-bottom: 1rem;
 }
-.toolbar {
+
+/* .toolbar {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
+} */
+
+.toolbar {
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+  /* can't do auto-fill because the download label doesn't expand when long */
+  /* grid-template-columns: repeat(auto-fill, minmax(10.5rem, 1fr)); */
+  grid-template-columns: repeat(2, minmax(10.5rem, 1fr));
   position: relative;
 }
 
@@ -75,12 +86,13 @@ a[aria-current="page"] {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.25rem; 
+  font-size: 0.875rem;
 }
 
-.toolbar > * {
+/* .toolbar > * {
   flex: 1;
-}
+} */
 
 .toolbar form {
   display: flex;
@@ -278,11 +290,11 @@ a.toc-link {
 }
 
 @container aside--wrap (max-width: 670px ) {
-  .toolbar {
+  /* .toolbar {
     flex-direction: column; 
-  }
+  } */
 
-  sl-dropdown {
+  /* sl-dropdown {
     width: 90%;
   }
 
@@ -292,7 +304,7 @@ a.toc-link {
 
   .toolbar form {
     width: 90%;
-  }
+  } */
 
   .record>div {
     grid-template-columns: 1fr;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -7,6 +7,7 @@
   --base-text-color: var(--color-neutral-400);
   --light-text-color: var(--color-neutral-300);
   --viewport-margin: var(--space-medium);
+  --text-xx-small: 0.875rem;
   --material: "Material Icons";
 }
 
@@ -1180,11 +1181,11 @@ sl-dropdown::part(panel) {
 }
 
 .text-xxx-small {
-  font-size: var(--text-xxx-small);
+  font-size: var(--text-xxx-small) !important;
 }
 
 .text-xx-small {
-  font-size: var(--text-xx-small);
+  font-size: var(--text-xx-small) !important;
 }
 
 /*
@@ -1381,6 +1382,7 @@ button {
   align-items: center;
   min-height: 2.5rem;
   margin: 0; /** must remove margin for Safari */
+  text-decoration: none;
 }
 
 .button--small {

--- a/templates/image/qbat/qbat.entry.xsl
+++ b/templates/image/qbat/qbat.entry.xsl
@@ -233,10 +233,14 @@
         <xsl:call-template name="build-favorite-action" />
         <xsl:call-template name="build-copy-link-action" />
         <xsl:call-template name="build-copy-citation-action" />
-        <!-- <xsl:apply-templates select="." mode="extra" /> -->
+        <xsl:apply-templates select="." mode="extra" />
       </div>
       <xsl:apply-templates select="//qui:callout[@slot='actions']" />
     </div>
+  </xsl:template>
+
+  <xsl:template match="qui:block[@slot='actions']" mode="extra">
+    <xsl:apply-templates select="*[@slot='extension']" mode="action" />
   </xsl:template>
 
   <xsl:template name="build-download-action">
@@ -260,9 +264,9 @@
 
   <xsl:template name="build-download-action-shoelace">
     <xsl:if test="qui:download-options/qui:download-item">
-      <sl-dropdown id="dropdown-action">
+      <sl-dropdown id="dropdown-action" placement="bottom">
         <sl-button slot="trigger" caret="caret" class="sl-button--primary">
-          <span class="flex flex-center flex-gap-0_5">
+          <span class="flex flex-center flex-gap-0_5 text-xx-small">
             <span class="material-icons text-xx-small">file_download</span>
             <span class="capitalize">
               <xsl:text>Download</xsl:text>
@@ -373,6 +377,30 @@
       <xsl:with-param name="icon">save</xsl:with-param>
       <xsl:with-param name="data-attributes">
         <qbat:attribute name="data-href">#cite-this-item</qbat:attribute>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="qui:link" mode="action">
+    <a href="{@href}" target="{@target}" class="button button--secondary text-xx-small">
+      <xsl:if test="@icon">
+        <span class="material-icons" aria-hidden="true">
+          <xsl:value-of select="@icon" />
+        </span>
+      </xsl:if>
+      <span><xsl:value-of select="." /></span>
+    </a>
+  </xsl:template>
+
+  <xsl:template match="qui:button" mode="action">
+    <xsl:call-template name="button">
+      <xsl:with-param name="label"><xsl:value-of select="." /></xsl:with-param>
+      <xsl:with-param name="classes">button--secondary</xsl:with-param>
+      <xsl:with-param name="action">go</xsl:with-param>
+      <xsl:with-param name="icon"><xsl:value-of select="@icon" /></xsl:with-param>
+      <xsl:with-param name="data-attributes">
+        <qbat:attribute name="data-href"><xsl:value-of select="@data-href" /></qbat:attribute>
+        <qbat:attribute name="data-target"><xsl:value-of select="@data-target" /></qbat:attribute>
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>

--- a/templates/image/qui/qui.entry.xsl
+++ b/templates/image/qui/qui.entry.xsl
@@ -375,9 +375,13 @@
 
       <xsl:call-template name="build-action-panel-iiif-link" />
 
+      <xsl:call-template name="build-action-panel-extra" />
+
     </qui:block>
 
   </xsl:template>
+
+  <xsl:template name="build-action-panel-extra" />
 
   <xsl:template match="ImageSizeTool">
     <xsl:apply-templates select="Level" />


### PR DESCRIPTION
Requires a `web/$c/$collid/qui/qui.entry.xsl` template that has a `build-action-panel-extra` template that returns a `qui:button` or `qui:link` with `slot=exteion`:

```
<xsl:template name="build-action-panel-extra">
  <qui:button icon="local_offer" slot="extension" data-href="{$href}" data-target="request">
    <xsl:text>Order this</xsl:text>
  </qui:button>
</xsl:template>
```

